### PR TITLE
Update Group Type Changer tool to allow mapping Group Attributes, and…

### DIFF
--- a/Plugins/org.secc.Administration/org_secc/Administration/GroupTypeChanger.ascx
+++ b/Plugins/org.secc.Administration/org_secc/Administration/GroupTypeChanger.ascx
@@ -2,33 +2,68 @@
 
 <asp:UpdatePanel ID="upReport" runat="server">
     <ContentTemplate>
-        <Rock:NotificationBox runat="server" ID="nbSuccess" Visible="false" NotificationBoxType="Success" Text="GroupType successfully changed."></Rock:NotificationBox>
+
+        <Rock:NotificationBox runat="server" ID="nbMessage" Visible="false" NotificationBoxType="Success" Text="GroupType successfully changed."></Rock:NotificationBox>
+
+        <div class="panel panel-block">
+            <div class="panel-heading">
+                <h4 class="panel-title"><asp:Literal ID="ltName" runat="server"></asp:Literal></h4>
+            </div>
+            <div class="panel-body">
+                <div class="row">
+                    <div class="col-md-6">
+                        <Rock:RockLiteral ID="ltGroupTypeName" runat="server" Label="Current Group Type"></Rock:RockLiteral>
+                    </div>
+                    <div class="col-md-6">
+                        <Rock:RockDropDownList runat="server" ID="ddlGroupTypes" Label="New Group Type" DataValueField="Id" DataTextField="Name"
+                            AutoPostBack="true" OnSelectedIndexChanged="ddlGroupTypes_SelectedIndexChanged">
+                        </Rock:RockDropDownList>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="row">
-            <div class="col-sm-6">
-                <Rock:RockLiteral ID="ltName" runat="server" Label="Group Name"></Rock:RockLiteral>
-            </div>
-            <div class="col-sm-6">
-                <Rock:RockLiteral ID="ltGroupTypeName" runat="server" Label="Group Type"></Rock:RockLiteral>
-            </div>
-        </div>
-        <Rock:RockDropDownList runat="server" ID="ddlGroupTypes" Label="New Group Type" DataValueField="Id" DataTextField="Name"
-            AutoPostBack="true" OnSelectedIndexChanged="ddlGroupTypes_SelectedIndexChanged">
-        </Rock:RockDropDownList>
-        <div class="col-sm-6">
+
+            <asp:Panel runat="server" ID="pnlGroupAttributes" Visible="false">
+                <div class="panel panel-block">
+                    <div class="panel-heading">
+                        <h4 class="panel-title">Group Attribute Mappings</h4>
+                    </div>
+                    <div class="panel-body">
+                        <asp:PlaceHolder runat="server" ID="phGroupAttributes" />
+                    </div>
+                </div>
+            </asp:Panel>
+
+            <asp:Panel runat="server" ID="pnlMemberAttributes" Visible="false">
+                <div class="panel panel-block">
+                    <div class="panel-heading">
+                        <h4 class="panel-title">Group Member Attribute Mappings</h4>
+                    </div>
+                    <div class="panel-body">
+                        <asp:PlaceHolder runat="server" ID="phMemberAttributes" />
+                    </div>
+                </div>
+            </asp:Panel>
+
             <asp:Panel runat="server" ID="pnlRoles" Visible="false">
-                <h3>Group Member Role Mappings</h3>
-                <asp:PlaceHolder runat="server" ID="phRoles" />
+                <div class="panel panel-block">
+                    <div class="panel-heading">
+                        <h4 class="panel-title">Group Member Role Mappings</h4>
+                    </div>
+                    <div class="panel-body">
+                        <asp:PlaceHolder runat="server" ID="phRoles" />
+                    </div>
+                </div>
             </asp:Panel>
         </div>
-        <div class="col-sm-6">
-            <asp:Panel runat="server" ID="pnlAttributes" Visible="false">
-                <h3>Group Member Group Type Attribute Mappings</h3>
-                <asp:PlaceHolder runat="server" ID="phAttributes" />
-            </asp:Panel>
-        </div>
-        <div class="col-xs-12">
-            <Rock:BootstrapButton runat="server" ID="btnSave" CssClass="btn btn-success" Text="Save"
-                 Visible="false" OnClick="btnSave_Click"></Rock:BootstrapButton>
+
+        <div class="row">
+            <div class="col-xs-12">
+                <Rock:BootstrapButton runat="server" ID="btnSave" CssClass="btn btn-success" Text="Save"
+                     Visible="false" OnClick="btnSave_Click"></Rock:BootstrapButton>
+            </div>
         </div>
 
     </ContentTemplate>


### PR DESCRIPTION
The current Group Type Changer tool does not update GroupSync records, so these are left orphaned pointing to wrong role. It also does not allow mapping Group Attributes (only Group Member Attributes). This pull request adds the following:

- Add UI for mapping Group Attributes (in addition to Group Member Attributes and Roles)
- Update logic to also update Group Sync records with new role ids
- Update logic to also update new GroupTypeId field on the Group Member records
- Clean up UI to be cleaner (use panels, etc.)