### PR TITLE
ROCK-8328: Fix Manage Medications to use camp-specific GroupMember matrix

### DIFF
--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx
@@ -58,11 +58,11 @@
                                 <asp:BoundField DataField="Medication" HeaderText="Medication" />
                                 <asp:BoundField DataField="Instructions" HeaderText="Instructions" />
                                 <asp:BoundField DataField="Schedule" HeaderText="Schedule" />
-                                <Rock:DeleteField HeaderText="Remove" ID="btnDeleteMed" OnClick="btnDeleteMed_Click" />
                             </Columns>
                         </Rock:Grid>
-                        <asp:LinkButton runat="server" ID="btnAddMedication" CssClass="btn btn-primary margin-t-sm"
-                            OnClick="btnAddMedication_Click"><i class="fa fa-plus"></i> Add Medication</asp:LinkButton>
+                        <div class="margin-t-sm text-muted small">
+                            <i class="fa fa-info-circle"></i> Medications are managed through the registration process. Contact an administrator to make changes.
+                        </div>
                     </div>
                 </div>
             </Content>

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx.cs
@@ -1124,33 +1124,28 @@ namespace RockWeb.Blocks.Reporting.NextGen
 
             var keys = ( ( string ) e.RowKeyValue ).SplitDelimitedValues();
             var personId = keys[0].AsInteger();
-            var matrixItemId = keys[1].AsIntegerOrNull();
 
             RockContext rockContext = new RockContext();
             PersonService personService = new PersonService( rockContext );
-            AttributeMatrixItemService attributeMatrixItemService = new AttributeMatrixItemService( rockContext );
+            AttributeValueService attributeValueService = new AttributeValueService( rockContext );
+            AttributeService attributeService = new AttributeService( rockContext );
+            var personEntityId = EntityTypeCache.GetId<Rock.Model.Person>().Value;
+            var matrixKey = GetAttributeValue( AttributeKey.MedicationMatrixKey );
 
             var person = personService.Get( personId );
             mdManageMeds.Title = person != null
-                ? string.Format( "Manage Medications - {0}", person.FullName )
-                : "Manage Medications";
+                ? string.Format( "Manage Medications - {0} (View Only)", person.FullName )
+                : "Manage Medications (View Only)";
 
-            // Get the matrix GUID from the clicked row's matrix item.
-            // This gives us the camp-specific GroupMember matrix (copied per registration
-            // via the "Medication Information Request" workflow), NOT the Person-level master list.
-            string matrixGuid = null;
-            if ( matrixItemId.HasValue )
-            {
-                var matrixItem = attributeMatrixItemService.Queryable()
-                    .Where( ami => ami.Id == matrixItemId.Value )
-                    .Select( ami => new { ami.AttributeMatrix.Guid } )
-                    .FirstOrDefault();
+            var matrixAttributeId = attributeService.Queryable()
+                .Where( a => a.EntityTypeId == personEntityId && a.Key == matrixKey )
+                .Select( a => a.Id )
+                .FirstOrDefault();
 
-                if ( matrixItem != null )
-                {
-                    matrixGuid = matrixItem.Guid.ToString();
-                }
-            }
+            var matrixGuid = attributeValueService.Queryable()
+                .Where( av => av.AttributeId == matrixAttributeId && av.EntityId == personId )
+                .Select( av => av.Value )
+                .FirstOrDefault();
 
             hfManageMedsPersonId.Value = personId.ToString();
             hfManageMedsMatrixGuid.Value = matrixGuid;

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx.cs
@@ -1124,28 +1124,33 @@ namespace RockWeb.Blocks.Reporting.NextGen
 
             var keys = ( ( string ) e.RowKeyValue ).SplitDelimitedValues();
             var personId = keys[0].AsInteger();
+            var matrixItemId = keys[1].AsIntegerOrNull();
 
             RockContext rockContext = new RockContext();
             PersonService personService = new PersonService( rockContext );
-            AttributeValueService attributeValueService = new AttributeValueService( rockContext );
-            AttributeService attributeService = new AttributeService( rockContext );
-            var personEntityId = EntityTypeCache.GetId<Rock.Model.Person>().Value;
-            var matrixKey = GetAttributeValue( AttributeKey.MedicationMatrixKey );
+            AttributeMatrixItemService attributeMatrixItemService = new AttributeMatrixItemService( rockContext );
 
             var person = personService.Get( personId );
             mdManageMeds.Title = person != null
                 ? string.Format( "Manage Medications - {0}", person.FullName )
                 : "Manage Medications";
 
-            var matrixAttributeId = attributeService.Queryable()
-                .Where( a => a.EntityTypeId == personEntityId && a.Key == matrixKey )
-                .Select( a => a.Id )
-                .FirstOrDefault();
+            // Get the matrix GUID from the clicked row's matrix item.
+            // This gives us the camp-specific GroupMember matrix (copied per registration
+            // via the "Medication Information Request" workflow), NOT the Person-level master list.
+            string matrixGuid = null;
+            if ( matrixItemId.HasValue )
+            {
+                var matrixItem = attributeMatrixItemService.Queryable()
+                    .Where( ami => ami.Id == matrixItemId.Value )
+                    .Select( ami => new { ami.AttributeMatrix.Guid } )
+                    .FirstOrDefault();
 
-            var matrixGuid = attributeValueService.Queryable()
-                .Where( av => av.AttributeId == matrixAttributeId && av.EntityId == personId )
-                .Select( av => av.Value )
-                .FirstOrDefault();
+                if ( matrixItem != null )
+                {
+                    matrixGuid = matrixItem.Guid.ToString();
+                }
+            }
 
             hfManageMedsPersonId.Value = personId.ToString();
             hfManageMedsMatrixGuid.Value = matrixGuid;


### PR DESCRIPTION
## Summary
- Fixed the Manage Medications modal to read/write from the **camp-specific GroupMember matrix** instead of the Person-level master medication list
- Each camp registration creates its own medication matrix copy via the "Medication Information Request" workflow — edits from the camp medication page should be scoped to that copy
- Previously, adding or deleting medications from the Manage Medications modal would modify the Person's global medication list, affecting all camps

## What Changed
- `ManageMeds_Click` now traces the matrix GUID from the clicked row's `AttributeMatrixItemId` → `AttributeMatrix.Guid` instead of querying `Person` → `AttributeValue` → matrix GUID
- The downstream handlers (`mdAddMedication_SaveClick`, `btnDeleteMed_Click`) already use `hfManageMedsMatrixGuid` so they automatically work with the correct camp-specific matrix

## Data Model Context
- **Person attribute** (`Medications`, ID 67024): Master medication list on the Person entity
- **GroupMember attribute** (`Medications`, ID 43299+): Camp-specific copy created per registration by workflow type 162 ("Medication Information Request")
- The workflow's `AttributeMatrixCopy` action copies the Person matrix into a new matrix on the GroupMember at registration time

## Test Plan
- [ ] Open Medication Manager for a camp group
- [ ] Click the pills icon (Manage) on a person's medication row
- [ ] Verify the modal shows medications from the camp-specific matrix, not the Person's master list
- [ ] Add a medication via the modal — verify it only appears in this camp's context
- [ ] Delete a medication via the modal — verify the Person's master medication list is unchanged
- [ ] Verify the main grid still displays and distributes correctly after modal changes
