### PR TITLE
Simplifying E-Decision Report

### DIFF
--- a/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx
@@ -45,7 +45,7 @@
                                 <asp:ListItem Text="Help Me Decide" Value="Help Me Decide" />
                             </Rock:RockCheckBoxList>
                             <div class="actions text-right">
-                                <div class="btn-group">
+                                <div>
                                     <asp:LinkButton ID="lbClearFilters" runat="server" CssClass="btn btn-default" Style="border-radius: 4px;">Clear Filters</asp:LinkButton>
                                     <asp:LinkButton ID="btnApply" runat="server" CssClass="btn btn-primary" ToolTip="Update Results" OnClick="btnApply_Click" Style="margin-left: 10px; border-radius: 4px;">
                                         <i class="fa fa-refresh"></i> Update

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx.cs
@@ -128,9 +128,8 @@ namespace RockWeb.Plugins.org_secc.Reporting
             if (!IsPostBack)
             {
                 LoadBoundFields();
+                UpdateBaptismTypeVisibility();
             }
-
-            UpdateBaptismTypeVisibility();
         }
 
         #endregion
@@ -215,7 +214,7 @@ namespace RockWeb.Plugins.org_secc.Reporting
         {
             var selectedDecisionType = ddlDecisionType.SelectedValue;
             var showBaptismType = selectedDecisionType.IsNotNullOrWhiteSpace()
-                && selectedDecisionType.Equals( "Baptism", StringComparison.InvariantCultureIgnoreCase );
+                && selectedDecisionType.Equals( "Baptism", StringComparison.OrdinalIgnoreCase );
 
             dvpBaptismType.Visible = showBaptismType;
 


### PR DESCRIPTION
Made three commits to simplify the e-decision report:

1. Changed filter label from 'Family Campus' to 'Primary Campus' to keep consistent language for users (retained "FamilyCampus" language in other non-user facing code to maintain consistency w/ the DB table column)

2. Made the 'Baptism Type' filter show conditionally only when the selected Decision Type is 'Baptism'

3. Moved the 'Update' button down next to the 'Clear Filters' button & matched their height/style