### PR TITLE
Rock-2464: Create scss to move Employment page to Rock

### DIFF
--- a/Plugins/org.secc.Themes/Themes/SECC2014/Styles/pages/connect/init.scss
+++ b/Plugins/org.secc.Themes/Themes/SECC2014/Styles/pages/connect/init.scss
@@ -15,3 +15,4 @@
 @import '../../pages/connect/partials/beliefs';
 @import '../../pages/connect/partials/about';
 @import '../../pages/connect/partials/locations';
+@import '../../pages/connect/partials/employment';

--- a/Plugins/org.secc.Themes/Themes/SECC2014/Styles/pages/connect/partials/_employment.scss
+++ b/Plugins/org.secc.Themes/Themes/SECC2014/Styles/pages/connect/partials/_employment.scss
@@ -1,0 +1,42 @@
+/* ------------------------------------------------------------------------------------
+	Visit: Sets the style for certain aspects of the Employment Opportunities Page
+------------------------------------------------------------------------------------- */
+
+.job {
+  padding: 2em 1em;
+  + .job {
+    border-top: 1px solid #a09d99;
+  }
+  header {
+    margin-bottom: 1em;
+  }
+  .job-title {
+    font-family: proxima-nova-n1,proxima-nova,"Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-weight: 100;
+  }
+  .location {
+    font-size: 0.9em;
+  }
+  .ministry {
+    float: right;
+  }
+  .hours {
+    float: right;
+    font-size: .9em;
+    font-style: italic;
+  }
+  .description {
+    max-height: 0;
+    overflow: auto;
+    transition: all 500ms ease-out;
+  }
+  &.active .description {
+    max-height: 2000px;
+  }
+  .apply-link {
+    float: right;
+  }
+  span[contenteditable] {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
Create new scss partial for Employment page and update init.scss to import the new partial.  This is for the move of the Employment Opportunities page to Rock.