### PR TITLE
ROCK-8362: Sanitize CustomSchedule

### DIFF
--- a/Plugins/org.secc.GroupManager/Model/PublishGroup.cs
+++ b/Plugins/org.secc.GroupManager/Model/PublishGroup.cs
@@ -208,7 +208,16 @@ namespace org.secc.GroupManager.Model
                 var spansMultipleYears = dates.Select( d => d.Year ).Distinct().Count() > 1;
                 var dateFormat = spansMultipleYears ? "MMM d, yyyy" : "MMM d";
 
-                var dateList = string.Join( ", ", dates.Select( d => d.ToString( dateFormat ) ) );
+                string dateList;
+                if ( dates.Count > 4 )
+                {
+                    var firstThree = string.Join( ", ", dates.Take( 3 ).Select( d => d.ToString( dateFormat ) ) );
+                    dateList = string.Format( "{0}, ... {1}", firstThree, dates.Last().ToString( dateFormat ) );
+                }
+                else
+                {
+                    dateList = string.Join( ", ", dates.Select( d => d.ToString( dateFormat ) ) );
+                }
 
                 if ( allSameDay )
                 {

--- a/Plugins/org.secc.GroupManager/Model/PublishGroup.cs
+++ b/Plugins/org.secc.GroupManager/Model/PublishGroup.cs
@@ -156,7 +156,7 @@ namespace org.secc.GroupManager.Model
             {
                 if ( CustomSchedule.IsNotNullOrWhiteSpace() )
                 {
-                    return CustomSchedule;
+                    return CustomSchedule.SanitizeHtml();
                 }
                 if ( WeeklyDayOfWeek.HasValue )
                 {
@@ -165,6 +165,64 @@ namespace org.secc.GroupManager.Model
                         WeeklyTimeOfDay.HasValue ? new DateTime( WeeklyTimeOfDay.Value.Ticks ).ToString( "h:mm tt" ) : "" );
                 }
                 return "";
+            }
+        }
+
+        /// <summary>
+        /// Converts a Schedule's RDATE or RRULE content into a human-readable date list.
+        /// For RDATE schedules: "Tuesdays at 6:30 PM: Aug 5, Aug 19, Sep 2, ..."
+        /// Falls back to ToFriendlyScheduleText for RRULE or when no dates are found.
+        /// </summary>
+        public static string FormatScheduleDates( Schedule schedule )
+        {
+            if ( schedule == null )
+            {
+                return string.Empty;
+            }
+
+            // If the schedule has a simple weekly pattern, let Rock handle it
+            if ( schedule.WeeklyDayOfWeek.HasValue )
+            {
+                return ( schedule.ToFriendlyScheduleText( true ) ?? string.Empty ).SanitizeHtml();
+            }
+
+            try
+            {
+                var dates = schedule.GetScheduledStartTimes( DateTime.MinValue, DateTime.Now.AddYears( 3 ) )
+                    .Take( 100 ).ToList();
+                if ( dates == null || !dates.Any() )
+                {
+                    return ( schedule.ToFriendlyScheduleText( true ) ?? string.Empty ).SanitizeHtml();
+                }
+
+                if ( dates.Count == 1 )
+                {
+                    return string.Format( "Once on {0} at {1}",
+                        dates[0].ToString( "MMM d, yyyy" ),
+                        dates[0].ToString( "h:mm tt" ) );
+                }
+
+                // Multiple dates — build a nice readable list
+                var time = dates[0].ToString( "h:mm tt" );
+                var allSameDay = dates.Select( d => d.DayOfWeek ).Distinct().Count() == 1;
+                var spansMultipleYears = dates.Select( d => d.Year ).Distinct().Count() > 1;
+                var dateFormat = spansMultipleYears ? "MMM d, yyyy" : "MMM d";
+
+                var dateList = string.Join( ", ", dates.Select( d => d.ToString( dateFormat ) ) );
+
+                if ( allSameDay )
+                {
+                    return string.Format( "{0}s at {1}: {2}",
+                        dates[0].DayOfWeek,
+                        time,
+                        dateList );
+                }
+
+                return string.Format( "At {0}: {1}", time, dateList );
+            }
+            catch
+            {
+                return ( schedule.ToFriendlyScheduleText( true ) ?? string.Empty ).SanitizeHtml();
             }
         }
 

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupRequest.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupRequest.ascx.cs
@@ -108,11 +108,11 @@ namespace RockWeb.Plugins.GroupManager
             {
                 publishGroup.LoadAttributes();
                 Rock.Attribute.Helper.AddEditControls( publishGroup, phAttributeEdits, false );
-            }
 
-            if ( publishGroup.Group.GroupTypeId == 60 ) // Determines if publish group is a home group
-            {
-                isHomeGroup = true;
+                if ( publishGroup.Group != null && publishGroup.Group.GroupTypeId == 60 )
+                {
+                    isHomeGroup = true;
+                }
             }
         }
 
@@ -203,7 +203,7 @@ namespace RockWeb.Plugins.GroupManager
                     // Custom schedule — Day of Week stays editable for filtering
                     ddlDayOfWeek.SelectedValue = publishGroup.WeeklyDayOfWeek != null ? ( ( int ) publishGroup.WeeklyDayOfWeek ).ToString() : "";
                     tTimeOfDay.SelectedTime = null;
-                    tbCustomSchedule.Text = schedule.FriendlyScheduleText;
+                    tbCustomSchedule.Text = PublishGroup.FormatScheduleDates( schedule );
                 }
                 dpStartDate.SelectedDate = schedule.EffectiveStartDate;
             }
@@ -266,7 +266,7 @@ namespace RockWeb.Plugins.GroupManager
                 tTimeOfDay.SelectedTime = publishGroup.Group.Schedule.WeeklyTimeOfDay;
                 tTimeOfDay.Enabled = false;
                 dpStartDate.SelectedDate = publishGroup.Group.Schedule.EffectiveStartDate.HasValue ? publishGroup.Group.Schedule.EffectiveStartDate : publishGroup.StartDate;
-                tbCustomSchedule.Text = publishGroup.Group.Schedule.iCalendarContent;
+                tbCustomSchedule.Text = PublishGroup.FormatScheduleDates( publishGroup.Group.Schedule );
                 tbCustomSchedule.ReadOnly = true;
                 tbLocationName.Text = publishGroup.Group.GroupLocations.FirstOrDefault()?.Location.PostalCode;
                 tbLocationName.ReadOnly = true;
@@ -404,7 +404,7 @@ namespace RockWeb.Plugins.GroupManager
                         // as a simple day + time (i.e. it's a complex/custom schedule)
                         if ( !group.Schedule.WeeklyDayOfWeek.HasValue )
                         {
-                            publishGroup.CustomSchedule = group.Schedule.FriendlyScheduleText;
+                            publishGroup.CustomSchedule = PublishGroup.FormatScheduleDates( group.Schedule );
                         }
                     }
 
@@ -491,7 +491,7 @@ namespace RockWeb.Plugins.GroupManager
             publishGroup.StartDateTime = drPublishDates.LowerValue.Value;
             publishGroup.WeeklyDayOfWeek = ddlDayOfWeek.SelectedValueAsEnumOrNull<DayOfWeek>();
             publishGroup.WeeklyTimeOfDay = tTimeOfDay.SelectedTime;
-            publishGroup.CustomSchedule = tbCustomSchedule.Text;
+            publishGroup.CustomSchedule = ( tbCustomSchedule.Text ?? string.Empty ).SanitizeHtml();
             publishGroup.StartDate = dpStartDate.SelectedDate;
             publishGroup.MeetingLocation = tbLocationName.Text;
             publishGroup.IsHidden = cbIsHidden.Checked;

--- a/Plugins/org.secc.Themes/Themes/SECC2019/Assets/Lava/Groups/GroupFinder.lava
+++ b/Plugins/org.secc.Themes/Themes/SECC2019/Assets/Lava/Groups/GroupFinder.lava
@@ -93,7 +93,7 @@
                             {% assign meetingDaySize = publishGroup.MeetingDay | Trim | Size %}
                             {% assign meetingTimeSize = publishGroup.MeetingDay | Trim | Size %}
                             {% if publishGroup.CustomSchedule != '' %}
-                                {% assign scheduleText = publishGroup.CustomSchedule %}
+                                {% assign scheduleText = publishGroup.CustomSchedule | StripHtml %}
                             {% elseif meetingDaySize > 0 and meetingTimeSize > 0 %}
                                 {% assign scheduleText = publishGroup.MeetingDay | Append:'s ' | Append:publishGroup.MeetingTime %}
                             {% endif %}

--- a/Plugins/org.secc.Themes/Themes/SECC2024/Assets/Lava/Groups/GroupFinder.lava
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Assets/Lava/Groups/GroupFinder.lava
@@ -133,7 +133,7 @@
                             {% assign meetingDaySize = publishGroup.MeetingDay | Trim | Size %}
                             {% assign meetingTimeSize = publishGroup.MeetingDay | Trim | Size %}
                             {% if publishGroup.CustomSchedule != '' %}
-                                {% assign scheduleText = publishGroup.CustomSchedule %}
+                                {% assign scheduleText = publishGroup.CustomSchedule | StripHtml %}
                             {% elseif meetingDaySize > 0 and meetingTimeSize > 0 %}
                                 {% assign scheduleText = publishGroup.MeetingDay | Append:'s ' | Append:publishGroup.MeetingTime %}
                             {% endif %}


### PR DESCRIPTION
## Summary
- **FormatScheduleDates()** method added to `PublishGroup.cs` — converts RDATE-based schedules into readable text (e.g., "Tuesdays at 6:30 PM: Aug 5, Aug 19, Sep 2...") instead of storing raw iCal or HTML
- **Replaced** `FriendlyScheduleText` (returns HTML for specific-date schedules) and `iCalendarContent` (raw iCal) references with `FormatScheduleDates` across all code paths that populate `CustomSchedule`
- **Save sanitization** — `.SanitizeHtml()` applied on save to strip any HTML that might leak through the textbox
- **Lava defense-in-depth** — `| StripHtml` filter added to SECC2019 and SECC2024 GroupFinder templates
- **NullReferenceException fix** — `OnInit` now guards `publishGroup` and `publishGroup.Group` before accessing `GroupTypeId`
- 
Test Link: https://sedev.secc.org/page/2006?PublishGroupId=9044

## Files Changed
| File | Changes |
|------|---------|
| `Plugins/org.secc.GroupManager/Model/PublishGroup.cs` | `FormatScheduleDates()` method, `ScheduleText` getter sanitization |
| `Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupRequest.ascx.cs` | Lines 206, 269, 407 (display), 494 (save), OnInit null fix |
| `Plugins/org.secc.Themes/Themes/SECC2019/Assets/Lava/Groups/GroupFinder.lava` | `| StripHtml` on CustomSchedule |
| `Plugins/org.secc.Themes/Themes/SECC2024/Assets/Lava/Groups/GroupFinder.lava` | `| StripHtml` on CustomSchedule |

## Test Plan
- [x] Open a publish group with an RDATE schedule (specific dates) — Custom Schedule should show "Tuesdays at 6:30 PM: Aug 5, Aug 19..." instead of iCal or HTML
- [x] Open a publish group with a weekly schedule — Custom Schedule should show normal friendly text
- [x] Open a new publish group request (no existing record) — page should not throw NullReferenceException
- [x] Save a publish group and verify CustomSchedule is stored as clean plain text
- [x] Check group finder page renders schedule text without HTML tags
- [x] Verify existing iCal records get cleaned up when the publish group page is opened and saved
