### PR TITLE
ROCK-8488 Fall back to minor's mobile phone when parent phone is blank

### DIFF
--- a/Plugins/org.secc.Reporting/Model/DecisionReportItem.cs
+++ b/Plugins/org.secc.Reporting/Model/DecisionReportItem.cs
@@ -175,7 +175,7 @@ namespace org.secc.Reporting.Model
             {
                 if (IsMinor)
                 {
-                    return ParentPhone;
+                    return ParentPhone.IsNotNullOrWhiteSpace() ? ParentPhone : MobilePhone;
                 }
 
                 return MobilePhone;

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx
@@ -65,7 +65,7 @@
                                         <Rock:RockBoundField HeaderText="Id" DataField="WorkflowId" Visible="false" />
                                         <Rock:RockTemplateField HeaderText="" ItemStyle-Width="40px" ItemStyle-CssClass="grid-select-field" ExcelExportBehavior="NeverInclude">
                                             <ItemTemplate>
-                                                <a href='<%# "/Person/" + Eval("PersonId") %>' title="View Profile" class="text-muted">
+                                                <a href='<%# "/Person/" + Eval("PersonId") %>' title="View Profile" class="text-muted" onclick="event.stopPropagation(); return true;">
                                                     <i class="fa fa-user"></i>
                                                 </a>
                                             </ItemTemplate>

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx
@@ -63,7 +63,7 @@
                                     ExportFilename="GivingAnalytics" OnRowSelected="gResults_RowSelected" OnRowDataBound="gResults_RowDataBound" DataKeyNames="RecordType, Id">
                                     <Columns>
                                         <Rock:RockBoundField HeaderText="Id" DataField="WorkflowId" Visible="false" />
-                                        <Rock:RockTemplateField HeaderText="" ItemStyle-Width="40px" ItemStyle-CssClass="grid-select-field" ExcludeFromExport="true">
+                                        <Rock:RockTemplateField HeaderText="" ItemStyle-Width="40px" ItemStyle-CssClass="grid-select-field" ExcelExportBehavior="NeverInclude">
                                             <ItemTemplate>
                                                 <a href='<%# "/Person/" + Eval("PersonId") %>' title="View Profile" class="text-muted">
                                                     <i class="fa fa-user"></i>

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx
@@ -63,6 +63,13 @@
                                     ExportFilename="GivingAnalytics" OnRowSelected="gResults_RowSelected" OnRowDataBound="gResults_RowDataBound" DataKeyNames="RecordType, Id">
                                     <Columns>
                                         <Rock:RockBoundField HeaderText="Id" DataField="WorkflowId" Visible="false" />
+                                        <Rock:RockTemplateField HeaderText="" ItemStyle-Width="40px" ItemStyle-CssClass="grid-select-field" ExcludeFromExport="true">
+                                            <ItemTemplate>
+                                                <a href='<%# "/Person/" + Eval("PersonId") %>' title="View Profile" class="text-muted">
+                                                    <i class="fa fa-user"></i>
+                                                </a>
+                                            </ItemTemplate>
+                                        </Rock:RockTemplateField>
                                         <Rock:RockBoundField HeaderText="Name" DataField="FullName" SortExpression="FullNameReversed" />
                                         <Rock:RockBoundField HeaderText="Gender" DataField="Gender" SortExpression="Gender" />
                                         <Rock:RockBoundField HeaderText="BirthDate" DataField="Birthdate" DataFormatString="{0:d}" />

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/DecisionAnalytics.ascx.cs
@@ -275,7 +275,7 @@ namespace RockWeb.Plugins.org_secc.Reporting
             {
                 lParentName.Text = decision.ParentGuardianName;
                 lParentPhone.Text = decision.ParentPhone;
-                lParentEmail.Text = decision.Email;
+                lParentEmail.Text = decision.ParentEmail;
                 pnlParentInfo.Visible = true;
             }
             else


### PR DESCRIPTION
## Summary

Three improvements to the Decision Analytics report (page 4657) so staff can reach more candidates and navigate the report more easily.

## Changes

- **Phone fallback for minors** — when a minor's ParentPhone is blank but they have their own MobilePhone on file, surface their own number in the grid instead of leaving the cell blank. (`DecisionReportItem.cs`)
- **Profile-link icon column** — leftmost column with a clickable user icon linking to `/Person/{id}` so staff can jump to a candidate's full Rock profile in one click. Excluded from Excel export via `ExcelExportBehavior=\"NeverInclude\"`; click does not bubble to the row-select handler. (`DecisionAnalytics.ascx`)
- **Modal bug fix** — for minors, the modal's \"Parent Email\" literal was bound to \`decision.Email\` (candidate's own email) instead of \`decision.ParentEmail\`. Now shows the parent's email under the correct label. (`DecisionAnalytics.ascx.cs`)

<img width="1917" height="941" alt="Screenshot 2026-05-04 154155" src="https://github.com/user-attachments/assets/c66a4e14-e8e8-479d-9b02-91481df8b3f2" />

## Test plan

- [x] Open page 4657 — confirm a user-icon column appears as the leftmost column on every row
- [x] Click an icon — should navigate to \`/Person/{id}\` (no modal flash)
- [x] Open a minor's row modal — \"Parent Email\" label shows the parent's email, not the candidate's
- [x] Find a minor with blank ParentPhone but populated own MobilePhone — Phone column shows their number, not blank
- [x] Export grid to Excel — icon column is absent from the export