### PR TITLE
ROCK-8447 Optimizations to reduce load when a server restarts

### DIFF
--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
@@ -139,24 +139,21 @@ namespace org.secc.FamilyCheckin.Cache
         public static void Remove( string qualifiedKey, Func<List<string>> keyFactory )
         {
             RockCache.Remove( qualifiedKey );
-            PublishCacheUpdateMessage( qualifiedKey, default( T ) );
             UpdateKeys( keyFactory, removeKey: qualifiedKey );
+            PublishCacheUpdateMessage( qualifiedKey, default( T ) );
         }
 
         public static void Clear( Func<List<string>> keyFactory )
         {
             // Get the definitive list of keys from the DB to ensure complete
             // local cleanup, even if the cached AllKeys list was evicted or stale.
-            var keysToRemove = keyFactory().Select( k => QualifiedKey( k ) ).ToList();
+            var keysToRemove = new HashSet<string>( keyFactory().Select( k => QualifiedKey( k ) ) );
 
             // Also include any locally cached keys that might not be in DB
             // (e.g. recently added but not yet persisted).
             foreach ( var cachedKey in AllKeys() )
             {
-                if ( !keysToRemove.Contains( cachedKey ) )
-                {
-                    keysToRemove.Add( cachedKey );
-                }
+                keysToRemove.Add( cachedKey );
             }
 
             // Remove each cached item locally without publishing per-item messages

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
@@ -24,19 +24,24 @@ namespace org.secc.FamilyCheckin.Cache
         private static readonly TimeSpan KeysRefreshInterval = TimeSpan.FromSeconds( 10 );
 
         // Warm-up: suppress publishing until this node is fully online.
-        // After IsRockStarted becomes true, we wait an additional grace period
-        // so the initial cache hydration doesn't flood the bus.
-        private static DateTime _warmUpCompleteUtc = DateTime.MinValue;
-        private static readonly TimeSpan WarmUpGracePeriod = TimeSpan.FromSeconds( 30 );
+        // Anchored to the time this type was first loaded (i.e. app start),
+        // NOT to the first publish attempt, so the grace period cannot
+        // fire long after the startup burst has already passed.
+        // Override via web.config appSettings: <add key="CheckinCacheWarmUpSeconds" value="30" />
+        private static readonly DateTime _typeLoadedUtc = DateTime.UtcNow;
+        private static readonly TimeSpan WarmUpGracePeriod = TimeSpan.FromSeconds(
+            int.TryParse( System.Configuration.ConfigurationManager.AppSettings["CheckinCacheWarmUpSeconds"], out int configuredSeconds )
+                ? configuredSeconds
+                : 30 );
 
         public void PostCached()
         {
         }
 
         /// <summary>
-        /// Returns true once Rock is started AND the grace period has elapsed,
-        /// meaning this node is safe to publish cache messages to the bus.
-        /// During warm-up, the node consumes messages but does not publish.
+        /// Returns true once Rock is started AND the grace period (measured
+        /// from app start) has elapsed. During warm-up the node consumes
+        /// messages but does not publish.
         /// </summary>
         private static bool IsReadyToPublish
         {
@@ -47,13 +52,10 @@ namespace org.secc.FamilyCheckin.Cache
                     return false;
                 }
 
-                // Capture the moment IsRockStarted first becomes true
-                if ( _warmUpCompleteUtc == DateTime.MinValue )
-                {
-                    _warmUpCompleteUtc = DateTime.UtcNow.Add( WarmUpGracePeriod );
-                }
-
-                return DateTime.UtcNow >= _warmUpCompleteUtc;
+                // Grace period is always relative to when the app loaded this type.
+                // If the app has been running longer than the grace period,
+                // this is true immediately — no delayed suppression.
+                return ( DateTime.UtcNow - _typeLoadedUtc ) >= WarmUpGracePeriod;
             }
         }
 
@@ -104,44 +106,33 @@ namespace org.secc.FamilyCheckin.Cache
                 return;
             }
 
-            int retryCount = 3;
-            int retryDelayMs = 100;
-            Exception lastException = null;
-
-            while ( retryCount > 0 )
+            try
             {
+                var keys = AllKeys();
+                if ( !keys.Any() || !keys.Contains( qualifiedKey ) )
+                {
+                    UpdateKeys( keyFactory, ensureKey: qualifiedKey );
+                }
+                RockCache.AddOrUpdate( qualifiedKey, item );
+                PublishCacheUpdateMessage( qualifiedKey, item );
+            }
+            catch ( Exception ex )
+            {
+                // Log but don't retry synchronously — retrying with Thread.Sleep
+                // blocks the request thread while holding the ASP.NET session lock,
+                // which causes session queue exhaustion under load.
+                Rock.Model.ExceptionLogService.LogException(
+                    new Exception( $"Failed to update cache for key {qualifiedKey}: {ex.Message}", ex ) );
+
+                // Best-effort: at minimum get it into local cache
                 try
                 {
-
-                    var keys = AllKeys();
-                    if ( !keys.Any() || !keys.Contains( qualifiedKey ) )
-                    {
-                        UpdateKeys( keyFactory, ensureKey: qualifiedKey );
-                    }
                     RockCache.AddOrUpdate( qualifiedKey, item );
-                    PublishCacheUpdateMessage( qualifiedKey, item );
-                    return;
                 }
-                catch ( Exception ex )
+                catch
                 {
-                    lastException = ex;
-                    retryCount--;
-
-                    if ( retryCount > 0 )
-                    {
-                        Rock.Model.ExceptionLogService.LogException(
-                            new Exception( $"Retrying cache update for {qualifiedKey}: {ex.Message}", ex ) );
-                        System.Threading.Thread.Sleep( retryDelayMs );
-                        retryDelayMs *= 2; // Exponential backoff
-                    }
+                    // Swallow — the item will be fetched from DB on next access
                 }
-            }
-
-            // If we get here, all retries failed
-            if ( lastException != null )
-            {
-                Rock.Model.ExceptionLogService.LogException(
-                    new Exception( $"Failed to update cache after multiple attempts for key {qualifiedKey}", lastException ) );
             }
         }
 
@@ -154,8 +145,22 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static void Clear( Func<List<string>> keyFactory )
         {
+            // Get the definitive list of keys from the DB to ensure complete
+            // local cleanup, even if the cached AllKeys list was evicted or stale.
+            var keysToRemove = keyFactory().Select( k => QualifiedKey( k ) ).ToList();
+
+            // Also include any locally cached keys that might not be in DB
+            // (e.g. recently added but not yet persisted).
+            foreach ( var cachedKey in AllKeys() )
+            {
+                if ( !keysToRemove.Contains( cachedKey ) )
+                {
+                    keysToRemove.Add( cachedKey );
+                }
+            }
+
             // Remove each cached item locally without publishing per-item messages
-            foreach ( var key in AllKeys().ToList() )
+            foreach ( var key in keysToRemove )
             {
                 RockCache.Remove( key );
             }
@@ -213,26 +218,30 @@ namespace org.secc.FamilyCheckin.Cache
                 {
                     bool modified = false;
 
+                    // Copy-on-write: clone the list so threads currently
+                    // enumerating the original reference are not affected.
+                    var updatedKeys = new List<string>( currentKeys );
+
                     // Ensure the specified key is present
-                    if ( !string.IsNullOrEmpty( ensureKey ) && !currentKeys.Contains( ensureKey ) )
+                    if ( !string.IsNullOrEmpty( ensureKey ) && !updatedKeys.Contains( ensureKey ) )
                     {
-                        currentKeys.Add( ensureKey );
+                        updatedKeys.Add( ensureKey );
                         modified = true;
                     }
 
                     // Remove the specified key
-                    if ( !string.IsNullOrEmpty( removeKey ) && currentKeys.Contains( removeKey ) )
+                    if ( !string.IsNullOrEmpty( removeKey ) && updatedKeys.Contains( removeKey ) )
                     {
-                        currentKeys.Remove( removeKey );
+                        updatedKeys.Remove( removeKey );
                         modified = true;
                     }
 
                     if ( modified )
                     {
-                        RockCache.AddOrUpdate( AllKey, AllRegion, currentKeys );
+                        RockCache.AddOrUpdate( AllKey, AllRegion, updatedKeys );
                     }
 
-                    return currentKeys;
+                    return updatedKeys;
                 }
 
                 var keys = keyFactory().Select( k => QualifiedKey( k ) ).ToList();

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
@@ -23,8 +23,38 @@ namespace org.secc.FamilyCheckin.Cache
         private static DateTime _lastKeysRefreshUtc = DateTime.MinValue;
         private static readonly TimeSpan KeysRefreshInterval = TimeSpan.FromSeconds( 10 );
 
+        // Warm-up: suppress publishing until this node is fully online.
+        // After IsRockStarted becomes true, we wait an additional grace period
+        // so the initial cache hydration doesn't flood the bus.
+        private static DateTime _warmUpCompleteUtc = DateTime.MinValue;
+        private static readonly TimeSpan WarmUpGracePeriod = TimeSpan.FromSeconds( 30 );
+
         public void PostCached()
         {
+        }
+
+        /// <summary>
+        /// Returns true once Rock is started AND the grace period has elapsed,
+        /// meaning this node is safe to publish cache messages to the bus.
+        /// During warm-up, the node consumes messages but does not publish.
+        /// </summary>
+        private static bool IsReadyToPublish
+        {
+            get
+            {
+                if ( !RockMessageBus.IsRockStarted )
+                {
+                    return false;
+                }
+
+                // Capture the moment IsRockStarted first becomes true
+                if ( _warmUpCompleteUtc == DateTime.MinValue )
+                {
+                    _warmUpCompleteUtc = DateTime.UtcNow.Add( WarmUpGracePeriod );
+                }
+
+                return DateTime.UtcNow >= _warmUpCompleteUtc;
+            }
         }
 
         public static List<string> AllKeys( Func<List<string>> keyFactory )
@@ -57,7 +87,6 @@ namespace org.secc.FamilyCheckin.Cache
                 }
 
                 RockCache.AddOrUpdate( qualifiedKey, item );
-                // PublishCacheUpdateMessage( qualifiedKey, item );
             }
             else
             {
@@ -88,7 +117,7 @@ namespace org.secc.FamilyCheckin.Cache
                     if ( !keys.Any() || !keys.Contains( qualifiedKey ) )
                     {
                         UpdateKeys( keyFactory, ensureKey: qualifiedKey );
-                    }            //RockCacheManager<T>.Instance.Cache.AddOrUpdate( qualifiedKey, item, v => item );
+                    }
                     RockCache.AddOrUpdate( qualifiedKey, item );
                     PublishCacheUpdateMessage( qualifiedKey, item );
                     return;
@@ -125,18 +154,21 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static void Clear( Func<List<string>> keyFactory )
         {
-            UpdateKeys( keyFactory );
-
-            // Create a copy of the keys to avoid collection modification during enumeration
+            // Remove each cached item locally without publishing per-item messages
             foreach ( var key in AllKeys().ToList() )
             {
-                FlushItem( key, keyFactory );
+                RockCache.Remove( key );
             }
+
+            // Clear the AllKeys list
+            RockCache.Remove( AllKey, AllRegion );
+
+            // Publish a single clear-all message instead of N+1
             PublishCacheUpdateMessage( null, default( T ) );
         }
+
         public static void FlushItem( string qualifiedKey, Func<List<string>> keyFactory )
         {
-            //RockCacheManager<T>.Instance.Cache.Remove( qualifiedKey );
             RockCache.Remove( qualifiedKey );
             UpdateKeys( keyFactory, removeKey: qualifiedKey );
             PublishCacheUpdateMessage( qualifiedKey, default( T ) );
@@ -224,6 +256,16 @@ namespace org.secc.FamilyCheckin.Cache
 
         private static void PublishCacheUpdateMessage( string key, T item )
         {
+            // During warm-up, only consume — don't publish.
+            // This prevents a recycling node from flooding the bus and
+            // causing all other nodes to invalidate their caches.
+            if ( !IsReadyToPublish )
+            {
+                RockLogger.Log.Debug( RockLogDomains.Bus,
+                    $"Suppressed cache publish during warm-up for {typeof( T ).Name} key={key ?? "(clear all)"}. Server: {RockMessageBus.NodeName}." );
+                return;
+            }
+
             var message = new CheckinCacheMessage
             {
                 Key = key,

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
@@ -23,6 +23,20 @@ namespace org.secc.FamilyCheckin.Cache
         private static DateTime _lastKeysRefreshUtc = DateTime.MinValue;
         private static readonly TimeSpan KeysRefreshInterval = TimeSpan.FromSeconds( 10 );
 
+        // The subclass supplies its keyFactory as a delegate on every public call.
+        // Remember the most recent one so internal/remote paths that have no keyFactory
+        // of their own (ClearLocal, called from the bus consumer) can still rebuild the
+        // key set from the DB when the cached AllKeys list is missing.
+        private static Func<List<string>> _lastKeyFactory;
+
+        private static void RememberKeyFactory( Func<List<string>> keyFactory )
+        {
+            if ( keyFactory != null )
+            {
+                _lastKeyFactory = keyFactory;
+            }
+        }
+
         // Warm-up: for the first N seconds after THIS NODE's bus comes online,
         // suppress publishing so a cold, recycled node repopulating its cache
         // does not flood the bus and force every other node to churn.
@@ -71,6 +85,7 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static List<string> AllKeys( Func<List<string>> keyFactory )
         {
+            RememberKeyFactory( keyFactory );
             var keys = AllKeys();
             if ( !keys.Any() )
             {
@@ -81,6 +96,7 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static T Get( string qualifiedKey, Func<T> itemFactory, Func<List<string>> keyFactory )
         {
+            RememberKeyFactory( keyFactory );
 
             var item = ( T ) RockCache.Get( qualifiedKey );
 
@@ -116,6 +132,8 @@ namespace org.secc.FamilyCheckin.Cache
                 return;
             }
 
+            RememberKeyFactory( keyFactory );
+
             try
             {
                 var keys = AllKeys();
@@ -148,6 +166,7 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static void Remove( string qualifiedKey, Func<List<string>> keyFactory )
         {
+            RememberKeyFactory( keyFactory );
             try
             {
                 RockCache.Remove( qualifiedKey );
@@ -173,6 +192,7 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static void Clear( Func<List<string>> keyFactory )
         {
+            RememberKeyFactory( keyFactory );
             try
             {
                 // Hold KeysUpdateLock for the whole clear so a concurrent UpdateKeys
@@ -216,6 +236,7 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static void FlushItem( string qualifiedKey, Func<List<string>> keyFactory )
         {
+            RememberKeyFactory( keyFactory );
             try
             {
                 RockCache.Remove( qualifiedKey );
@@ -270,9 +291,10 @@ namespace org.secc.FamilyCheckin.Cache
         /// Adds a key to the AllKeys list in response to a remote (bus) update.
         /// Takes <see cref="KeysUpdateLock"/> so it cannot race the local
         /// <see cref="UpdateKeys"/> read-modify-write and clobber concurrent edits.
-        /// If the local list is missing, the list is invalidated so the next read
-        /// rebuilds it from the DB (matching the pre-optimization behavior) rather
-        /// than registering a single key against a non-existent list.
+        /// If the local list is missing, it is rebuilt from the DB (via the last known
+        /// keyFactory) with this key included, so the list does not stay null — leaving
+        /// it null would also blind <see cref="ClearLocal"/>. If no keyFactory is known
+        /// yet, fall back to invalidation so the next read rebuilds it.
         /// </summary>
         internal static void RegisterRemoteKey( string qualifiedKey )
         {
@@ -286,7 +308,29 @@ namespace org.secc.FamilyCheckin.Cache
                 var keys = RockCache.Get( AllKey, AllRegion ) as List<string>;
                 if ( keys == null )
                 {
-                    // No local list — invalidate so the next AllKeys(keyFactory) rebuilds from DB.
+                    var keyFactory = _lastKeyFactory;
+                    if ( keyFactory != null )
+                    {
+                        try
+                        {
+                            var rebuilt = keyFactory().Select( k => QualifiedKey( k ) ).ToList();
+                            if ( !rebuilt.Contains( qualifiedKey ) )
+                            {
+                                rebuilt.Add( qualifiedKey );
+                            }
+                            RockCache.AddOrUpdate( AllKey, AllRegion, rebuilt );
+                            _lastKeysRefreshUtc = DateTime.UtcNow;
+                            return;
+                        }
+                        catch ( Exception ex )
+                        {
+                            Rock.Model.ExceptionLogService.LogException(
+                                new Exception( $"RegisterRemoteKey rebuild failed for {typeof( T ).Name}: {ex.Message}", ex ) );
+                        }
+                    }
+
+                    // No keyFactory known (or rebuild failed) — invalidate so the next
+                    // AllKeys(keyFactory) rebuilds from DB.
                     RockCache.Remove( AllKey, AllRegion );
                     return;
                 }
@@ -348,6 +392,29 @@ namespace org.secc.FamilyCheckin.Cache
             lock ( KeysUpdateLock )
             {
                 var keys = RockCache.Get( AllKey, AllRegion ) as List<string>;
+                if ( keys == null )
+                {
+                    // The AllKeys list is missing (evicted, or not yet built on a cold node
+                    // that has only been fed remote updates). Without it we have no way to
+                    // find the per-key item entries, so a clear-all would silently leave them
+                    // stale. Fall back to the DB key set via the last keyFactory a local
+                    // caller supplied. Best-effort: this evicts DB-current keys; a cached item
+                    // whose DB row was already deleted cannot be located without the list.
+                    var keyFactory = _lastKeyFactory;
+                    if ( keyFactory != null )
+                    {
+                        try
+                        {
+                            keys = keyFactory().Select( k => QualifiedKey( k ) ).ToList();
+                        }
+                        catch ( Exception ex )
+                        {
+                            Rock.Model.ExceptionLogService.LogException(
+                                new Exception( $"ClearLocal key rebuild failed for {typeof( T ).Name}: {ex.Message}", ex ) );
+                        }
+                    }
+                }
+
                 if ( keys != null )
                 {
                     foreach ( var key in keys )

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
@@ -173,34 +173,45 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static void Clear( Func<List<string>> keyFactory )
         {
-            // Hold KeysUpdateLock for the whole clear so a concurrent UpdateKeys
-            // cannot rebuild the list from the DB and undo the local clear.
-            lock ( KeysUpdateLock )
+            try
             {
-                // Get the definitive list of keys from the DB to ensure complete
-                // local cleanup, even if the cached AllKeys list was evicted or stale.
-                var keysToRemove = new HashSet<string>( keyFactory().Select( k => QualifiedKey( k ) ) );
-
-                // Also include any locally cached keys that might not be in DB
-                // (e.g. recently added but not yet persisted).
-                foreach ( var cachedKey in AllKeys() )
+                // Hold KeysUpdateLock for the whole clear so a concurrent UpdateKeys
+                // cannot rebuild the list from the DB and undo the local clear.
+                lock ( KeysUpdateLock )
                 {
-                    keysToRemove.Add( cachedKey );
+                    // Get the definitive list of keys from the DB to ensure complete
+                    // local cleanup, even if the cached AllKeys list was evicted or stale.
+                    var keysToRemove = new HashSet<string>( keyFactory().Select( k => QualifiedKey( k ) ) );
+
+                    // Also include any locally cached keys that might not be in DB
+                    // (e.g. recently added but not yet persisted).
+                    foreach ( var cachedKey in AllKeys() )
+                    {
+                        keysToRemove.Add( cachedKey );
+                    }
+
+                    // Remove each cached item locally without publishing per-item messages
+                    foreach ( var key in keysToRemove )
+                    {
+                        RockCache.Remove( key );
+                    }
+
+                    // Clear the AllKeys list and force the next read to rebuild from DB.
+                    RockCache.Remove( AllKey, AllRegion );
+                    _lastKeysRefreshUtc = DateTime.MinValue;
                 }
 
-                // Remove each cached item locally without publishing per-item messages
-                foreach ( var key in keysToRemove )
-                {
-                    RockCache.Remove( key );
-                }
-
-                // Clear the AllKeys list and force the next read to rebuild from DB.
-                RockCache.Remove( AllKey, AllRegion );
-                _lastKeysRefreshUtc = DateTime.MinValue;
+                // Publish a single clear-all message instead of N+1
+                PublishCacheUpdateMessage( null, default( T ) );
             }
-
-            // Publish a single clear-all message instead of N+1
-            PublishCacheUpdateMessage( null, default( T ) );
+            catch ( Exception ex )
+            {
+                // Match the other mutators: log and degrade rather than throwing into
+                // the caller (e.g. a check-in request). A failed keyFactory()/RockCache
+                // call leaves the clear partially applied, which the next refresh heals.
+                Rock.Model.ExceptionLogService.LogException(
+                    new Exception( $"Failed to clear cache for {typeof( T ).Name}: {ex.Message}", ex ) );
+            }
         }
 
         public static void FlushItem( string qualifiedKey, Func<List<string>> keyFactory )
@@ -321,6 +332,32 @@ namespace org.secc.FamilyCheckin.Cache
             lock ( KeysUpdateLock )
             {
                 RockCache.Remove( AllKey, AllRegion );
+            }
+        }
+
+        /// <summary>
+        /// Evicts this node's locally cached items for this type in response to a
+        /// remote (bus) clear-all, then invalidates the AllKeys list.
+        /// Items are stored via RockCache.AddOrUpdate(key, item) — i.e. in
+        /// RockCacheManager&lt;object&gt; — so RockCache.ClearCachedItemsForType(T)
+        /// (which only clears RockCacheManager&lt;T&gt;) does NOT remove them; we must
+        /// remove each key explicitly, mirroring the publisher's local Clear().
+        /// </summary>
+        internal static void ClearLocal()
+        {
+            lock ( KeysUpdateLock )
+            {
+                var keys = RockCache.Get( AllKey, AllRegion ) as List<string>;
+                if ( keys != null )
+                {
+                    foreach ( var key in keys )
+                    {
+                        RockCache.Remove( key );
+                    }
+                }
+
+                RockCache.Remove( AllKey, AllRegion );
+                _lastKeysRefreshUtc = DateTime.MinValue;
             }
         }
 

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
@@ -30,9 +30,10 @@ namespace org.secc.FamilyCheckin.Cache
         // Override via web.config appSettings: <add key="CheckinCacheWarmUpSeconds" value="30" />
         private static readonly DateTime _typeLoadedUtc = DateTime.UtcNow;
         private static readonly TimeSpan WarmUpGracePeriod = TimeSpan.FromSeconds(
-            int.TryParse( System.Configuration.ConfigurationManager.AppSettings["CheckinCacheWarmUpSeconds"], out int configuredSeconds )
-                ? configuredSeconds
-                : 30 );
+            Math.Max( 0,
+                int.TryParse( System.Configuration.ConfigurationManager.AppSettings["CheckinCacheWarmUpSeconds"], out int configuredSeconds )
+                    ? configuredSeconds
+                    : 30 ) );
 
         public void PostCached()
         {
@@ -138,32 +139,56 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static void Remove( string qualifiedKey, Func<List<string>> keyFactory )
         {
-            RockCache.Remove( qualifiedKey );
-            UpdateKeys( keyFactory, removeKey: qualifiedKey );
-            PublishCacheUpdateMessage( qualifiedKey, default( T ) );
+            try
+            {
+                RockCache.Remove( qualifiedKey );
+                UpdateKeys( keyFactory, removeKey: qualifiedKey );
+                PublishCacheUpdateMessage( qualifiedKey, default( T ) );
+            }
+            catch ( Exception ex )
+            {
+                Rock.Model.ExceptionLogService.LogException(
+                    new Exception( $"Failed to remove cache for key {qualifiedKey}: {ex.Message}", ex ) );
+
+                // Best-effort: at minimum evict from local cache
+                try
+                {
+                    RockCache.Remove( qualifiedKey );
+                }
+                catch
+                {
+                    // Swallow — the item will be re-evaluated from DB on next access
+                }
+            }
         }
 
         public static void Clear( Func<List<string>> keyFactory )
         {
-            // Get the definitive list of keys from the DB to ensure complete
-            // local cleanup, even if the cached AllKeys list was evicted or stale.
-            var keysToRemove = new HashSet<string>( keyFactory().Select( k => QualifiedKey( k ) ) );
-
-            // Also include any locally cached keys that might not be in DB
-            // (e.g. recently added but not yet persisted).
-            foreach ( var cachedKey in AllKeys() )
+            // Hold KeysUpdateLock for the whole clear so a concurrent UpdateKeys
+            // cannot rebuild the list from the DB and undo the local clear.
+            lock ( KeysUpdateLock )
             {
-                keysToRemove.Add( cachedKey );
-            }
+                // Get the definitive list of keys from the DB to ensure complete
+                // local cleanup, even if the cached AllKeys list was evicted or stale.
+                var keysToRemove = new HashSet<string>( keyFactory().Select( k => QualifiedKey( k ) ) );
 
-            // Remove each cached item locally without publishing per-item messages
-            foreach ( var key in keysToRemove )
-            {
-                RockCache.Remove( key );
-            }
+                // Also include any locally cached keys that might not be in DB
+                // (e.g. recently added but not yet persisted).
+                foreach ( var cachedKey in AllKeys() )
+                {
+                    keysToRemove.Add( cachedKey );
+                }
 
-            // Clear the AllKeys list
-            RockCache.Remove( AllKey, AllRegion );
+                // Remove each cached item locally without publishing per-item messages
+                foreach ( var key in keysToRemove )
+                {
+                    RockCache.Remove( key );
+                }
+
+                // Clear the AllKeys list and force the next read to rebuild from DB.
+                RockCache.Remove( AllKey, AllRegion );
+                _lastKeysRefreshUtc = DateTime.MinValue;
+            }
 
             // Publish a single clear-all message instead of N+1
             PublishCacheUpdateMessage( null, default( T ) );
@@ -171,9 +196,27 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static void FlushItem( string qualifiedKey, Func<List<string>> keyFactory )
         {
-            RockCache.Remove( qualifiedKey );
-            UpdateKeys( keyFactory, removeKey: qualifiedKey );
-            PublishCacheUpdateMessage( qualifiedKey, default( T ) );
+            try
+            {
+                RockCache.Remove( qualifiedKey );
+                UpdateKeys( keyFactory, removeKey: qualifiedKey );
+                PublishCacheUpdateMessage( qualifiedKey, default( T ) );
+            }
+            catch ( Exception ex )
+            {
+                Rock.Model.ExceptionLogService.LogException(
+                    new Exception( $"Failed to flush cache for key {qualifiedKey}: {ex.Message}", ex ) );
+
+                // Best-effort: at minimum evict from local cache
+                try
+                {
+                    RockCache.Remove( qualifiedKey );
+                }
+                catch
+                {
+                    // Swallow — the item will be re-evaluated from DB on next access
+                }
+            }
         }
 
         internal protected static string QualifiedKey( int id )
@@ -203,6 +246,75 @@ namespace org.secc.FamilyCheckin.Cache
             return keys ?? new List<string>();
         }
 
+        /// <summary>
+        /// Adds a key to the AllKeys list in response to a remote (bus) update.
+        /// Takes <see cref="KeysUpdateLock"/> so it cannot race the local
+        /// <see cref="UpdateKeys"/> read-modify-write and clobber concurrent edits.
+        /// If the local list is missing, the list is invalidated so the next read
+        /// rebuilds it from the DB (matching the pre-optimization behavior) rather
+        /// than registering a single key against a non-existent list.
+        /// </summary>
+        internal static void RegisterRemoteKey( string qualifiedKey )
+        {
+            if ( string.IsNullOrEmpty( qualifiedKey ) )
+            {
+                return;
+            }
+
+            lock ( KeysUpdateLock )
+            {
+                var keys = RockCache.Get( AllKey, AllRegion ) as List<string>;
+                if ( keys == null )
+                {
+                    // No local list — invalidate so the next AllKeys(keyFactory) rebuilds from DB.
+                    RockCache.Remove( AllKey, AllRegion );
+                    return;
+                }
+
+                if ( !keys.Contains( qualifiedKey ) )
+                {
+                    // Copy-on-write so any reader still enumerating the old reference is unaffected.
+                    var updatedKeys = new List<string>( keys ) { qualifiedKey };
+                    RockCache.AddOrUpdate( AllKey, AllRegion, updatedKeys );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes a key from the AllKeys list in response to a remote (bus) update.
+        /// Takes <see cref="KeysUpdateLock"/> to avoid racing local edits.
+        /// </summary>
+        internal static void UnregisterRemoteKey( string qualifiedKey )
+        {
+            if ( string.IsNullOrEmpty( qualifiedKey ) )
+            {
+                return;
+            }
+
+            lock ( KeysUpdateLock )
+            {
+                var keys = RockCache.Get( AllKey, AllRegion ) as List<string>;
+                if ( keys != null && keys.Contains( qualifiedKey ) )
+                {
+                    var updatedKeys = new List<string>( keys );
+                    updatedKeys.Remove( qualifiedKey );
+                    RockCache.AddOrUpdate( AllKey, AllRegion, updatedKeys );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Invalidates the AllKeys list in response to a remote (bus) clear-all,
+        /// under <see cref="KeysUpdateLock"/>. The next read rebuilds it from the DB.
+        /// </summary>
+        internal static void InvalidateRemoteKeys()
+        {
+            lock ( KeysUpdateLock )
+            {
+                RockCache.Remove( AllKey, AllRegion );
+            }
+        }
+
         private static List<string> UpdateKeys( Func<List<string>> keyFactory, string ensureKey = null, string removeKey = null )
         {
             lock ( KeysUpdateLock )
@@ -215,8 +327,10 @@ namespace org.secc.FamilyCheckin.Cache
                 {
                     bool modified = false;
 
-                    // Copy-on-write: clone the list so threads currently
-                    // enumerating the original reference are not affected.
+                    // Copy-on-write: clone the list so any reader still enumerating
+                    // the original reference is not affected. NOTE: this protects
+                    // readers only — concurrent writers are serialized by KeysUpdateLock,
+                    // which all key mutators (local and remote) must hold.
                     var updatedKeys = new List<string>( currentKeys );
 
                     // Ensure the specified key is present

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
@@ -23,12 +23,17 @@ namespace org.secc.FamilyCheckin.Cache
         private static DateTime _lastKeysRefreshUtc = DateTime.MinValue;
         private static readonly TimeSpan KeysRefreshInterval = TimeSpan.FromSeconds( 10 );
 
-        // Warm-up: suppress publishing until this node is fully online.
-        // Anchored to the time this type was first loaded (i.e. app start),
-        // NOT to the first publish attempt, so the grace period cannot
-        // fire long after the startup burst has already passed.
+        // Warm-up: for the first N seconds after THIS NODE's bus comes online,
+        // suppress publishing so a cold, recycled node repopulating its cache
+        // does not flood the bus and force every other node to churn.
+        //
+        // The window is anchored to when the bus is first observed ready
+        // (see CheckinCacheWarmUp), NOT to type load. Type load happens early
+        // in app start, well before Rock/the bus finish initializing — with a
+        // type-load anchor the grace period expired during the (often >30s)
+        // cold start, before the node could publish anything, so it never
+        // actually suppressed the startup burst.
         // Override via web.config appSettings: <add key="CheckinCacheWarmUpSeconds" value="30" />
-        private static readonly DateTime _typeLoadedUtc = DateTime.UtcNow;
         private static readonly TimeSpan WarmUpGracePeriod = TimeSpan.FromSeconds(
             Math.Max( 0,
                 int.TryParse( System.Configuration.ConfigurationManager.AppSettings["CheckinCacheWarmUpSeconds"], out int configuredSeconds )
@@ -40,9 +45,9 @@ namespace org.secc.FamilyCheckin.Cache
         }
 
         /// <summary>
-        /// Returns true once Rock is started AND the grace period (measured
-        /// from app start) has elapsed. During warm-up the node consumes
-        /// messages but does not publish.
+        /// Returns true once Rock is started AND the grace period (measured from
+        /// when the bus was first observed ready) has elapsed. During warm-up the
+        /// node still consumes messages but does not publish.
         /// </summary>
         private static bool IsReadyToPublish
         {
@@ -53,10 +58,14 @@ namespace org.secc.FamilyCheckin.Cache
                     return false;
                 }
 
-                // Grace period is always relative to when the app loaded this type.
-                // If the app has been running longer than the grace period,
-                // this is true immediately — no delayed suppression.
-                return ( DateTime.UtcNow - _typeLoadedUtc ) >= WarmUpGracePeriod;
+                // Anchor the grace window to the first moment the bus is ready
+                // (process-wide, set once). Measuring from here — not type load —
+                // means the window covers the node's first N seconds of being
+                // online, which is exactly when a cold node repopulating its
+                // cache would otherwise flood the bus.
+                var now = DateTime.UtcNow;
+                var busReadyUtc = CheckinCacheWarmUp.MarkBusReady( now );
+                return ( now - busReadyUtc ) >= WarmUpGracePeriod;
             }
         }
 
@@ -406,6 +415,33 @@ namespace org.secc.FamilyCheckin.Cache
         public virtual string ToJson()
         {
             return JsonConvert.SerializeObject( this );
+        }
+    }
+
+    /// <summary>
+    /// Process-wide warm-up state shared across all <see cref="CheckinCache{T}"/>
+    /// closed generic types. The bus-ready instant is recorded once for the whole
+    /// app domain so the warm-up window is anchored to node startup — not re-armed
+    /// hours later the first time some rarely-used cache type happens to publish.
+    /// </summary>
+    internal static class CheckinCacheWarmUp
+    {
+        // 0 = bus not yet observed ready. Stored as UTC ticks for a lock-free
+        // compare-and-set.
+        private static long _busReadyTicks = 0;
+
+        /// <summary>
+        /// Records <paramref name="nowUtc"/> as the bus-ready instant the first
+        /// time it is called, and returns the recorded instant on every call.
+        /// Because check-in caches are exercised immediately under check-in load,
+        /// the first call lands right as the node comes online.
+        /// </summary>
+        internal static DateTime MarkBusReady( DateTime nowUtc )
+        {
+            var existing = System.Threading.Interlocked.CompareExchange( ref _busReadyTicks, nowUtc.Ticks, 0 );
+            return existing == 0
+                ? nowUtc
+                : new DateTime( existing, DateTimeKind.Utc );
         }
     }
 }

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCacheConsumer.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCacheConsumer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Rock.Bus;
 using Rock.Bus.Consumer;
@@ -78,13 +79,13 @@ namespace org.secc.FamilyCheckin.Cache
                             RockCache.AddOrUpdate( message.Key, item );
                         }
 
-                        // Surgically add the key to the existing AllKeys list
-                        // instead of invalidating it (which triggers a DB call)
-                        var keys = RockCache.Get( allKeysListCacheKey, allKeysListCacheRegion ) as System.Collections.Generic.List<string>;
+                        // Copy-on-write: clone the list before modifying so threads
+                        // currently enumerating the old reference are not affected.
+                        var keys = RockCache.Get( allKeysListCacheKey, allKeysListCacheRegion ) as List<string>;
                         if ( keys != null && !keys.Contains( message.Key ) )
                         {
-                            keys.Add( message.Key );
-                            RockCache.AddOrUpdate( allKeysListCacheKey, allKeysListCacheRegion, keys );
+                            var updatedKeys = new List<string>( keys ) { message.Key };
+                            RockCache.AddOrUpdate( allKeysListCacheKey, allKeysListCacheRegion, updatedKeys );
                         }
 
                         RockLogger.Log.Debug( RockLogDomains.Bus,
@@ -120,11 +121,13 @@ namespace org.secc.FamilyCheckin.Cache
                     RockCache.Remove( message.Key );
                 }
 
-                // Surgically remove from the AllKeys list instead of invalidating
-                var keys = RockCache.Get( allKeysListCacheKey, allKeysListCacheRegion ) as System.Collections.Generic.List<string>;
-                if ( keys != null && keys.Remove( message.Key ) )
+                // Copy-on-write: clone before removing so concurrent readers are safe.
+                var keys = RockCache.Get( allKeysListCacheKey, allKeysListCacheRegion ) as List<string>;
+                if ( keys != null && keys.Contains( message.Key ) )
                 {
-                    RockCache.AddOrUpdate( allKeysListCacheKey, allKeysListCacheRegion, keys );
+                    var updatedKeys = new List<string>( keys );
+                    updatedKeys.Remove( message.Key );
+                    RockCache.AddOrUpdate( allKeysListCacheKey, allKeysListCacheRegion, updatedKeys );
                 }
 
                 RockLogger.Log.Debug( RockLogDomains.Bus, $"Removed cache for key {message.Key}. Server: {RockMessageBus.NodeName}." );

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCacheConsumer.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCacheConsumer.cs
@@ -20,6 +20,16 @@ namespace org.secc.FamilyCheckin.Cache
                 return;
             }
 
+            // Skip messages this node published — the local cache was already
+            // updated before the message was sent, so processing it again is
+            // redundant and doubles the work.
+            if ( RockMessageBus.IsFromSelf( message ) )
+            {
+                RockLogger.Log.Debug( RockLogDomains.Bus,
+                    $"Skipping self-sent CheckinCache message for key {message.Key}. Server: {RockMessageBus.NodeName}." );
+                return;
+            }
+
             try
             {
                 var cacheType = Type.GetType( message.CacheTypeName );
@@ -48,11 +58,10 @@ namespace org.secc.FamilyCheckin.Cache
         /// </summary>
         private void ProcessCacheMessage<T>( CheckinCacheMessage message )
         {
-            // Constants for the AllKeys list, matching CheckinCache<T>
             string allKeysListCacheKey = $"{typeof( T ).Name}:All";
-            string allKeysListCacheRegion = "AllItems"; // This is the 'AllRegion' constant from CheckinCache<T>
+            string allKeysListCacheRegion = "AllItems";
 
-            // If we have additional data, this is an update
+            // If we have additional data, this is an update — apply the value directly
             if ( !string.IsNullOrEmpty( message.AdditionalData ) )
             {
                 try
@@ -69,11 +78,17 @@ namespace org.secc.FamilyCheckin.Cache
                             RockCache.AddOrUpdate( message.Key, item );
                         }
 
-                        // Invalidate the AllKeys list as an item was added/updated
-                        RockCache.Remove( allKeysListCacheKey, allKeysListCacheRegion );
+                        // Surgically add the key to the existing AllKeys list
+                        // instead of invalidating it (which triggers a DB call)
+                        var keys = RockCache.Get( allKeysListCacheKey, allKeysListCacheRegion ) as System.Collections.Generic.List<string>;
+                        if ( keys != null && !keys.Contains( message.Key ) )
+                        {
+                            keys.Add( message.Key );
+                            RockCache.AddOrUpdate( allKeysListCacheKey, allKeysListCacheRegion, keys );
+                        }
 
                         RockLogger.Log.Debug( RockLogDomains.Bus,
-                            $"Updated cache for key {message.Key}. Server: {RockMessageBus.NodeName}. AdditionalData: {message.AdditionalData}" );
+                            $"Updated cache for key {message.Key}. Server: {RockMessageBus.NodeName}." );
                     }
                 }
                 catch ( Exception ex )
@@ -89,7 +104,7 @@ namespace org.secc.FamilyCheckin.Cache
                     {
                         RockCache.Remove( message.Key );
                     }
-                    // invalidate AllKeys on error
+                    // Only invalidate AllKeys on deserialization error
                     RockCache.Remove( allKeysListCacheKey, allKeysListCacheRegion );
                 }
             }
@@ -104,19 +119,23 @@ namespace org.secc.FamilyCheckin.Cache
                 {
                     RockCache.Remove( message.Key );
                 }
-                // Invalidate the AllKeys list as an item was removed
-                RockCache.Remove( allKeysListCacheKey, allKeysListCacheRegion );
 
-                RockLogger.Log.Debug( RockLogDomains.Bus, $"Removed cache for key {message.Key}" );
+                // Surgically remove from the AllKeys list instead of invalidating
+                var keys = RockCache.Get( allKeysListCacheKey, allKeysListCacheRegion ) as System.Collections.Generic.List<string>;
+                if ( keys != null && keys.Remove( message.Key ) )
+                {
+                    RockCache.AddOrUpdate( allKeysListCacheKey, allKeysListCacheRegion, keys );
+                }
+
+                RockLogger.Log.Debug( RockLogDomains.Bus, $"Removed cache for key {message.Key}. Server: {RockMessageBus.NodeName}." );
             }
             else
             {
                 // This is a clear all for this cache type
                 string typeName = typeof( T ).Name;
                 RockCache.ClearCachedItemsForType( typeof( T ) );
-                // Clear/invalidate the AllKeys list specifically
                 RockCache.Remove( allKeysListCacheKey, allKeysListCacheRegion );
-                RockLogger.Log.Debug( RockLogDomains.Bus, $"Cleared all cache for type {typeName}" );
+                RockLogger.Log.Debug( RockLogDomains.Bus, $"Cleared all cache for type {typeName}. Server: {RockMessageBus.NodeName}." );
             }
         }
 

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCacheConsumer.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCacheConsumer.cs
@@ -49,7 +49,12 @@ namespace org.secc.FamilyCheckin.Cache
             }
             catch ( Exception ex )
             {
-                RockLogger.Log.Error( RockLogDomains.Bus, $"Error processing cache message. {ex.Message} Server: {RockMessageBus.NodeName}." );
+                // method.Invoke wraps any exception from ProcessCacheMessage in a
+                // TargetInvocationException whose own Message is the useless generic
+                // "Exception has been thrown by the target of an invocation." Unwrap it
+                // so the real failure (and its stack) is what gets logged.
+                var actual = ( ex as System.Reflection.TargetInvocationException )?.InnerException ?? ex;
+                RockLogger.Log.Error( RockLogDomains.Bus, actual, $"Error processing cache message. {actual.Message} Server: {RockMessageBus.NodeName}." );
             }
         }
 
@@ -119,10 +124,13 @@ namespace org.secc.FamilyCheckin.Cache
             }
             else
             {
-                // This is a clear all for this cache type
+                // This is a clear all for this cache type.
+                // ClearLocal removes the per-key items (stored in RockCacheManager<object>)
+                // AND invalidates the AllKeys list. RockCache.ClearCachedItemsForType only
+                // clears RockCacheManager<T>, which does not hold these items, so it would
+                // leave every cached item stale on this node.
                 string typeName = typeof( T ).Name;
-                RockCache.ClearCachedItemsForType( typeof( T ) );
-                CheckinCache<T>.InvalidateRemoteKeys();
+                CheckinCache<T>.ClearLocal();
                 RockLogger.Log.Debug( RockLogDomains.Bus, $"Cleared all cache for type {typeName}. Server: {RockMessageBus.NodeName}." );
             }
         }

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCacheConsumer.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCacheConsumer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Newtonsoft.Json;
 using Rock.Bus;
 using Rock.Bus.Consumer;
@@ -59,9 +58,6 @@ namespace org.secc.FamilyCheckin.Cache
         /// </summary>
         private void ProcessCacheMessage<T>( CheckinCacheMessage message )
         {
-            string allKeysListCacheKey = $"{typeof( T ).Name}:All";
-            string allKeysListCacheRegion = "AllItems";
-
             // If we have additional data, this is an update — apply the value directly
             if ( !string.IsNullOrEmpty( message.AdditionalData ) )
             {
@@ -79,14 +75,9 @@ namespace org.secc.FamilyCheckin.Cache
                             RockCache.AddOrUpdate( message.Key, item );
                         }
 
-                        // Copy-on-write: clone the list before modifying so threads
-                        // currently enumerating the old reference are not affected.
-                        var keys = RockCache.Get( allKeysListCacheKey, allKeysListCacheRegion ) as List<string>;
-                        if ( keys != null && !keys.Contains( message.Key ) )
-                        {
-                            var updatedKeys = new List<string>( keys ) { message.Key };
-                            RockCache.AddOrUpdate( allKeysListCacheKey, allKeysListCacheRegion, updatedKeys );
-                        }
+                        // Maintain the AllKeys list under the shared KeysUpdateLock so we
+                        // cannot lose updates racing the local UpdateKeys read-modify-write.
+                        CheckinCache<T>.RegisterRemoteKey( message.Key );
 
                         RockLogger.Log.Debug( RockLogDomains.Bus,
                             $"Updated cache for key {message.Key}. Server: {RockMessageBus.NodeName}." );
@@ -106,7 +97,7 @@ namespace org.secc.FamilyCheckin.Cache
                         RockCache.Remove( message.Key );
                     }
                     // Only invalidate AllKeys on deserialization error
-                    RockCache.Remove( allKeysListCacheKey, allKeysListCacheRegion );
+                    CheckinCache<T>.InvalidateRemoteKeys();
                 }
             }
             else if ( message.Key != null )
@@ -121,14 +112,8 @@ namespace org.secc.FamilyCheckin.Cache
                     RockCache.Remove( message.Key );
                 }
 
-                // Copy-on-write: clone before removing so concurrent readers are safe.
-                var keys = RockCache.Get( allKeysListCacheKey, allKeysListCacheRegion ) as List<string>;
-                if ( keys != null && keys.Contains( message.Key ) )
-                {
-                    var updatedKeys = new List<string>( keys );
-                    updatedKeys.Remove( message.Key );
-                    RockCache.AddOrUpdate( allKeysListCacheKey, allKeysListCacheRegion, updatedKeys );
-                }
+                // Drop the key from AllKeys under the shared lock.
+                CheckinCache<T>.UnregisterRemoteKey( message.Key );
 
                 RockLogger.Log.Debug( RockLogDomains.Bus, $"Removed cache for key {message.Key}. Server: {RockMessageBus.NodeName}." );
             }
@@ -137,7 +122,7 @@ namespace org.secc.FamilyCheckin.Cache
                 // This is a clear all for this cache type
                 string typeName = typeof( T ).Name;
                 RockCache.ClearCachedItemsForType( typeof( T ) );
-                RockCache.Remove( allKeysListCacheKey, allKeysListCacheRegion );
+                CheckinCache<T>.InvalidateRemoteKeys();
                 RockLogger.Log.Debug( RockLogDomains.Bus, $"Cleared all cache for type {typeName}. Server: {RockMessageBus.NodeName}." );
             }
         }


### PR DESCRIPTION
# What changed and why


## CheckinCache.cs
| Change | Effect |
| -------- | -------- |
| IsReadyToPublish gate | Suppresses all bus publishing until IsRockStarted is True<T>() plus a 30-second grace period. The recycling server silently hydrates its cache from the DB and consumes messages from other nodes, without disturbing them. |
| Clear() rewritten | Removes items locally in a loop but publishes only 1 message (the clear-all with key=null) instead of N+1 messages. This alone eliminates the biggest message amplification. |
	
	

## CheckinCacheConsumer.cs
| Change | Effect |
| -------- | -------- |
| IsFromSelf<TQueue>(IRockMessage<TQueue>) check | Skips messages this node sent. The local cache was already updated before publishing, so processing your own message was doubling every operation. |
| Surgical AllKeys updates | Instead of calling RockCache.Remove(allKeysListCacheKey) on every message (which forces a keyFactory() DB call on next access), the consumer now adds/removes the single key directly in the cached list. The AllKeys list only gets invalidated on errors or full clears. |
