### PR TITLE
prep files for handoff

### DIFF
--- a/Plugins/org.secc.Themes/Themes/SECC2019Portal/Layouts/Site.Master
+++ b/Plugins/org.secc.Themes/Themes/SECC2019Portal/Layouts/Site.Master
@@ -81,7 +81,11 @@
     <!-- Set the viewport width to device width for mobile -->
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=2.0">
 
-    <!-- Included CSS Files -->
+    <!-- SECC2019 Theme CSS Files -->
+    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Themes/SECC2019/Styles/layout.css", true) %>"/>
+    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Themes/SECC2019/Styles/main.css", true) %>"/>
+
+    <!-- SECC2019Portal Theme CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/seportal.css", true) %>"/>
     <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
     <asp:ContentPlaceHolder ID="css" runat="server" />

--- a/Plugins/org.secc.Themes/Themes/SECC2019Portal/Styles/seportal.scss
+++ b/Plugins/org.secc.Themes/Themes/SECC2019Portal/Styles/seportal.scss
@@ -1,8 +1,41 @@
 /*** SECC2019Portal will be a child theme of SECC2019, thus will inherit a bunch of styles ***/
-@import '_layout';
-@import '_main';
+//@import '_layout';
+//@import '_main';
 
-@import '_lib/_block-grid';
+//@import '_lib/_block-grid';
+@import "../../SECC2019/Styles/_lib/_init";
+@import '../../SECC2019/Styles/_mixins';
+// Media queries
+// Example usage:
+// $media $sm {
+//   body {
+//     background: red;
+//   }
+// }
+// Grid breakpoints
+//
+// Define the minimum and maximum dimensions at which your layout will change,
+// adapting to different screen sizes, for use in media queries.
+
+$grid-breakpoints: (
+	// Extra small screen / phone
+	xs: 0,
+	// Small screen / phone
+	sm: 34em,
+	// Medium screen / tablet
+	md: 48em,
+	// Large screen / desktop
+	lg: 62em,
+	// Extra large screen / wide desktop
+	xl: 75em
+) !default;
+
+$xs: unquote("(min-width: #{$screen-xs-min})");
+$sm: unquote("(min-width: #{$screen-sm-min})");
+$md: unquote("(min-width: #{$screen-md-min})");
+$lg: unquote("(min-width: #{$screen-lg-min})");
+$sm-only: unquote("(min-width: #{$screen-sm}) and (max-width: #{$screen-sm-max})");
+$md-only: unquote("(min-width: #{$screen-md}) and (max-width: #{$screen-md-max})");
 
 //SECC2019Portal custom styles
 hr.g-border-b-2--xs {
@@ -474,7 +507,7 @@ hr.g-border-b-2--xs {
           @include media-breakpoint-up(sm){
           	width: calc(35% + 20px) !important;
           }
-          @include media-breakpoint-up(md){
+          @include media-breakpoint-up(lg){
           	width: calc(100% + 20px) !important;
           }
 	      }

--- a/Plugins/org.secc.Themes/Themes/SECC2019Portal/config.rb
+++ b/Plugins/org.secc.Themes/Themes/SECC2019Portal/config.rb
@@ -1,0 +1,20 @@
+require 'compass/import-once/activate'
+# Require any additional compass plugins here.
+
+# Set this to the root of your project when deployed:
+http_path = "/"
+css_dir = "Styles"
+sass_dir = "Styles"
+images_dir = "Assets/img"
+javascripts_dir = "Scripts"
+fonts_dir = "fonts"
+
+output_style = :nested
+
+# To enable relative paths to assets via compass helper functions. Uncomment:
+# relative_assets = true
+
+line_comments = false
+color_output = false
+
+preferred_syntax = :scss


### PR DESCRIPTION
Final style tweaks.
Removed SECC2019 Theme imports and just linked to those compiled css files directly in Site.Master for a much smaller seportal.css file