### PR TITLE
ROCK-8428 Fixed false positive critical error

### DIFF
--- a/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
+++ b/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
@@ -164,14 +164,14 @@ namespace RockWeb.Plugins.org_secc.SystemsMonitor
                     var webFarmService = new WebFarmNodeService( rockContext );
 
                     var currentNode = webFarmService.Queryable()
-                        .Where( n => n.NodeName == currentMachineName && n.IsActive )
+                        .Where( n => n.NodeName == currentMachineName )
                         .OrderByDescending( n => n.LastSeenDateTime )
                         .FirstOrDefault();
 
                     if ( currentNode == null )
                     {
                         currentNode = webFarmService.Queryable()
-                            .Where( n => n.NodeName.StartsWith( currentMachineName ) && n.IsActive )
+                            .Where( n => n.NodeName.StartsWith( currentMachineName ) )
                             .OrderByDescending( n => n.LastSeenDateTime )
                             .FirstOrDefault();
                     }

--- a/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
+++ b/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
@@ -163,6 +163,9 @@ namespace RockWeb.Plugins.org_secc.SystemsMonitor
                 {
                     var webFarmService = new WebFarmNodeService( rockContext );
 
+                    // Intentionally do not filter by IsActive when resolving the current node.
+                    // After cache clears or other transient web-farm events, a healthy node can
+                    // be temporarily marked inactive; using IsActive here would cause false positives.
                     var currentNode = webFarmService.Queryable()
                         .Where( n => n.NodeName == currentMachineName )
                         .OrderByDescending( n => n.LastSeenDateTime )


### PR DESCRIPTION
Previously after a cache clear, a node might be marked inactive in the db, but it should still be considered healthy if the other checks pass