### PR TITLE
Updated CardWizard templates to work with unlimited partitions

### DIFF
--- a/Plugins/org.secc.Connection/org_secc/Connection/CardWizard/CardCampus.lava
+++ b/Plugins/org.secc.Connection/org_secc/Connection/CardWizard/CardCampus.lava
@@ -1,7 +1,7 @@
                 {%- assign campus = partition -%}
 				{%- assign spotsLeft = campus.Limit | Minus: campus.Filled -%}
 				<div class="col-sm-6 col-md-4" style="margin-bottom: 20px;">
-					{% if spotsLeft > 0 and campus.Limit > 0 %}
+					{% if campus.Limit == null or spotsLeft > 0 and campus.Limit > 0 %}
 						{% if partitionSize > 0 %}
 							<a href="#" onclick="doSlide('#{{divId}}_{{campus.Value}}'); return false;">
 						{% else %}
@@ -9,7 +9,6 @@
 						{% endif %}
 					{% endif %}
 					<div class="serve-card" style="height: 180px">
-                    <a href="#" onclick="doSlide('#{{divId}}_{{campus.Value}}'); return false;">
                         <div class="box text-center">
 							<div class="clearfix">
 								<span class="label label-default pull-right" style="margin: 10px 10px 0px 0px;">{% if campus.Limit == null %}Unlimited{% else %}{% if spotsLeft <= 0 %}Full{% else %}{{spotsLeft}} {{ 'Spot' | PluralizeForQuantity:spotsLeft }} Remaining{% endif %}{% endif %}</span>
@@ -18,7 +17,7 @@
                             <h4>{{ campus.Entity.Name }}</h4>
                         </div>
 					</div>
-					{% if spotsLeft > 0 and campus.Limit > 0 %}
+					{% if campus.Limit == null or spotsLeft > 0 and campus.Limit > 0 %}
 						</a>
 					{% endif %}
                 </div>

--- a/Plugins/org.secc.Connection/org_secc/Connection/CardWizard/CardDefinedType.lava
+++ b/Plugins/org.secc.Connection/org_secc/Connection/CardWizard/CardDefinedType.lava
@@ -2,7 +2,7 @@
 				{% assign partitionSize = partition.Partitions | Size %}
 				{%- assign spotsLeft = definedType.Limit | Minus: definedType.Filled -%}
 				<div class="col-sm-6 col-md-4" style="margin-bottom: 20px;">
-					{% if spotsLeft > 0 and definedType.Limit > 0 %}
+					{% if definedType.Limit == null or spotsLeft > 0 and definedType.Limit > 0 %}
 						{% if partitionSize > 0 %}
 							<a href="#" onclick="doSlide('#{{divId}}_{{definedType.Value}}'); return false;">
 						{% else %}
@@ -18,7 +18,7 @@
 								<span>{{ definedType.Entity.Description }}</span>
 							</div>
 						</div>
-					{% if spotsLeft > 0 and definedType.Limit > 0 %}
+					{% if definedType.Limit == null or spotsLeft > 0 and definedType.Limit > 0 %}
 						</a>
 					{% endif %}
                 </div>

--- a/Plugins/org.secc.Connection/org_secc/Connection/CardWizard/CardRole.lava
+++ b/Plugins/org.secc.Connection/org_secc/Connection/CardWizard/CardRole.lava
@@ -1,7 +1,7 @@
                 {%- assign role = partition -%}
 				{%- assign spotsLeft = role.Limit | Minus: role.Filled -%}
 				<div class="col-sm-6 col-md-4">
-					{% if spotsLeft > 0 and role.Limit > 0 %}
+					{% if role.Limit == null or spotsLeft > 0 and role.Limit > 0 %}
 						{% if partitionSize > 0 %}
 							<a href="#" onclick="doSlide('#{{divId}}_{{role.Value}}'); return false;">
 						{% else %}
@@ -20,7 +20,7 @@
                             <h3>{{ role.Entity.Name }}</h3>
                         </div>
 					</div>
-					{% if spotsLeft > 0 and role.Limit > 0 %}
+					{% if role.Limit == null or spotsLeft > 0 and role.Limit > 0 %}
 						</a>
 					{% endif %}
                 </div>

--- a/Plugins/org.secc.Connection/org_secc/Connection/CardWizard/CardSchedule.lava
+++ b/Plugins/org.secc.Connection/org_secc/Connection/CardWizard/CardSchedule.lava
@@ -1,7 +1,7 @@
                 {%- assign schedule = partition -%}
 				{%- assign spotsLeft = schedule.Limit | Minus: schedule.Filled -%}
 				<div class="col-sm-6 col-md-4" style="margin-bottom: 20px;">
-					{% if spotsLeft > 0 and schedule.Limit > 0 %}
+					{% if schedule.Limit == null or spotsLeft > 0 and schedule.Limit > 0 %}
 						{% if partitionSize > 0 %}
 							<a href="#" onclick="doSlide('#{{divId}}_{{schedule.Value}}'); return false;">
 						{% else %}
@@ -16,7 +16,7 @@
                             <h3>{{ schedule.Entity.Name }}</h3>
                         </div>
 					</div>
-					{% if spotsLeft > 0 and schedule.Limit > 0 %}
+					{% if schedule.Limit == null or spotsLeft > 0 and schedule.Limit > 0 %}
 						</a>
 					{% endif %}
                 </div>


### PR DESCRIPTION
This PR fixes #44

Currently, the card wizard lava templates are not working correctly if a partition is set for unlimited spots (left blank). The card becomes non-clickable like it would if the partition were full.

This PR adds a null check into the lava templates to ensure the templates function correctly with unlimited spots.