### PR TITLE
Volunteer Signup Wizard: V8 Performance Improvements

### DIFF
--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupWizard.ascx
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupWizard.ascx
@@ -1,12 +1,12 @@
-﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="VolunteerSignupWizard.ascx.cs" Inherits="org.secc.Connection.VolunteerSignupWizard" %>
+<%@ Control Language="C#" AutoEventWireup="true" CodeFile="VolunteerSignupWizard.ascx.cs" Inherits="org.secc.Connection.VolunteerSignupWizard" %>
 
 <asp:UpdatePanel ID="upnlContent" runat="server">
     <ContentTemplate>
 
        <Rock:NotificationBox ID="nbConfigurationWarning" runat="server" NotificationBoxType="Warning" Visible="false" />
         
-        <asp:Literal ID="lBody" runat="server" ></asp:Literal> 
-        <asp:Literal ID="lDebug" runat="server" ></asp:Literal> 
+        <asp:Literal ID="lBody" runat="server"></asp:Literal> 
+        <asp:Literal ID="lDebug" runat="server" Visible="false"></asp:Literal> 
 
         
         <Rock:ModalDialog ID="mdEdit" runat="server" OnSaveClick="mdEdit_SaveClick" Title="Edit Signup Settings">


### PR DESCRIPTION
Note: This PR will probably need a little bit of work before it's pulled in but the main bulk of it does create some real world performance gains. Unfortunately it's got formatting changes in there too.

## The notable inclusions in this PR

1. A switch to using non-obsolete cache calls (v8+)
2. Some additional documentation on method signatures and some extra comments in the more critical methods
3. Precalculating the `Partition.NextPartition` in a single O(_n_) pass as opposed to using a getter which was O(n) (causing `GetTree` to do O(n<sup>2</sup>) units of work)
4. Not storing any counts which have a value of 0. In cases which have a large possible number of permutations (multiple campuses, schedules, and roles with little overlap) a large number of 0 counts redundantly exist. These generate a large number of stack frames to be generated in the recursive call which kill performance. By assuming by default the limit for these nodes is 0 in an instance with 7000 combinations I reduced the page load time from 18-21 seconds to 3-5 seconds.

## Further potential performance improvements:
- Find ways to reduce the viewstate size
- Swapping to using a data structure for the tree that is more tree like