### PR TITLE
ROCK-8488 E-Decision Form Report Adjustment

### DIFF
--- a/Plugins/org.secc.Reporting/Model/DecisionReportItem.cs
+++ b/Plugins/org.secc.Reporting/Model/DecisionReportItem.cs
@@ -175,7 +175,7 @@ namespace org.secc.Reporting.Model
             {
                 if (IsMinor)
                 {
-                    return ParentPhone;
+                    return ParentPhone.IsNotNullOrWhiteSpace() ? ParentPhone : MobilePhone;
                 }
 
                 return MobilePhone;


### PR DESCRIPTION
## Summary
- Decision Analytics grid was showing a blank phone for minors who didn't supply a parent phone number. More minors now provide their own mobile number directly on the form.
- When `IsMinor` is true and `ParentPhone` is null/whitespace, `MobilePhoneGridValue` now falls back to the minor's own `MobilePhone` instead of returning blank.
- Adult behavior and `EmailGridValue` are unchanged.

Jira: [ROCK-8488](https://seccdev.atlassian.net/browse/ROCK-8488)

## Test plan
- [ ] Open the Decision Analytics block and run a report that includes minor records.
- [ ] Confirm minors with a `ParentPhone` still display the parent number (no regression).
- [ ] Confirm minors without a `ParentPhone` but with a `MobilePhone` now display the minor's mobile number rather than blank.
- [ ] Confirm minors with neither value still render blank (no exception).
- [ ] Confirm adult rows continue to display the person's `MobilePhone`.

[ROCK-8488]: https://seccdev.atlassian.net/browse/ROCK-8488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ