### PR TITLE
ROCK-8407 Disable/restore communications for inactive people

### DIFF
--- a/Plugins/org.secc.Jobs/DisableCommunicationsForInactivePeople.cs
+++ b/Plugins/org.secc.Jobs/DisableCommunicationsForInactivePeople.cs
@@ -1,0 +1,213 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data.Entity;
+using System.Data.Entity.SqlServer;
+using System.Linq;
+
+using Newtonsoft.Json;
+using Quartz;
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Jobs;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace org.secc.Jobs
+{
+    /// <summary>
+    /// Job that disables email and SMS communication preferences for people
+    /// whose Record Status is Inactive. Stores original preferences in a
+    /// DefinedType so they can be restored if the person becomes active again.
+    /// </summary>
+    [DisplayName( "SECC | Disable Communications for Inactive People" )]
+    [Description( "Disables email and SMS preferences for people with an Inactive record status. Original preferences are stored in a DefinedType for later restoration." )]
+    [DefinedTypeField( "Inactive Person Communication Overrides Defined Type",
+        Description = "The Defined Type used to store original communication preferences for inactive people.",
+        IsRequired = true,
+        Key = "InactiveCommunicationOverridesDefinedType",
+        Order = 0 )]
+    [IntegerField( "Lookback Days",
+        Description = "Only process people whose record status changed within this many days. Set to 0 to process all inactive people regardless of when their status changed. Use 0 for the initial run.",
+        IsRequired = false,
+        DefaultIntegerValue = 15,
+        Key = "LookbackDays",
+        Order = 1 )]
+    [BooleanField( "Dry Run",
+        Description = "When enabled, the job reports how many people would be affected without making any changes. Use this to validate the job before processing real data.",
+        DefaultBooleanValue = true,
+        Key = "DryRun",
+        Order = 2 )]
+    [DisallowConcurrentExecution]
+    public class DisableCommunicationsForInactivePeople : IJob
+    {
+        private class PreferenceSnapshot
+        {
+            public int EmailPreference { get; set; }
+            public List<PhoneSnapshot> Phones { get; set; }
+        }
+
+        private class PhoneSnapshot
+        {
+            public int PhoneNumberId { get; set; }
+            public bool IsMessagingEnabled { get; set; }
+        }
+
+        /// <summary>
+        /// Empty constructor required by the Quartz scheduler.
+        /// </summary>
+        public DisableCommunicationsForInactivePeople()
+        {
+        }
+
+        public virtual void Execute( IJobExecutionContext context )
+        {
+            JobDataMap dataMap = context.JobDetail.JobDataMap;
+            var definedTypeGuid = dataMap.GetString( "InactiveCommunicationOverridesDefinedType" ).AsGuid();
+            int lookbackDays = dataMap.GetString( "LookbackDays" ).AsIntegerOrNull() ?? 15;
+            bool dryRun = dataMap.GetString( "DryRun" ).AsBoolean();
+
+            var rockContext = new RockContext();
+            var personService = new PersonService( rockContext );
+            var definedValueService = new DefinedValueService( rockContext );
+            var definedType = DefinedTypeCache.Get( definedTypeGuid );
+
+            if ( definedType == null )
+            {
+                throw new RockJobWarningException( "Inactive Person Communication Overrides Defined Type not found. Verify the job attribute is configured." );
+            }
+
+            // Get the Inactive record status DefinedValue Id
+            var inactiveStatusCache = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_INACTIVE.AsGuid() );
+            if ( inactiveStatusCache == null )
+            {
+                throw new RockJobWarningException( "Could not find the Inactive Record Status DefinedValue." );
+            }
+            var inactiveStatusId = inactiveStatusCache.Id;
+
+            // Build a subquery of PersonIds already tracked (stays in SQL, avoids parameter limit)
+            var trackedPersonIdQuery = definedValueService.Queryable()
+                .Where( dv => dv.DefinedTypeId == definedType.Id )
+                .Select( dv => dv.Value );
+
+            // Query inactive people not yet tracked
+            var query = personService.Queryable().AsNoTracking()
+                .Where( p => p.RecordStatusValueId == inactiveStatusId )
+                .Where( p => !trackedPersonIdQuery.Contains( SqlFunctions.StringConvert( ( double ) p.Id ).Trim() ) );
+
+            // Apply lookback filter if configured (skip for initial catch-up run with 0)
+            if ( lookbackDays > 0 )
+            {
+                var lookbackDate = RockDateTime.Now.AddDays( -lookbackDays );
+                query = query.Where( p => p.RecordStatusLastModifiedDateTime.HasValue
+                    && p.RecordStatusLastModifiedDateTime.Value >= lookbackDate );
+            }
+
+            var inactivePeople = query
+                .OrderBy( p => p.Id )
+                .Select( p => new
+                {
+                    p.Id,
+                    p.EmailPreference
+                } )
+                .ToList();
+
+            // Dry run: report what would happen without making changes
+            if ( dryRun )
+            {
+                context.Result = $"[DRY RUN] Found {inactivePeople.Count} inactive people to process (lookback: {( lookbackDays > 0 ? lookbackDays + " days" : "all" )}). No changes were made.";
+                return;
+            }
+
+            int disabledCount = 0;
+            int errorCount = 0;
+
+            foreach ( var person in inactivePeople )
+            {
+                try
+                {
+                    var personContext = new RockContext();
+                    var pService = new PersonService( personContext );
+                    var phService = new PhoneNumberService( personContext );
+                    var dvService = new DefinedValueService( personContext );
+
+                    var personEntity = pService.Get( person.Id );
+                    if ( personEntity == null )
+                    {
+                        continue;
+                    }
+
+                    // Load all phone numbers once for snapshot and modification
+                    var phoneEntities = phService.Queryable()
+                        .Where( pn => pn.PersonId == person.Id )
+                        .ToList();
+
+                    // Build snapshot using typed DTOs
+                    var snapshot = new PreferenceSnapshot
+                    {
+                        EmailPreference = ( int ) person.EmailPreference,
+                        Phones = phoneEntities.Select( ph => new PhoneSnapshot
+                        {
+                            PhoneNumberId = ph.Id,
+                            IsMessagingEnabled = ph.IsMessagingEnabled
+                        } ).ToList()
+                    };
+
+                    // Store original preferences as a DefinedValue (Value = PersonId)
+                    var definedValue = new DefinedValue
+                    {
+                        DefinedTypeId = definedType.Id,
+                        Value = person.Id.ToString(),
+                        Description = JsonConvert.SerializeObject( snapshot ),
+                        IsSystem = false
+                    };
+                    dvService.Add( definedValue );
+
+                    // Disable email (DoNotEmail blocks all email — bulk and regular)
+                    personEntity.EmailPreference = EmailPreference.DoNotEmail;
+
+                    // Disable SMS on all phone numbers
+                    foreach ( var phone in phoneEntities.Where( pn => pn.IsMessagingEnabled ) )
+                    {
+                        phone.IsMessagingEnabled = false;
+                    }
+
+                    personContext.SaveChanges();
+                    disabledCount++;
+                }
+                catch ( Exception ex )
+                {
+                    ExceptionLogService.LogException( ex );
+                    errorCount++;
+                }
+            }
+
+            // Invalidate the DefinedType cache so other code sees the new entries
+            DefinedTypeCache.Remove( definedType.Id );
+
+            var result = $"Evaluated {inactivePeople.Count} inactive people (lookback: {( lookbackDays > 0 ? lookbackDays + " days" : "all" )}). Disabled communications for {disabledCount}.";
+            if ( errorCount > 0 )
+            {
+                result += $" {errorCount} errors occurred.";
+                throw new RockJobWarningException( result );
+            }
+
+            context.Result = result;
+        }
+    }
+}

--- a/Plugins/org.secc.Jobs/DisableCommunicationsForInactivePeople.cs
+++ b/Plugins/org.secc.Jobs/DisableCommunicationsForInactivePeople.cs
@@ -136,6 +136,7 @@ namespace org.secc.Jobs
 
             int disabledCount = 0;
             int errorCount = 0;
+            int skippedCount = 0;
 
             foreach ( var person in inactivePeople )
             {
@@ -149,6 +150,7 @@ namespace org.secc.Jobs
                     var personEntity = pService.Get( person.Id );
                     if ( personEntity == null )
                     {
+                        skippedCount++;
                         continue;
                     }
 
@@ -200,7 +202,7 @@ namespace org.secc.Jobs
             // Invalidate the DefinedType cache so other code sees the new entries
             DefinedTypeCache.Remove( definedType.Id );
 
-            var result = $"Evaluated {inactivePeople.Count} inactive people (lookback: {( lookbackDays > 0 ? lookbackDays + " days" : "all" )}). Disabled communications for {disabledCount}.";
+            var result = $"Evaluated {inactivePeople.Count} inactive people (lookback: {( lookbackDays > 0 ? lookbackDays + " days" : "all" )}). Disabled communications for {disabledCount}. Skipped {skippedCount} (no longer found).";
             if ( errorCount > 0 )
             {
                 result += $" {errorCount} errors occurred.";

--- a/Plugins/org.secc.Jobs/DisableCommunicationsForInactivePeople.cs
+++ b/Plugins/org.secc.Jobs/DisableCommunicationsForInactivePeople.cs
@@ -142,7 +142,8 @@ namespace org.secc.Jobs
             {
                 try
                 {
-                    var personContext = new RockContext();
+                    using ( var personContext = new RockContext() )
+                    {
                     var pService = new PersonService( personContext );
                     var phService = new PhoneNumberService( personContext );
                     var dvService = new DefinedValueService( personContext );
@@ -191,6 +192,7 @@ namespace org.secc.Jobs
 
                     personContext.SaveChanges();
                     disabledCount++;
+                    }
                 }
                 catch ( Exception ex )
                 {

--- a/Plugins/org.secc.Jobs/RestoreCommunicationsForReactivatedPeople.cs
+++ b/Plugins/org.secc.Jobs/RestoreCommunicationsForReactivatedPeople.cs
@@ -123,7 +123,8 @@ namespace org.secc.Jobs
             {
                 try
                 {
-                    var personContext = new RockContext();
+                    using ( var personContext = new RockContext() )
+                    {
                     var pService = new PersonService( personContext );
                     var phService = new PhoneNumberService( personContext );
                     var dvService = new DefinedValueService( personContext );
@@ -176,6 +177,7 @@ namespace org.secc.Jobs
 
                     personContext.SaveChanges();
                     restoredCount++;
+                    }
                 }
                 catch ( Exception ex )
                 {

--- a/Plugins/org.secc.Jobs/RestoreCommunicationsForReactivatedPeople.cs
+++ b/Plugins/org.secc.Jobs/RestoreCommunicationsForReactivatedPeople.cs
@@ -117,6 +117,7 @@ namespace org.secc.Jobs
 
             int restoredCount = 0;
             int errorCount = 0;
+            int skippedCount = 0;
 
             foreach ( var personId in reactivatedPeople )
             {
@@ -130,6 +131,7 @@ namespace org.secc.Jobs
                     var personEntity = pService.Get( personId );
                     if ( personEntity == null )
                     {
+                        skippedCount++;
                         continue;
                     }
 
@@ -141,6 +143,7 @@ namespace org.secc.Jobs
 
                     if ( trackingEntry == null )
                     {
+                        skippedCount++;
                         continue;
                     }
 
@@ -148,6 +151,7 @@ namespace org.secc.Jobs
                     var snapshot = JsonConvert.DeserializeObject<PreferenceSnapshot>( trackingEntry.Description );
                     if ( snapshot == null )
                     {
+                        skippedCount++;
                         continue;
                     }
 
@@ -183,7 +187,7 @@ namespace org.secc.Jobs
             // Invalidate the DefinedType cache so other code sees the removed entries
             DefinedTypeCache.Remove( definedType.Id );
 
-            var result = $"Evaluated {reactivatedPeople.Count} reactivated people with tracking entries. Restored communications for {restoredCount}.";
+            var result = $"Evaluated {reactivatedPeople.Count} reactivated people with tracking entries. Restored communications for {restoredCount}. Skipped {skippedCount} (no longer found or snapshot unavailable).";
             if ( errorCount > 0 )
             {
                 result += $" {errorCount} errors occurred.";

--- a/Plugins/org.secc.Jobs/RestoreCommunicationsForReactivatedPeople.cs
+++ b/Plugins/org.secc.Jobs/RestoreCommunicationsForReactivatedPeople.cs
@@ -1,0 +1,196 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data.Entity;
+using System.Data.Entity.SqlServer;
+using System.Linq;
+
+using Newtonsoft.Json;
+using Quartz;
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Jobs;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace org.secc.Jobs
+{
+    /// <summary>
+    /// Job that restores email and SMS communication preferences for people
+    /// who were previously disabled by DisableCommunicationsForInactivePeople
+    /// and have since become active again.
+    /// </summary>
+    [DisplayName( "SECC | Restore Communications for Reactivated People" )]
+    [Description( "Restores original email and SMS preferences for people who have become active again, using snapshots stored in a DefinedType." )]
+    [DefinedTypeField( "Inactive Person Communication Overrides Defined Type",
+        Description = "The Defined Type used to store original communication preferences for inactive people.",
+        IsRequired = true,
+        Key = "InactiveCommunicationOverridesDefinedType",
+        Order = 0 )]
+    [BooleanField( "Dry Run",
+        Description = "When enabled, the job reports how many people would be restored without making any changes.",
+        DefaultBooleanValue = true,
+        Key = "DryRun",
+        Order = 1 )]
+    [DisallowConcurrentExecution]
+    public class RestoreCommunicationsForReactivatedPeople : IJob
+    {
+        private class PreferenceSnapshot
+        {
+            public int EmailPreference { get; set; }
+            public List<PhoneSnapshot> Phones { get; set; }
+        }
+
+        private class PhoneSnapshot
+        {
+            public int PhoneNumberId { get; set; }
+            public bool IsMessagingEnabled { get; set; }
+        }
+
+        /// <summary>
+        /// Empty constructor required by the Quartz scheduler.
+        /// </summary>
+        public RestoreCommunicationsForReactivatedPeople()
+        {
+        }
+
+        public virtual void Execute( IJobExecutionContext context )
+        {
+            JobDataMap dataMap = context.JobDetail.JobDataMap;
+            var definedTypeGuid = dataMap.GetString( "InactiveCommunicationOverridesDefinedType" ).AsGuid();
+            bool dryRun = dataMap.GetString( "DryRun" ).AsBoolean();
+
+            var rockContext = new RockContext();
+            var personService = new PersonService( rockContext );
+            var definedValueService = new DefinedValueService( rockContext );
+            var definedType = DefinedTypeCache.Get( definedTypeGuid );
+
+            if ( definedType == null )
+            {
+                throw new RockJobWarningException( "Inactive Person Communication Overrides Defined Type not found. Verify the job attribute is configured." );
+            }
+
+            // Get the Active record status DefinedValue Id
+            var activeStatusCache = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_ACTIVE.AsGuid() );
+            if ( activeStatusCache == null )
+            {
+                throw new RockJobWarningException( "Could not find the Active Record Status DefinedValue." );
+            }
+            var activeStatusId = activeStatusCache.Id;
+
+            // Build a subquery of PersonIds that have tracking entries in the DefinedType
+            var trackedPersonIdQuery = definedValueService.Queryable()
+                .Where( dv => dv.DefinedTypeId == definedType.Id )
+                .Select( dv => dv.Value );
+
+            // Find everyone who is now Active AND has a tracking entry.
+            // No lookback filter here — the tracking entry itself scopes the result set,
+            // and this ensures nobody gets stranded if the job misses a run.
+            var reactivatedPeople = personService.Queryable().AsNoTracking()
+                .Where( p => p.RecordStatusValueId == activeStatusId )
+                .Where( p => trackedPersonIdQuery.Contains( SqlFunctions.StringConvert( ( double ) p.Id ).Trim() ) )
+                .OrderBy( p => p.Id )
+                .Select( p => p.Id )
+                .ToList();
+
+            // Dry run: report what would happen without making changes
+            if ( dryRun )
+            {
+                context.Result = $"[DRY RUN] Found {reactivatedPeople.Count} reactivated people with tracking entries. No changes were made.";
+                return;
+            }
+
+            int restoredCount = 0;
+            int errorCount = 0;
+
+            foreach ( var personId in reactivatedPeople )
+            {
+                try
+                {
+                    var personContext = new RockContext();
+                    var pService = new PersonService( personContext );
+                    var phService = new PhoneNumberService( personContext );
+                    var dvService = new DefinedValueService( personContext );
+
+                    var personEntity = pService.Get( personId );
+                    if ( personEntity == null )
+                    {
+                        continue;
+                    }
+
+                    // Find the tracking DefinedValue for this person
+                    var personIdString = personId.ToString();
+                    var trackingEntry = dvService.Queryable()
+                        .Where( dv => dv.DefinedTypeId == definedType.Id && dv.Value == personIdString )
+                        .FirstOrDefault();
+
+                    if ( trackingEntry == null )
+                    {
+                        continue;
+                    }
+
+                    // Parse the snapshot
+                    var snapshot = JsonConvert.DeserializeObject<PreferenceSnapshot>( trackingEntry.Description );
+                    if ( snapshot == null )
+                    {
+                        continue;
+                    }
+
+                    // Restore email preference
+                    personEntity.EmailPreference = ( EmailPreference ) snapshot.EmailPreference;
+
+                    // Restore SMS preferences per phone number
+                    if ( snapshot.Phones != null )
+                    {
+                        foreach ( var phoneSnapshot in snapshot.Phones )
+                        {
+                            var phone = phService.Get( phoneSnapshot.PhoneNumberId );
+                            if ( phone != null && phone.PersonId == personEntity.Id )
+                            {
+                                phone.IsMessagingEnabled = phoneSnapshot.IsMessagingEnabled;
+                            }
+                        }
+                    }
+
+                    // Remove the tracking DefinedValue
+                    dvService.Delete( trackingEntry );
+
+                    personContext.SaveChanges();
+                    restoredCount++;
+                }
+                catch ( Exception ex )
+                {
+                    ExceptionLogService.LogException( ex );
+                    errorCount++;
+                }
+            }
+
+            // Invalidate the DefinedType cache so other code sees the removed entries
+            DefinedTypeCache.Remove( definedType.Id );
+
+            var result = $"Evaluated {reactivatedPeople.Count} reactivated people with tracking entries. Restored communications for {restoredCount}.";
+            if ( errorCount > 0 )
+            {
+                result += $" {errorCount} errors occurred.";
+                throw new RockJobWarningException( result );
+            }
+
+            context.Result = result;
+        }
+    }
+}

--- a/Plugins/org.secc.Jobs/org.secc.Jobs.csproj
+++ b/Plugins/org.secc.Jobs/org.secc.Jobs.csproj
@@ -67,6 +67,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DisableCommunicationsForInactivePeople.cs" />
     <Compile Include="CompleteWorkflows.cs" />
     <Compile Include="EasterChildrensAttendance.cs" />
     <Compile Include="Event\AddEventCanCheckinRelationships.cs" />
@@ -76,6 +77,7 @@
     <Compile Include="MigratePickleballCredits.cs" />
     <Compile Include="Migrations\001_EventRelationshipRoles.cs" />
     <Compile Include="RemoveDevicesFromPersons.cs" />
+    <Compile Include="RestoreCommunicationsForReactivatedPeople.cs" />
     <Compile Include="RemoveEventCanCheckinRelationships.cs" />
     <Compile Include="SetFirstAttendanceDate.cs" />
     <Compile Include="PushPayDownloadCheckNumbers.cs" />


### PR DESCRIPTION
## Summary
- Adds `DisableCommunicationsForInactivePeople` job — snapshots and disables `EmailPreference` + per-phone `IsMessagingEnabled` for people whose record status is Inactive. Supports configurable lookback days and Dry Run.
- Adds `RestoreCommunicationsForReactivatedPeople` job — restores preferences from the snapshot for anyone who has gone back to Active, then removes the tracking entry. No lookback so missed runs don't strand anyone.
- Snapshots live in a new `Inactive Person Communication Overrides` DefinedType (Value = PersonId, Description = JSON snapshot).

Ticket: https://seccdev.atlassian.net/browse/ROCK-8407

## Rollout notes
The initial backfill (~307k email flips, ~48k SMS phone flips on prod-sized data) is handled by a one-time SQL setup script run directly against the database — not by this job. The jobs are designed for ongoing incremental work (default 15-day lookback on the Disable job).

## Test plan
- [x] Build the solution — no compile errors
- [x] Deploy to DEV
- [x] Run the one-time setup SQL on DEV (creates the DefinedType and bulk-processes existing inactive people inside a transaction with dry-run counts and 5 sample snapshots for review)
- [x] Spot-check 3–5 tracking DefinedValues on DEV — confirm JSON parses and phone IDs match
- [x] Pick a test person, flip to Active, run Restore job (Dry Run → real) — confirm preferences restored and tracking entry deleted
- [x] Flip a different test person to Inactive, run Disable job with `LookbackDays=15` (Dry Run → real) — confirm snapshot + disabled preferences
- [x] Run Disable job twice in a row — second run should be a no-op (idempotency)
- [x] Schedule both jobs at non-overlapping times (2am Disable / 3am Restore) and let them run overnight on DEV — no exceptions in Exception Log
- [ ] Promote to PROD once DEV is stable