### PR TITLE
ROCK-8499 Fix sermon share link to point to YouTube

### DIFF
--- a/Content/Lava/SEMobileApp/Sermons/SermonIdV2.lava
+++ b/Content/Lava/SEMobileApp/Sermons/SermonIdV2.lava
@@ -13,6 +13,13 @@ Sermon Page V2
 		{%- assign series = contentchannelitemItems | First -%}
 	{%- endcontentchannelitem -%}
 {%- endcontentchannelitemassociation -%}
+{%- assign youtubeId = sermon | Attribute:'YouTubeId' -%}
+{%- assign startTime = sermon | Attribute:'YoutubeSermonStartTime' -%}
+{%- if youtubeId != empty -%}
+	{%- capture shareUrl -%}https://youtu.be/{{ youtubeId }}{%- if startTime != empty -%}?t={{ startTime }}{%- endif -%}{%- endcapture -%}
+{%- else -%}
+	{%- capture shareUrl -%}{{ 'Global' | Attribute:'PublicApplicationRoot' }}sermons/{{ series.PrimarySlug }}/{{ sermon.PrimarySlug }}{%- endcapture -%}
+{%- endif -%}
 {
     "blocks": [{
         "type": "mediaBanner",
@@ -67,7 +74,7 @@ Sermon Page V2
                 "icon": "share",
                 "action": {
                     "handler": "share",
-                    "shareUrl": "{{ 'Global' | Attribute:'PublicApplicationRoot' }}sermons/{{series.PrimarySlug}}/{{sermon.PrimarySlug}}",
+                    "shareUrl": "{{ shareUrl }}",
                     "shareBody": "Check this out! {{series.Title | Replace:'"','\"'}} | {{sermon.Title | Replace:'"','\"'}}"
                 }
             }]


### PR DESCRIPTION
## Summary
- Mobile app sermon Share button now produces a direct YouTube link (`https://youtu.be/{YouTubeId}`, with `?t={YoutubeSermonStartTime}` when set) instead of the old Rock sermon URL that just redirected to the generic Webflow sermons page.
- Falls back to the existing `southeastchristian.org/sermons/{series}/{sermon}` URL for the ~356 pre-2020 archive sermons that don't have a `YouTubeId` value — no regression, same URL as today.

Ticket: [ROCK-8499](https://seccdev.atlassian.net/browse/ROCK-8499)

## Test plan
- [x] Share a recent sermon from the Subsplash app → opens YouTube directly
- [x] Share a sermon with `YoutubeSermonStartTime` set → URL includes `?t=<seconds>`
- [ ] Share a pre-2020 archive sermon (no `YouTubeId`) → falls back to the existing URL

[ROCK-8499]: https://seccdev.atlassian.net/browse/ROCK-8499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ