### PR TITLE
Updating server health block to only monitor for maintenance flag

### DIFF
--- a/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx
+++ b/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx
@@ -53,9 +53,6 @@
                         </div>
                     </div>
                 </asp:Panel>
-
-                <Rock:BootstrapButton ID="btnRefresh" runat="server" CssClass="btn btn-default btn-sm"
-                    Text="<i class='fa fa-refresh'></i> Refresh" OnClick="btnRefresh_Click" />
             </div>
 
         </asp:Panel>

--- a/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx
+++ b/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx
@@ -16,43 +16,6 @@
 
             <div class="panel-body">
                 <Rock:NotificationBox ID="nbMessage" runat="server" />
-
-                <asp:Panel ID="pnlDetails" runat="server">
-                    <div class="row">
-                        <div class="col-md-4">
-                            <dl>
-                                <dt>Machine Name</dt>
-                                <dd><asp:Literal ID="lMachineName" runat="server" /></dd>
-                            </dl>
-                        </div>
-                        <div class="col-md-4">
-                            <dl>
-                                <dt>Web Farm</dt>
-                                <dd><asp:Literal ID="lWebFarmEnabled" runat="server" /></dd>
-                            </dl>
-                        </div>
-                        <div class="col-md-4">
-                            <dl>
-                                <dt>Last Seen</dt>
-                                <dd><asp:Literal ID="lLastSeen" runat="server" /></dd>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-6">
-                            <dl>
-                                <dt>Message Bus</dt>
-                                <dd><asp:Literal ID="lMessageBus" runat="server" /></dd>
-                            </dl>
-                        </div>
-                        <div class="col-md-6">
-                            <dl>
-                                <dt>Cache Queue Rate/Min</dt>
-                                <dd><asp:Literal ID="lCacheQueueRate" runat="server" /></dd>
-                            </dl>
-                        </div>
-                    </div>
-                </asp:Panel>
             </div>
 
         </asp:Panel>

--- a/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
+++ b/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
@@ -75,7 +75,7 @@ namespace RockWeb.Plugins.org_secc.SystemsMonitor
         private void RunHealthCheck()
         {
             nbMessage.Visible = false;
-            pnlDetails.Visible = false;
+            pnlDetails.Visible = true;
 
             lMachineName.Text = Environment.MachineName;
 

--- a/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
+++ b/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
@@ -14,7 +14,6 @@
 using System;
 using System.ComponentModel;
 using System.IO;
-using System.Web.UI;
 using Rock.Web.UI;
 
 namespace RockWeb.Plugins.org_secc.SystemsMonitor

--- a/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
+++ b/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
@@ -74,9 +74,6 @@ namespace RockWeb.Plugins.org_secc.SystemsMonitor
         private void RunHealthCheck()
         {
             nbMessage.Visible = false;
-            pnlDetails.Visible = true;
-
-            lMachineName.Text = Environment.MachineName;
 
             string maintenanceFile = Server.MapPath( "~/_maintenance.flag" );
 

--- a/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
+++ b/Plugins/org.secc.SystemsMonitor/org_secc/SystemsMonitor/ServerHealth.ascx.cs
@@ -12,59 +12,19 @@
 // limitations under the License.
 // </copyright>
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
-using System.Net.Http;
 using System.Web.UI;
-
-using Rock;
-using Rock.Attribute;
-using Rock.Bus;
-using Rock.Bus.Queue;
-using Rock.Data;
-using Rock.Model;
-using Rock.Web.Cache;
 using Rock.Web.UI;
-using Rock.WebFarm;
 
 namespace RockWeb.Plugins.org_secc.SystemsMonitor
 {
     [DisplayName( "Server Health" )]
     [Category( "SECC > Systems Monitor" )]
-    [Description( "Displays the health status of this Rock web-farm node, including heartbeat, message bus, and cache queue checks." )]
-
-    [DefinedTypeField(
-        "Health Check URLs Defined Type",
-        Description = "The Defined Type that contains the health check URLs for each web farm node. Each Defined Value's Value should be the URL and its Description should be the machine name.",
-        IsRequired = false,
-        DefaultValue = "7ac04f77-c889-493b-9f0a-fa92c1508067",
-        Key = AttributeKey.HealthCheckDefinedType,
-        Order = 0 )]
+    [Description( "Displays the health status of this Rock web-farm node." )]
 
     public partial class ServerHealth : RockBlock
     {
-        #region Attribute Keys
-
-        private static class AttributeKey
-        {
-            public const string HealthCheckDefinedType = "HealthCheckDefinedType";
-        }
-
-        #endregion
-
-        #region Constants
-
-        /// <summary>
-        /// Shared HttpClient with a short timeout so the health check doesn't hang.
-        /// </summary>
-        private static readonly HttpClient HealthClient = new HttpClient
-        {
-            Timeout = TimeSpan.FromSeconds( 3 )
-        };
-
-        #endregion
 
         #region Base Control Methods
 
@@ -105,14 +65,6 @@ namespace RockWeb.Plugins.org_secc.SystemsMonitor
             RunHealthCheck();
         }
 
-        /// <summary>
-        /// Handles the Click event of the btnRefresh control.
-        /// </summary>
-        protected void btnRefresh_Click( object sender, EventArgs e )
-        {
-            RunHealthCheck();
-        }
-
         #endregion
 
         #region Methods
@@ -125,12 +77,8 @@ namespace RockWeb.Plugins.org_secc.SystemsMonitor
             nbMessage.Visible = false;
             pnlDetails.Visible = false;
 
-            string currentMachineName = Environment.MachineName;
-            lMachineName.Text = currentMachineName;
+            lMachineName.Text = Environment.MachineName;
 
-            // ---------------------------------------------------------
-            // DEPLOYMENT MAINTENANCE MODE CHECK
-            // ---------------------------------------------------------
             string maintenanceFile = Server.MapPath( "~/_maintenance.flag" );
 
             if ( File.Exists( maintenanceFile ) )
@@ -139,181 +87,7 @@ namespace RockWeb.Plugins.org_secc.SystemsMonitor
                 return;
             }
 
-            // ---------------------------------------------------------
-            // WEB FARM CHECK — only run when Web Farm is enabled
-            // ---------------------------------------------------------
-            bool webFarmEnabled = RockWebFarm.IsEnabled();
-            lWebFarmEnabled.Text = webFarmEnabled
-                ? "<span class='label label-success'>Enabled</span>"
-                : "<span class='label label-default'>Disabled</span>";
-
-            if ( !webFarmEnabled )
-            {
-                pnlDetails.Visible = true;
-                lLastSeen.Text = "N/A";
-                lMessageBus.Text = "N/A";
-                lCacheQueueRate.Text = "N/A";
-                ShowResult( true, "Healthy (Web Farm is not enabled; farm-specific checks were skipped)" );
-                return;
-            }
-
-            try
-            {
-                using ( var rockContext = new RockContext() )
-                {
-                    var webFarmService = new WebFarmNodeService( rockContext );
-
-                    // Intentionally do not filter by IsActive when resolving the current node.
-                    // After cache clears or other transient web-farm events, a healthy node can
-                    // be temporarily marked inactive; using IsActive here would cause false positives.
-                    var currentNode = webFarmService.Queryable()
-                        .Where( n => n.NodeName == currentMachineName )
-                        .OrderByDescending( n => n.LastSeenDateTime )
-                        .FirstOrDefault();
-
-                    if ( currentNode == null )
-                    {
-                        currentNode = webFarmService.Queryable()
-                            .Where( n => n.NodeName.StartsWith( currentMachineName ) )
-                            .OrderByDescending( n => n.LastSeenDateTime )
-                            .FirstOrDefault();
-                    }
-
-                    if ( currentNode == null )
-                    {
-                        ShowResult( false, string.Format( "Critical: Server '{0}' is not registered in WebFarmNode table.", currentMachineName ) );
-                        return;
-                    }
-
-                    // Populate detail fields
-                    pnlDetails.Visible = true;
-                    lLastSeen.Text = currentNode.LastSeenDateTime.ToString( "g" );
-
-                    // 2. Check for "Zombie" State (Stale Heartbeat)
-                    double minutesSinceLastSeen = RockDateTime.Now.Subtract( currentNode.LastSeenDateTime ).TotalMinutes;
-
-                    if ( minutesSinceLastSeen > 5 )
-                    {
-                        ShowResult( false, string.Format( "Error: Node heartbeat is stale. Last seen {0} minutes ago.", Math.Round( minutesSinceLastSeen, 1 ) ) );
-                        return;
-                    }
-
-                    // 3. Ensure the bus is active
-                    bool busReady = RockMessageBus.IsReady();
-                    lMessageBus.Text = busReady ? "<span class='label label-success'>Ready</span>" : "<span class='label label-danger'>Not Ready</span>";
-
-                    if ( !busReady )
-                    {
-                        ShowResult( false, "Error: Message bus is not ready." );
-                        return;
-                    }
-
-                    // 4. Check cache queue consumption
-                    var cacheQueue = RockQueue.GetQueueTypes()
-                        .Select( qt => RockQueue.Get( qt ) )
-                        .FirstOrDefault( q => q != null && q.Name.Equals( "rock-cache-queue", StringComparison.OrdinalIgnoreCase ) );
-
-                    if ( cacheQueue == null )
-                    {
-                        ShowResult( false, "Error: Cache queue 'rock-cache-queue' not found." );
-                        return;
-                    }
-
-                    int? ratePerMinute = cacheQueue.StatLog.MessagesConsumedLastMinute;
-
-                    if ( !ratePerMinute.HasValue )
-                    {
-                        lCacheQueueRate.Text = "N/A (not yet available)";
-                        ShowResult( true, "Healthy (cache queue stat data not yet available)" );
-                        return;
-                    }
-
-                    lCacheQueueRate.Text = ratePerMinute.Value.ToString();
-
-                    if ( ratePerMinute.Value > 0 )
-                    {
-                        ShowResult( true, string.Format( "Healthy (rate/min: {0})", ratePerMinute.Value ) );
-                        return;
-                    }
-
-                    // 5. Rate is 0 — dynamically resolve other servers from DefinedType
-                    var otherServerUrls = GetOtherServerHealthUrls( currentMachineName );
-
-                    bool anyOtherServerHealthy = false;
-
-                    foreach ( var url in otherServerUrls )
-                    {
-                        try
-                        {
-                            using ( var response = HealthClient.GetAsync( url ).GetAwaiter().GetResult() )
-                            {
-                                if ( ( int ) response.StatusCode == 200 )
-                                {
-                                    anyOtherServerHealthy = true;
-                                    break;
-                                }
-                            }
-                        }
-                        catch
-                        {
-                            // Timeout, connection refused, DNS failure, etc.
-                        }
-                    }
-
-                    if ( !anyOtherServerHealthy )
-                    {
-                        ShowResult( true, "Healthy (last server standing, rate/min: 0, no other servers responded healthy)" );
-                        return;
-                    }
-
-                    ShowResult( false, "Error: Cache queue consumption is zero. Consumed 0 message(s) in the last minute. At least 1 other server is healthy." );
-                }
-            }
-            catch ( Exception ex )
-            {
-                ExceptionLogService.LogException( ex );
-                ShowResult( false, "An unexpected error occurred while checking server health." );
-            }
-        }
-
-        /// <summary>
-        /// Reads all DefinedValues from the configured "Health Check URLs" DefinedType,
-        /// skips the entry whose Description matches the current server's machine name,
-        /// and returns the remaining health check URLs.
-        /// </summary>
-        private List<string> GetOtherServerHealthUrls( string currentMachineName )
-        {
-            var urls = new List<string>();
-
-            var definedTypeGuid = GetAttributeValue( AttributeKey.HealthCheckDefinedType ).AsGuidOrNull();
-
-            if ( !definedTypeGuid.HasValue )
-            {
-                return urls;
-            }
-
-            var definedType = DefinedTypeCache.Get( definedTypeGuid.Value );
-
-            if ( definedType == null )
-            {
-                return urls;
-            }
-
-            foreach ( var dv in definedType.DefinedValues.Where( v => v.IsActive ) )
-            {
-                if ( dv.Description.IsNotNullOrWhiteSpace()
-                     && dv.Description.Trim().Equals( currentMachineName, StringComparison.OrdinalIgnoreCase ) )
-                {
-                    continue;
-                }
-
-                if ( dv.Value.IsNotNullOrWhiteSpace() )
-                {
-                    urls.Add( dv.Value );
-                }
-            }
-
-            return urls;
+            ShowResult( true, "Healthy" );
         }
 
         /// <summary>


### PR DESCRIPTION
This block was doing a lot of complicated calculations of message bus usage and monitoring health of other servers, but it was actually causing additional reliability issues. This update restores the maintenance flag functionality without the additional complexity.