### PR TITLE
ROCK-8501 Add MedicationActive flag and source-aware medication manager

### DIFF
--- a/Plugins/org.secc.FamilyCheckin/Workflows/CreateMedicationLabels.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/CreateMedicationLabels.cs
@@ -131,7 +131,17 @@ namespace org.secc.FamilyCheckin
                                 mergeObjects.Add( "People", people );
                                 mergeObjects.Add( "GroupType", groupType );
 
-                                if ( attributeMatrix == null || attributeMatrix.AttributeMatrixItems.Count == 0 )
+                                // Filter inactive medications so the kiosk doesn't print labels for meds the leader has marked inactive.
+                                var matrixItems = attributeMatrix?.AttributeMatrixItems
+                                    .Where( ami =>
+                                    {
+                                        ami.LoadAttributes();
+                                        return ami.GetAttributeValue( "MedicationActive" ).AsBoolean( true );
+                                    } )
+                                    .ToList()
+                                    ?? new List<AttributeMatrixItem>();
+
+                                if ( attributeMatrix == null || matrixItems.Count == 0 )
                                 {
                                     // Add a No Medication Information label for anyone without data
                                     var checkInLabel = new CheckInLabel( labelCache, mergeObjects );
@@ -149,7 +159,7 @@ namespace org.secc.FamilyCheckin
                                 }
                                 else
                                 {
-                                    var items = attributeMatrix.AttributeMatrixItems.ToList();
+                                    var items = matrixItems;
                                     var index = 0;
 
                                     while ( index < items.Count )

--- a/Plugins/org.secc.Jobs/GroupLeaderMedicationNotifications.cs
+++ b/Plugins/org.secc.Jobs/GroupLeaderMedicationNotifications.cs
@@ -120,6 +120,7 @@ namespace org.secc.Jobs
             var personEntityType = EntityTypeCache.Get( typeof( Person ) );
             var earliestCheckinDate = RockDateTime.Now.AddDays( -JobAttributes.MedicationCheckinDays ).Date;
             var medicationScheduleAttribute = GetMatrixItemAttribute( "Schedule" );
+            var medicationActiveAttribute = GetMatrixItemAttribute( "MedicationActive" );
 
             foreach ( var groupId in groupIds )
             {
@@ -143,16 +144,35 @@ namespace org.secc.Jobs
                 var medicationScheduleValues = attributeValueService.Queryable()
                     .Where( v => v.AttributeId == medicationScheduleAttribute.Id );
 
+                // Inactive medications should not count toward the leader's reminder count.
+                // Treat absent values as active (matches AsBoolean(true) default in app code).
+                var medicationActiveValues = medicationActiveAttribute != null
+                    ? attributeValueService.Queryable().Where( v => v.AttributeId == medicationActiveAttribute.Id )
+                    : null;
+
                 var selectedScheduleGuidString = JobAttributes.MedicationScheduleValue.Guid.ToString();
 
-                var groupMemberWithMeds = groupMembers
+                var withMatrixItems = groupMembers
                     .Where( m => !m.GroupRole.IsLeader )
                     .Join( medicationCheckinDateValues, m => m.PersonId, ci => ci.EntityId,
                        ( m, ci ) => new { GroupMember = m, CheckinValue = ci } )
                     .Join( medicationMatrixAttributeValues, gm => gm.GroupMember.PersonId, av => av.EntityId,
                         ( m, ma ) => new { GroupMember = m.GroupMember, CheckinValue = m.CheckinValue, MatrixValue = ma } )
                     .Join( new AttributeMatrixItemService( rockContext ).Queryable(), m => m.MatrixValue.Value, ami => ami.AttributeMatrix.Guid.ToString(),
-                        ( m, ami ) => new { GroupMember = m.GroupMember, CheckinValue = m.CheckinValue, MatrixItem = ami } )
+                        ( m, ami ) => new { GroupMember = m.GroupMember, CheckinValue = m.CheckinValue, MatrixItem = ami } );
+
+                if ( medicationActiveValues != null )
+                {
+                    withMatrixItems = withMatrixItems
+                        .GroupJoin( medicationActiveValues, m => m.MatrixItem.Id, av => av.EntityId,
+                            ( m, avs ) => new { m.GroupMember, m.CheckinValue, m.MatrixItem, ActiveValues = avs } )
+                        .SelectMany( x => x.ActiveValues.DefaultIfEmpty(),
+                            ( x, av ) => new { x.GroupMember, x.CheckinValue, x.MatrixItem, ActiveValue = av } )
+                        .Where( x => x.ActiveValue == null || x.ActiveValue.Value != "False" )
+                        .Select( x => new { x.GroupMember, x.CheckinValue, x.MatrixItem } );
+                }
+
+                var groupMemberWithMeds = withMatrixItems
                     .Join( medicationScheduleValues, m => m.MatrixItem.Id, s => s.EntityId,
                         ( m, s ) => new { m.GroupMember, m.CheckinValue, ScheduleValue = s.Value } )
                     .Where( m => m.ScheduleValue.Contains(selectedScheduleGuidString) )

--- a/Plugins/org.secc.Reporting/Migrations/006_MedicationReportFilterInactive.cs
+++ b/Plugins/org.secc.Reporting/Migrations/006_MedicationReportFilterInactive.cs
@@ -1,0 +1,196 @@
+using Rock.Plugin;
+
+namespace org.secc.Reporting.Migrations
+{
+    /// <summary>
+    /// Re-creates _org_secc_CampManager_GetMedicationReport with a filter that excludes
+    /// medications marked inactive (the MedicationActive attribute on the matrix template
+    /// added for ROCK-8328 follow-up). Items with no stored MedicationActive value are
+    /// treated as active to match the AsBoolean(true) default in the C# consumers.
+    /// </summary>
+    [MigrationNumber( 6, "1.12.0" )]
+    public class MedicationReportFilterInactive : Migration
+    {
+
+        public override void Up()
+        {
+            Sql( @"
+                IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_SCHEMA='dbo' and  ROUTINE_NAME = '_org_secc_CampManager_GetMedicationReport' and ROUTINE_TYPE='PROCEDURE')
+                BEGIN
+	                DROP PROCEDURE [dbo].[_org_secc_CampManager_GetMedicationReport]
+                END
+            " );
+            Sql( @"
+                CREATE PROCEDURE [dbo].[_org_secc_CampManager_GetMedicationReport]
+                (
+                    @RegistrationTemplateId INT,
+                    @RegistrationInstanceId INT = NULL
+                )
+                AS
+
+                DECLARE @MedicationPA INT  = 67024
+                DECLARE @MedicationNameMXA INT = 42457
+                DECLARE @MedicationInsructionMXA INT = 42592
+                DECLARE @MedicationScheduleMXA INT = 42458
+
+                -- Look up MedicationActive attribute id at runtime so this migration
+                -- works on environments where the attribute id differs.
+                DECLARE @MedicationActiveMXA INT = (
+                    SELECT TOP 1 a.Id
+                    FROM Attribute a
+                    INNER JOIN AttributeMatrixTemplate amt
+                        ON CAST(amt.Id AS NVARCHAR(20)) = a.EntityTypeQualifierValue
+                    WHERE a.[Key] = 'MedicationActive'
+                      AND a.EntityTypeQualifierColumn = 'AttributeMatrixTemplateId'
+                      AND amt.[Guid] = 'd2ed9b3d-309a-4a70-bda4-2c090acd1384'
+                )
+
+                DECLARE @CampSmallGroupTypeId INT = 445
+
+                CREATE TABLE #tmpSmallGroups
+                (
+                    InstanceId INT,
+                    GroupId INT
+                )
+
+                CREATE TABLE #tmpCamperMeds
+                (
+                    Id INT NOT NULL IDENTITY(1,1) PRIMARY KEY,
+                    PersonId INT,
+                    LastName NVARCHAR(50),
+                    NickName NVARCHAR(50),
+                    Gender INT,
+                    BirthDate DATE,
+                    RegistrationTemplateId INT,
+                    RegistrationTemplateName NVARCHAR(100),
+                    RegistrationInstanceId INT,
+                    RegistrationInstanceName NVARCHAR(100),
+                    Medication NVARCHAR(MAX),
+                    Instructions NVARCHAR(MAX),
+                    Schedule NVARCHAR(MAX),
+                    GroupId INT,
+                    GroupName NVARCHAR(100),
+                    LeaderName NVARCHAR(100)
+                )
+
+
+                insert into #tmpSmallGroups
+                (
+                    InstanceId,
+                    GroupId
+                )
+                select re.SourceEntityId , re.TargetEntityId
+                from RegistrationTemplatePlacement p
+                inner join RelatedEntity re on TRY_CAST(p.id as nvarchar(2000)) = re.QualifierValue
+                WHERE p.RegistrationTemplateId = @RegistrationTemplateId
+                    and p.GroupTypeId = @CampSmallGroupTypeId
+
+
+                INSERT INTO #tmpCamperMeds
+                (
+                    PersonId,
+                    LastName,
+                    NickName,
+                    Gender,
+                    BirthDate,
+                    RegistrationTemplateId,
+                    RegistrationTemplateName,
+                    RegistrationInstanceId,
+                    RegistrationInstanceName,
+                    Medication,
+                    Instructions,
+                    Schedule,
+                    GroupId
+                )
+                SELECT
+                    p.Id,
+                    p.LastName,
+                    p.NickName,
+                    p.Gender,
+                    p.BirthDate,
+                    rt.Id as RegistrationTemplateId,
+                    rt.Name as RegistrationTemplateName,
+                    ri.Id as RegistrationInstanceId,
+                    ri.Name as RegistrationInstanceName,
+                    medication.[Value] as Medication,
+                    medInstruction.[Value] as Instructions,
+                    medSchedule.[Value] as Schedule,
+                    (
+                        SELECT TOP 1 gm.GroupId
+                        FROM #tmpSmallGroups sg
+                        INNER JOIN GroupMember gm on sg.GroupId = gm.GroupId  and sg.InstanceId = ri.Id
+                        WHERE gm.PersonId = p.Id
+                            and gm.GroupMemberStatus = 1
+                    ) as GroupId
+                FROM  RegistrationRegistrant rr
+                INNER JOIN Registration r on rr.RegistrationId = r.Id
+                INNER JOIN RegistrationInstance ri on r.RegistrationInstanceId = ri.Id
+                INNER JOIN RegistrationTemplate rt on ri.RegistrationTemplateId = rt.Id
+                INNER JOIN PersonAlias pa on rr.PersonAliasId = pa.Id
+                INNER JOIN Person p on pa.PersonId = p.id
+                INNER JOIN AttributeValue av on p.Id = av.EntityId and av.AttributeId = @MedicationPA
+                INNER JOIN AttributeMatrix ax on TRY_CAST(av.VALUE AS uniqueidentifier) = ax.Guid
+                INNER JOIN AttributeMatrixItem axi on ax.Id = axi.AttributeMatrixId
+                LEFT OUTER JOIN AttributeValue medication on axi.Id = medication.EntityId and medication.AttributeId = @MedicationNameMXA
+                LEFT OUTER JOIN AttributeValue medInstruction on axi.Id = medInstruction.EntityId and medInstruction.AttributeId = @MedicationInsructionMXA
+                LEFT OUTER JOIN AttributeValue medSchedule on axi.Id = medSchedule.EntityId and medSchedule.AttributeId = @MedicationScheduleMXA
+                LEFT OUTER JOIN AttributeValue medActive on axi.Id = medActive.EntityId and medActive.AttributeId = @MedicationActiveMXA
+                WHERE rr.OnWaitList = 0
+                    and rt.id = @RegistrationTemplateId
+                    AND (ISNULL(@RegistrationInstanceId,0) = 0  or ri.Id = @RegistrationInstanceId)
+                    AND (medActive.[Value] IS NULL OR medActive.[Value] != 'False')
+
+                UPDATE t
+                SET
+                    t.GroupName = g.Name,
+                    t.LeaderName = (
+                        SELECT TOP 1 p.NickName + ' ' + p.LastName
+                        FROM GroupMember gm
+                        INNER JOIN GroupTypeRole gr on gm.GroupRoleId = gr.Id and gr.isleader = 1
+                        INNER JOIN Person p on gm.PersonId = p.Id
+                        WHERE gm.GroupMemberStatus = 1 and groupId = t.GroupId)
+                FROM #tmpCamperMeds t
+                INNER JOIN [Group] g on t.GroupId = g.Id
+
+                SELECT
+                    Id,
+                    PersonId,
+                    LastName,
+                    NickName,
+                    Gender,
+                    Birthdate,
+                    RegistrationTemplateId,
+                    RegistrationTemplateName,
+                    RegistrationInstanceId,
+                    RegistrationInstanceName,
+                    Medication,
+                    Instructions,
+                    Schedule,
+                    GroupId,
+                    GroupName,
+                    LeaderName
+                FROM #tmpCamperMeds
+                ORDER BY LastName,
+                    NickName,
+                    PersonId
+
+                DROP TABLE #tmpCamperMeds
+                DROP TABLE #tmpSmallGroups
+            " );
+        }
+
+        public override void Down()
+        {
+            // Restoring previous SP body would re-introduce the bug where inactive meds are exported.
+            // Drop it; re-running migration 005 will re-create the original.
+            Sql( @"
+                IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_SCHEMA='dbo' and  ROUTINE_NAME = '_org_secc_CampManager_GetMedicationReport' and ROUTINE_TYPE='PROCEDURE')
+                BEGIN
+	                DROP PROCEDURE [dbo].[_org_secc_CampManager_GetMedicationReport]
+                END
+            " );
+        }
+
+
+    }
+}

--- a/Plugins/org.secc.Reporting/org.secc.Reporting.csproj
+++ b/Plugins/org.secc.Reporting/org.secc.Reporting.csproj
@@ -126,6 +126,7 @@ xcopy /Y /R  "$(ProjectDir)bin\Debug\org.secc.Reporting.pdb" "$(SolutionDir)Rock
     <Compile Include="Helpers.cs" />
     <Compile Include="Migrations\001_Init.cs" />
     <Compile Include="Migrations\005_MedicationReportStoredProcedure.cs" />
+    <Compile Include="Migrations\006_MedicationReportFilterInactive.cs" />
     <Compile Include="Migrations\DecisonFormReportTable.cs" />
     <Compile Include="Migrations\DecisionReportView.cs" />
     <Compile Include="Migrations\WorshipAttendanceHistory.cs" />

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx
@@ -51,13 +51,19 @@
             <Content>
                 <asp:HiddenField runat="server" ID="hfManageMedsPersonId" />
                 <asp:HiddenField runat="server" ID="hfManageMedsMatrixGuid" />
+                <asp:HiddenField runat="server" ID="hfManageMedsSource" />
                 <div class="row">
                     <div class="col-md-12">
-                        <Rock:Grid runat="server" ID="gMedications" ShowActionRow="false" DataKeyNames="Id" AllowPaging="false">
+                        <asp:Literal runat="server" ID="ltManageMedsSourceBadge" />
+                        <Rock:Grid runat="server" ID="gMedications" ShowActionRow="false" DataKeyNames="Id" AllowPaging="false"
+                            OnRowDataBound="gMedications_RowDataBound">
                             <Columns>
                                 <asp:BoundField DataField="Medication" HeaderText="Medication" />
                                 <asp:BoundField DataField="Instructions" HeaderText="Instructions" />
                                 <asp:BoundField DataField="Schedule" HeaderText="Schedule" />
+                                <Rock:BoolField DataField="Active" HeaderText="Active" />
+                                <Rock:LinkButtonField ID="btnToggleActive" HeaderText="Toggle" CssClass="btn btn-default btn-sm" Text="<i class='fa fa-toggle-on'></i>" OnClick="ToggleActive_Click" />
+                                <Rock:EditField HeaderText="Edit" ID="btnEditMed" OnClick="btnEditMed_Click" />
                                 <Rock:DeleteField HeaderText="Remove" ID="btnDeleteMed" OnClick="btnDeleteMed_Click" />
                             </Columns>
                         </Rock:Grid>
@@ -77,6 +83,22 @@
                         <Rock:RockTextBox runat="server" ID="tbNewMedication" Label="Medication" Required="true" />
                         <Rock:RockTextBox runat="server" ID="tbNewInstructions" Label="Instructions" />
                         <Rock:RockListBox runat="server" ID="lbNewSchedule" Label="Schedule"
+                            DataValueField="Guid" DataTextField="Value" />
+                    </div>
+                </div>
+            </Content>
+        </Rock:ModalDialog>
+
+        <%-- Edit Medication Sub-Modal --%>
+        <Rock:ModalDialog runat="server" ID="mdEditMedication" Title="Edit Medication" SaveButtonText="Save" OnSaveClick="mdEditMedication_SaveClick"
+            CancelLinkVisible="true" CssClass="modal-add-med">
+            <Content>
+                <asp:HiddenField runat="server" ID="hfEditMatrixItemId" />
+                <div class="row">
+                    <div class="col-md-12">
+                        <Rock:RockTextBox runat="server" ID="tbEditMedication" Label="Medication" Required="true" />
+                        <Rock:RockTextBox runat="server" ID="tbEditInstructions" Label="Instructions" />
+                        <Rock:RockListBox runat="server" ID="lbEditSchedule" Label="Schedule"
                             DataValueField="Guid" DataTextField="Value" />
                     </div>
                 </div>

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx.cs
@@ -311,6 +311,15 @@ namespace RockWeb.Blocks.Reporting.NextGen
                 return null;
             }
 
+            // GroupMember-entity matrix attributes (snapshot) — same key as Person, different entity type.
+            // Most camp registrations create a per-event copy via the "Medication Information Request" workflow
+            // and store its Guid here. When present, prefer it over the Person master.
+            List<int> groupMemberMatrixAttributeIds = attributeService.Queryable()
+                .Where( a =>
+                    a.EntityTypeId == groupMemberEntityid
+                    && a.Key == key )
+                .Select( a => a.Id ).ToList();
+
             List<int> filterAttributeIds = null;
             var filterAttributeKey = GetAttributeValue( "GroupMemberAttributeFilter" );
             if ( !string.IsNullOrWhiteSpace( filterAttributeKey ) )
@@ -326,13 +335,35 @@ namespace RockWeb.Blocks.Reporting.NextGen
 
             var attributeMatrixItemEntityId = EntityTypeCache.GetId<AttributeMatrixItem>();
 
-            var qry = groupMembers
+            var groupMemberMatrixValues = attributeValueService.Queryable()
+                .Where( av => groupMemberMatrixAttributeIds.Contains( av.AttributeId ) && av.Value != null && av.Value != "" );
+
+            var personMatrixValues = attributeValueService.Queryable()
+                .Where( av => attributeIds.Contains( av.AttributeId ) && av.Value != null && av.Value != "" );
+
+            // Snapshot path: members with a GroupMember-level matrix value join via that.
+            // Person path: members WITHOUT a snapshot fall back to the Person master (NOT EXISTS antijoin).
+            // Two simple INNER-JOIN queries UNION'd via Concat — avoids a CASE/COALESCE expression in the
+            // matrix-Guid join key, which the SQL optimizer couldn't handle and timed out on.
+            var qrySnapshot = groupMembers
                .Join(
-                   attributeValueService.Queryable().Where( av => attributeIds.Contains( av.AttributeId ) ),
+                   groupMemberMatrixValues,
+                   m => m.Id,
+                   gmav => gmav.EntityId.Value,
+                   ( m, gmav ) => new { Person = m.Person, Member = m, AttributeValue = gmav.Value }
+               );
+
+            var qryPerson = groupMembers
+               .Where( m => !groupMemberMatrixValues.Any( gmav => gmav.EntityId == m.Id ) )
+               .Join(
+                   personMatrixValues,
                    m => m.PersonId,
-                   av => av.EntityId.Value,
-                   ( m, av ) => new { m.Person, Member = m, AttributeValue = av.Value }
-               )
+                   pav => pav.EntityId.Value,
+                   ( m, pav ) => new { Person = m.Person, Member = m, AttributeValue = pav.Value }
+               );
+
+            var qry = qrySnapshot
+               .Concat( qryPerson )
                .Join(
                    attributeMatrixService.Queryable(),
                    m => m.AttributeValue,
@@ -511,6 +542,12 @@ namespace RockWeb.Blocks.Reporting.NextGen
                 var medicines = member.GroupBy( m => m.MatrixItemId );
                 foreach ( var medicine in medicines )
                 {
+                    var activeAtt = medicine.FirstOrDefault( m => m.Attribute.Key == "MedicationActive" );
+                    if ( activeAtt != null && activeAtt.AttributeValue != null && activeAtt.AttributeValue.Value.AsBoolean( true ) == false )
+                    {
+                        continue;
+                    }
+
                     var scheduleAtt = medicine.FirstOrDefault( m => m.Attribute.Key == "Schedule" );
                     if ( scheduleAtt == null || scheduleAtt.AttributeValue.Value == null )
                     {
@@ -1117,41 +1154,81 @@ namespace RockWeb.Blocks.Reporting.NextGen
             BindGrid();
         }
 
+        private const string SourcePerson = "Person";
+        private const string SourceSnapshot = "Snapshot";
+
         protected void ManageMeds_Click( object sender, Rock.Web.UI.Controls.RowEventArgs e )
         {
             // Ensure clean modal state
             mdAddMedication.Hide();
+            mdEditMedication.Hide();
 
             var keys = ( ( string ) e.RowKeyValue ).SplitDelimitedValues();
             var personId = keys[0].AsInteger();
+            var matrixItemId = keys.Length > 1 ? keys[1].AsIntegerOrNull() : null;
 
             RockContext rockContext = new RockContext();
             PersonService personService = new PersonService( rockContext );
-            AttributeValueService attributeValueService = new AttributeValueService( rockContext );
-            AttributeService attributeService = new AttributeService( rockContext );
-            var personEntityId = EntityTypeCache.GetId<Rock.Model.Person>().Value;
-            var matrixKey = GetAttributeValue( AttributeKey.MedicationMatrixKey );
+            AttributeMatrixItemService attributeMatrixItemService = new AttributeMatrixItemService( rockContext );
 
             var person = personService.Get( personId );
             mdManageMeds.Title = person != null
                 ? string.Format( "Manage Medications - {0}", person.FullName )
                 : "Manage Medications";
 
-            var matrixAttributeId = attributeService.Queryable()
-                .Where( a => a.EntityTypeId == personEntityId && a.Key == matrixKey )
-                .Select( a => a.Id )
-                .FirstOrDefault();
-
-            var matrixGuid = attributeValueService.Queryable()
-                .Where( av => av.AttributeId == matrixAttributeId && av.EntityId == personId )
-                .Select( av => av.Value )
-                .FirstOrDefault();
+            // Resolve matrix Guid from the clicked row's matrix item so the modal edits the same data the grid is showing
+            // (snapshot when one exists, otherwise the Person master).
+            string matrixGuid = null;
+            if ( matrixItemId.HasValue )
+            {
+                matrixGuid = attributeMatrixItemService.Queryable()
+                    .Where( ami => ami.Id == matrixItemId.Value )
+                    .Select( ami => ami.AttributeMatrix.Guid.ToString() )
+                    .FirstOrDefault();
+            }
 
             hfManageMedsPersonId.Value = personId.ToString();
             hfManageMedsMatrixGuid.Value = matrixGuid;
 
+            var matrixGuidParsed = matrixGuid.AsGuidOrNull();
+            var source = matrixGuidParsed.HasValue && IsSnapshotMatrix( rockContext, matrixGuidParsed.Value )
+                ? SourceSnapshot
+                : SourcePerson;
+            hfManageMedsSource.Value = source;
+
+            ConfigureManageMedsModalForSource( source );
             BindMedicationsGrid( personId );
             mdManageMeds.Show();
+        }
+
+        /// <summary>
+        /// A matrix is treated as a per-event snapshot when at least one GroupMember-entity attribute references it.
+        /// Snapshots are created by the "Medication Information Request" registration workflow that runs for most camps.
+        /// </summary>
+        private bool IsSnapshotMatrix( RockContext rockContext, Guid matrixGuid )
+        {
+            var groupMemberEntityId = EntityTypeCache.GetId<Rock.Model.GroupMember>().Value;
+            var matrixGuidStr = matrixGuid.ToString();
+            return new AttributeValueService( rockContext ).Queryable()
+                .Any( av => av.Value == matrixGuidStr
+                    && av.Attribute.EntityTypeId == groupMemberEntityId );
+        }
+
+        private void ConfigureManageMedsModalForSource( string source )
+        {
+            bool isSnapshot = source == SourceSnapshot;
+
+            // Column indices in mdManageMeds grid: 0=Medication, 1=Instructions, 2=Schedule, 3=Active, 4=Toggle, 5=Edit, 6=Delete
+            gMedications.Columns[3].Visible = !isSnapshot; // Active badge — Person only
+            gMedications.Columns[4].Visible = !isSnapshot; // Toggle button — Person only
+            gMedications.Columns[5].Visible = isSnapshot;  // Edit — Snapshot only
+            gMedications.Columns[6].Visible = isSnapshot;  // Delete — Snapshot only
+
+            btnAddMedication.Visible = isSnapshot;
+
+            ltManageMedsSourceBadge.Text = isSnapshot
+                ? "<div class='alert alert-info margin-b-sm'><i class='fa fa-copy'></i> <strong>Per-event copy</strong> — edits stay in this event and do not change the camper's master record.</div>"
+                : "<div class='alert alert-warning margin-b-sm'><i class='fa fa-user'></i> <strong>Master record</strong> — toggle Active to skip a medication for this event without changing the master list.</div>";
         }
 
         private void BindMedicationsGrid( int personId )
@@ -1188,7 +1265,8 @@ namespace RockWeb.Blocks.Reporting.NextGen
                     ami.Id,
                     Medication = ami.GetAttributeValue( "Medication" ),
                     Instructions = ami.GetAttributeValue( "Instructions" ),
-                    Schedule = string.Join( ", ", scheduleValues )
+                    Schedule = string.Join( ", ", scheduleValues ),
+                    Active = ami.GetAttributeValue( "MedicationActive" ).AsBoolean( true )
                 };
             } ).ToList();
 
@@ -1196,8 +1274,72 @@ namespace RockWeb.Blocks.Reporting.NextGen
             gMedications.DataBind();
         }
 
+        protected void gMedications_RowDataBound( object sender, GridViewRowEventArgs e )
+        {
+            if ( e.Row.RowType != DataControlRowType.DataRow )
+                return;
+
+            // Make the Toggle button reflect the row's current Active state with toggle-on/toggle-off icons.
+            var rowView = e.Row.DataItem;
+            if ( rowView == null )
+                return;
+
+            var activeProp = rowView.GetType().GetProperty( "Active" );
+            if ( activeProp == null )
+                return;
+
+            bool isActive = ( bool ) activeProp.GetValue( rowView );
+
+            // Find the toggle LinkButton (column index 4 — see ConfigureManageMedsModalForSource).
+            if ( e.Row.Cells.Count > 4 )
+            {
+                var cell = e.Row.Cells[4];
+                foreach ( var ctrl in cell.Controls )
+                {
+                    var lb = ctrl as LinkButton;
+                    if ( lb != null )
+                    {
+                        lb.Text = isActive
+                            ? "<i class='fa fa-toggle-on'></i>"
+                            : "<i class='fa fa-toggle-off text-muted'></i>";
+                        lb.ToolTip = isActive ? "Inactivate" : "Reactivate";
+                    }
+                }
+            }
+        }
+
+        protected void ToggleActive_Click( object sender, Rock.Web.UI.Controls.RowEventArgs e )
+        {
+            // Defense-in-depth: only valid for Person-source matrices.
+            if ( hfManageMedsSource.Value != SourcePerson )
+                return;
+
+            var matrixItemId = e.RowKeyId;
+            RockContext rockContext = new RockContext();
+            var item = new AttributeMatrixItemService( rockContext ).Get( matrixItemId );
+            if ( item == null )
+                return;
+
+            // Verify the item belongs to the matrix the modal opened against.
+            var expectedMatrixGuid = hfManageMedsMatrixGuid.Value.AsGuidOrNull();
+            if ( expectedMatrixGuid == null || item.AttributeMatrix == null || item.AttributeMatrix.Guid != expectedMatrixGuid.Value )
+                return;
+
+            item.LoadAttributes( rockContext );
+            bool currentlyActive = item.GetAttributeValue( "MedicationActive" ).AsBoolean( true );
+            item.SetAttributeValue( "MedicationActive", ( !currentlyActive ).ToString() );
+            item.SaveAttributeValues( rockContext );
+
+            BindMedicationsGrid( hfManageMedsPersonId.ValueAsInt() );
+            BindGrid();
+        }
+
         protected void btnDeleteMed_Click( object sender, Rock.Web.UI.Controls.RowEventArgs e )
         {
+            // Defense-in-depth: only delete from snapshot matrices. Person-master rows go through ToggleActive instead.
+            if ( hfManageMedsSource.Value != SourceSnapshot )
+                return;
+
             var matrixItemId = e.RowKeyId;
 
             RockContext rockContext = new RockContext();
@@ -1210,6 +1352,10 @@ namespace RockWeb.Blocks.Reporting.NextGen
                 // Verify the item belongs to the expected matrix
                 var expectedMatrixGuid = hfManageMedsMatrixGuid.Value.AsGuidOrNull();
                 if ( expectedMatrixGuid == null || item.AttributeMatrix == null || item.AttributeMatrix.Guid != expectedMatrixGuid.Value )
+                    return;
+
+                // Final safety: confirm the matrix is genuinely a snapshot before destructive deletion.
+                if ( !IsSnapshotMatrix( rockContext, expectedMatrixGuid.Value ) )
                     return;
 
                 // Delete associated attribute values scoped to AttributeMatrixItem entity type
@@ -1228,8 +1374,86 @@ namespace RockWeb.Blocks.Reporting.NextGen
             BindGrid();
         }
 
+        protected void btnEditMed_Click( object sender, Rock.Web.UI.Controls.RowEventArgs e )
+        {
+            if ( hfManageMedsSource.Value != SourceSnapshot )
+                return;
+
+            var matrixItemId = e.RowKeyId;
+            RockContext rockContext = new RockContext();
+            var item = new AttributeMatrixItemService( rockContext ).Get( matrixItemId );
+            if ( item == null )
+                return;
+
+            var expectedMatrixGuid = hfManageMedsMatrixGuid.Value.AsGuidOrNull();
+            if ( expectedMatrixGuid == null || item.AttributeMatrix == null || item.AttributeMatrix.Guid != expectedMatrixGuid.Value )
+                return;
+
+            item.LoadAttributes( rockContext );
+
+            hfEditMatrixItemId.Value = item.Id.ToString();
+            tbEditMedication.Text = item.GetAttributeValue( "Medication" );
+            tbEditInstructions.Text = item.GetAttributeValue( "Instructions" );
+
+            var definedType = DefinedTypeCache.Get( GetAttributeValue( "DefinedType" ).AsGuid() );
+            if ( definedType != null )
+            {
+                lbEditSchedule.DataSource = definedType.DefinedValues;
+                lbEditSchedule.DataBind();
+
+                var existingScheduleGuids = item.GetAttributeValue( "Schedule" ).SplitDelimitedValues();
+                foreach ( ListItem li in lbEditSchedule.Items )
+                {
+                    li.Selected = existingScheduleGuids.Contains( li.Value );
+                }
+            }
+
+            mdEditMedication.Show();
+        }
+
+        protected void mdEditMedication_SaveClick( object sender, EventArgs e )
+        {
+            if ( hfManageMedsSource.Value != SourceSnapshot )
+                return;
+
+            if ( string.IsNullOrWhiteSpace( tbEditMedication.Text ) )
+                return;
+
+            var selectedSchedules = lbEditSchedule.Items.Cast<ListItem>()
+                .Where( i => i.Selected )
+                .Select( i => i.Value ).ToList();
+            if ( !selectedSchedules.Any() )
+                return;
+
+            var matrixItemId = hfEditMatrixItemId.Value.AsIntegerOrNull();
+            if ( matrixItemId == null )
+                return;
+
+            RockContext rockContext = new RockContext();
+            var item = new AttributeMatrixItemService( rockContext ).Get( matrixItemId.Value );
+            if ( item == null )
+                return;
+
+            var expectedMatrixGuid = hfManageMedsMatrixGuid.Value.AsGuidOrNull();
+            if ( expectedMatrixGuid == null || item.AttributeMatrix == null || item.AttributeMatrix.Guid != expectedMatrixGuid.Value )
+                return;
+
+            item.LoadAttributes( rockContext );
+            item.SetAttributeValue( "Medication", tbEditMedication.Text.Trim() );
+            item.SetAttributeValue( "Instructions", tbEditInstructions.Text.Trim() );
+            item.SetAttributeValue( "Schedule", string.Join( ",", selectedSchedules ) );
+            item.SaveAttributeValues( rockContext );
+
+            BindMedicationsGrid( hfManageMedsPersonId.ValueAsInt() );
+            BindGrid();
+            mdEditMedication.Hide();
+        }
+
         protected void btnAddMedication_Click( object sender, EventArgs e )
         {
+            if ( hfManageMedsSource.Value != SourceSnapshot )
+                return;
+
             tbNewMedication.Text = string.Empty;
             tbNewInstructions.Text = string.Empty;
 
@@ -1245,6 +1469,9 @@ namespace RockWeb.Blocks.Reporting.NextGen
 
         protected void mdAddMedication_SaveClick( object sender, EventArgs e )
         {
+            if ( hfManageMedsSource.Value != SourceSnapshot )
+                return;
+
             if ( string.IsNullOrWhiteSpace( tbNewMedication.Text ) )
                 return;
 
@@ -1260,6 +1487,10 @@ namespace RockWeb.Blocks.Reporting.NextGen
 
             var matrixGuid = hfManageMedsMatrixGuid.Value.AsGuidOrNull();
             if ( matrixGuid == null )
+                return;
+
+            // Final safety: confirm the matrix is a snapshot before adding.
+            if ( !IsSnapshotMatrix( rockContext, matrixGuid.Value ) )
                 return;
 
             var matrix = attributeMatrixService.Get( matrixGuid.Value );

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationInformation.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationInformation.ascx.cs
@@ -119,6 +119,11 @@ namespace RockWeb.Blocks.Reporting.NextGen
                 var attribute = person.GetAttributeValue( GetAttributeValue( "MedicationMatrixKey" ) );
                 var attributeMatrix = attributeMatrixService.Get( attribute.AsGuid() );
 
+                if ( attributeMatrix != null )
+                {
+                    FilterInactiveMatrixItems( attributeMatrix );
+                }
+
                 LavaData data = new LavaData
                 {
                     Person = person,
@@ -158,6 +163,8 @@ namespace RockWeb.Blocks.Reporting.NextGen
                 var attributeMatrix = attributeMatrixService.Get( attribute.AsGuid() );
                 if ( attributeMatrix != null )
                 {
+                    FilterInactiveMatrixItems( attributeMatrix );
+
                     var lava = attributeMatrix.AttributeMatrixTemplate.FormattedLava;
                     var template = attributeMatrix.AttributeMatrixTemplate;
                     template.LoadAttributes();
@@ -176,6 +183,23 @@ namespace RockWeb.Blocks.Reporting.NextGen
 
             gGrid.DataSource = gridData;
             gGrid.DataBind();
+        }
+
+        /// <summary>
+        /// Replaces the matrix's in-memory AttributeMatrixItems collection with only the active items
+        /// so Lava templates iterating Medications.AttributeMatrixItems skip inactive medications.
+        /// Treats items with no stored MedicationActive value as active (default-true semantics).
+        /// </summary>
+        private void FilterInactiveMatrixItems( AttributeMatrix attributeMatrix )
+        {
+            var activeItems = attributeMatrix.AttributeMatrixItems
+                .Where( ami =>
+                {
+                    ami.LoadAttributes();
+                    return ami.GetAttributeValue( "MedicationActive" ).AsBoolean( true );
+                } )
+                .ToList();
+            attributeMatrix.AttributeMatrixItems = new System.Collections.ObjectModel.Collection<AttributeMatrixItem>( activeItems );
         }
 
         private void AddCaretakees( List<Person> familyMembers, RockContext rockContext )


### PR DESCRIPTION
## Summary

Restores safe medication management on the camp medication dispense page by differentiating behavior per data source:

- **Snapshot camps** (most summer camps — registration workflow copies meds to a GroupMember-level matrix): full Edit / Delete / Add Medication on the snapshot. Edits stay scoped to the event.
- **Person-master camps** (HSM Fall Retreat, MSM Discipleship Weekend, RUCKUS, etc. — no workflow): only Activate / Inactivate via a new `MedicationActive` boolean attribute on the matrix template. Inactivating skips the med for the event without touching the master record.

Replaces the view-only modal from the prior ROCK-8328 follow-up (`01273c59`), and supersedes PR #209.

## Setup required per environment

Add a new attribute on the medication matrix template (Guid `d2ed9b3d-309a-4a70-bda4-2c090acd1384`):

- **Name:** `Active`
- **Key:** `MedicationActive`
- **Field Type:** `Boolean`
- **Default Value:** `True`

Either via the Rock UI ("Template Item Attributes" section) or via SQL insert. The new migration `006_MedicationReportFilterInactive.cs` references this attribute by key at runtime so the stored proc stays portable across environments.

After adding, **clear Rock cache** so the running app picks up the new attribute metadata.

## Code changes

| File | Change |
|---|---|
| `MedicationDispense.ascx` | Modal grid: source-badge, Active+Toggle columns, Edit/Delete columns, Add Medication button, Edit sub-modal |
| `MedicationDispense.ascx.cs` | Grid query restructured (`Concat` of two simple INNER-JOIN queries — snapshot path + Person fallback via `NOT EXISTS` antijoin — replacing an earlier `GroupJoin + CASE` approach that caused SQL timeouts). Source detection via `IsSnapshotMatrix`. Toggle / Edit / Delete / Add handlers, all gated to the correct source. Skip-inactive in dispense loop. |
| `GroupLeaderMedicationNotifications.cs` | Notification job's matrix-item join LEFT-joins `MedicationActive` and skips items with `Value = "False"`. Treats absent values as active. |
| `MedicationInformation.ascx.cs` | New `FilterInactiveMatrixItems` helper called from `BindLava` and `BindGrid` so family-facing view hides inactive meds. |
| `CreateMedicationLabels.cs` | Kiosk check-in skips inactive items when generating medication labels. |
| `Migrations/006_MedicationReportFilterInactive.cs` (new) | Re-creates `_org_secc_CampManager_GetMedicationReport` stored proc with a `LEFT JOIN` on `MedicationActive` and `WHERE [Value] IS NULL OR [Value] != 'False'`. Looks up the attribute Id at runtime by key + template-Guid qualifier. |

All consumers use `AsBoolean(true)` semantics — matrix items with no stored `MedicationActive` value are treated as active.

## Test plan

- [x] **Phase 1 — toggle Active/Inactive on no-snapshot camp.** Verified on HSM Fall Retreat (page 2818): toggle writes `False` to the AV, med disappears from dispense grid, reactivates cleanly.
- [x] **Phase 2 — Edit / Delete / Add Medication on snapshot camp.** Verified on HSM Camp (page 1389) with a cloned snapshot. All three actions work and the Person master matrix is unchanged after snapshot edits.
- [x] **Grid query performance.** No SQL timeouts on snapshot camps after the `Concat` restructure.
- [x] **`MedicationInformation` block (`/myevents`).** Family-facing view hides inactive meds end-to-end.
- [x] **`GroupLeaderMedicationNotifications` job — filter predicate verified by SQL.** Job logic exactly matches our `IS NULL OR != 'False'` predicate; TEST ADVIL on test person classifies as EXCLUDED. Job-trigger test deferred (dev env has no active reminder-job descendant groups + concern about real comms). The join chain itself ran successfully 18 times in 2025 production cron runs — our change is just a `LEFT JOIN + WHERE` inserted into that working chain.
- [x] **`CreateMedicationLabels` (Medication Check-In workflow #191) — predicate verified by SQL.** Same `AsBoolean(true)` pattern as the verified family-facing block; same data, same EXCLUDED result. "All inactive" case correctly routes to the existing "No Medication Information Found" label fallback.
- [x] **Camp medication report stored procedure — end-to-end verified.** Ran `EXEC dbo._org_secc_CampManager_GetMedicationReport @RegistrationTemplateId = 1483` (2025 HSM Camp template). Test person rows returned `Tylenol` and `Methaline Blue` but **not** `TEST ADVIL` — the inactive med is correctly excluded from the Excel export pipeline.

## Open question (not blocking)

Should `/myevents` allow parents to toggle Active/Inactive directly, or stay view-only? See the [open question comment](https://github.com/secc/RockPlugins/pull/224#issuecomment-4421989261) for the trade-offs. Currently view-only; no change in this PR.