### PR TITLE
Rock 8398/multi file field type

### DIFF
--- a/Plugins/org.secc.Attributes/Controls/MultiFileUpload.cs
+++ b/Plugins/org.secc.Attributes/Controls/MultiFileUpload.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Attributes/Controls/MultiFileUpload.cs
+++ b/Plugins/org.secc.Attributes/Controls/MultiFileUpload.cs
@@ -1,0 +1,470 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Web;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+using Rock;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.UI.Controls;
+
+namespace org.secc.Attributes.Controls
+{
+    /// <summary>
+    /// Edit control for MultiFileFieldType. Renders an HTML5 multi-file picker that
+    /// uploads each selected file via Rock's FileUploader handler, tracks the resulting
+    /// BinaryFile Ids in a hidden field, and renders a removable list of currently
+    /// attached files.
+    /// </summary>
+    public class MultiFileUpload : CompositeControl, IRockControl
+    {
+        #region IRockControl Properties
+
+        [Bindable( true ), Category( "Appearance" ), DefaultValue( "" ), Description( "The text for the label." )]
+        public string Label
+        {
+            get { return ViewState["Label"] as string ?? string.Empty; }
+            set { ViewState["Label"] = value; }
+        }
+
+        [Bindable( true ), Category( "Appearance" ), Description( "The CSS class to add to the form-group div." )]
+        public string FormGroupCssClass
+        {
+            get { return ViewState["FormGroupCssClass"] as string ?? string.Empty; }
+            set { ViewState["FormGroupCssClass"] = value; }
+        }
+
+        [Bindable( true ), Category( "Appearance" ), DefaultValue( "" ), Description( "The help block." )]
+        public string Help
+        {
+            get { return HelpBlock != null ? HelpBlock.Text : string.Empty; }
+            set { if ( HelpBlock != null ) { HelpBlock.Text = value; } }
+        }
+
+        [Bindable( true ), Category( "Appearance" ), DefaultValue( "" ), Description( "The warning block." )]
+        public string Warning
+        {
+            get { return WarningBlock != null ? WarningBlock.Text : string.Empty; }
+            set { if ( WarningBlock != null ) { WarningBlock.Text = value; } }
+        }
+
+        [Bindable( true ), Category( "Behavior" ), DefaultValue( "false" ), Description( "Is the value required?" )]
+        public bool Required
+        {
+            get { return ViewState["Required"] as bool? ?? false; }
+            set { ViewState["Required"] = value; }
+        }
+
+        public string RequiredErrorMessage
+        {
+            get { return RequiredFieldValidator != null ? RequiredFieldValidator.ErrorMessage : string.Empty; }
+            set { if ( RequiredFieldValidator != null ) { RequiredFieldValidator.ErrorMessage = value; } }
+        }
+
+        public string ValidationGroup
+        {
+            get { return ViewState["ValidationGroup"] as string; }
+            set
+            {
+                ViewState["ValidationGroup"] = value;
+                if ( RequiredFieldValidator != null ) { RequiredFieldValidator.ValidationGroup = value; }
+            }
+        }
+
+        public virtual bool IsValid
+        {
+            get
+            {
+                if ( !Required )
+                {
+                    return true;
+                }
+                return GetCurrentFileIds().Any();
+            }
+        }
+
+        public HelpBlock HelpBlock { get; set; }
+        public WarningBlock WarningBlock { get; set; }
+        public RequiredFieldValidator RequiredFieldValidator { get; set; }
+
+        public bool DisplayRequiredIndicator
+        {
+            get { return ViewState["Required"] as bool? ?? false; }
+            set { }
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public Guid? BinaryFileTypeGuid
+        {
+            get { return ViewState["BinaryFileTypeGuid"] as Guid?; }
+            set { ViewState["BinaryFileTypeGuid"] = value; }
+        }
+
+        public int MaxFiles
+        {
+            get { return ViewState["MaxFiles"] as int? ?? 0; }
+            set { ViewState["MaxFiles"] = value; }
+        }
+
+        public string AllowedExtensions
+        {
+            get { return ViewState["AllowedExtensions"] as string ?? string.Empty; }
+            set { ViewState["AllowedExtensions"] = value ?? string.Empty; }
+        }
+
+        /// <summary>
+        /// The persisted AttributeMatrix Guid. Set by the field type before render;
+        /// returned (potentially updated) after postback by the field type's GetEditValue.
+        /// </summary>
+        public string Value
+        {
+            get { return ViewState["Value"] as string ?? string.Empty; }
+            set { ViewState["Value"] = value ?? string.Empty; }
+        }
+
+        #endregion
+
+        #region Private State
+
+        private HiddenField _hfFileIds;
+
+        #endregion
+
+        public MultiFileUpload()
+            : base()
+        {
+            HelpBlock = new HelpBlock();
+            WarningBlock = new WarningBlock();
+            RequiredFieldValidator = new HiddenFieldValidator();
+        }
+
+        /// <summary>
+        /// Seeds the hidden field with the BinaryFile Ids currently attached to this attribute.
+        /// Called by the field type's SetEditValue on initial page load.
+        /// </summary>
+        public void SetCurrentFileIds( IEnumerable<int> ids )
+        {
+            EnsureChildControls();
+            _hfFileIds.Value = ids == null ? string.Empty : string.Join( ",", ids );
+        }
+
+        /// <summary>
+        /// Reads the BinaryFile Ids that the user has chosen (initial set plus any uploaded,
+        /// minus any removed). The field type calls this from GetEditValue.
+        /// </summary>
+        public List<int> GetCurrentFileIds()
+        {
+            EnsureChildControls();
+            return ( _hfFileIds.Value ?? string.Empty )
+                .Split( new[] { ',' }, StringSplitOptions.RemoveEmptyEntries )
+                .Select( s => s.Trim().AsIntegerOrNull() )
+                .Where( i => i.HasValue && i.Value > 0 )
+                .Select( i => i.Value )
+                .Distinct()
+                .ToList();
+        }
+
+        protected override void OnLoad( EventArgs e )
+        {
+            EnsureChildControls();
+            base.OnLoad( e );
+        }
+
+        protected override void CreateChildControls()
+        {
+            base.CreateChildControls();
+            Controls.Clear();
+            RockControlHelper.CreateChildControls( this, Controls );
+
+            _hfFileIds = new HiddenField { ID = "hfFileIds" };
+            Controls.Add( _hfFileIds );
+
+            if ( RequiredFieldValidator != null )
+            {
+                RequiredFieldValidator.ControlToValidate = _hfFileIds.ID;
+                RequiredFieldValidator.InitialValue = string.Empty;
+                RequiredFieldValidator.Enabled = Required;
+                RequiredFieldValidator.ValidationGroup = ValidationGroup;
+            }
+        }
+
+        public override void RenderControl( HtmlTextWriter writer )
+        {
+            if ( Visible )
+            {
+                RockControlHelper.RenderControl( this, writer );
+            }
+        }
+
+        public void RenderBaseControl( HtmlTextWriter writer )
+        {
+            EnsureChildControls();
+
+            // Look up the file names for currently-attached ids so we can render the list server-side.
+            var currentIds = GetCurrentFileIds();
+            var files = new List<FileDisplay>();
+            if ( currentIds.Any() )
+            {
+                using ( var rockContext = new RockContext() )
+                {
+                    files = new BinaryFileService( rockContext ).Queryable()
+                        .Where( bf => currentIds.Contains( bf.Id ) )
+                        .Select( bf => new FileDisplay { Id = bf.Id, Guid = bf.Guid, FileName = bf.FileName } )
+                        .ToList();
+                }
+            }
+
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, "multi-file-upload" );
+            writer.AddAttribute( HtmlTextWriterAttribute.Id, ClientID + "_wrap" );
+            writer.RenderBeginTag( HtmlTextWriterTag.Div );
+
+            _hfFileIds.RenderControl( writer );
+
+            // File list
+            writer.AddAttribute( HtmlTextWriterAttribute.Id, ClientID + "_list" );
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, "multi-file-upload-list list-unstyled" );
+            writer.RenderBeginTag( HtmlTextWriterTag.Ul );
+            foreach ( var f in files )
+            {
+                RenderListItem( writer, f.Id, f.Guid, f.FileName );
+            }
+            writer.RenderEndTag(); // ul
+
+            // File picker
+            writer.AddAttribute( HtmlTextWriterAttribute.Type, "file" );
+            writer.AddAttribute( HtmlTextWriterAttribute.Id, ClientID + "_picker" );
+            writer.AddAttribute( "multiple", "multiple" );
+            if ( !string.IsNullOrWhiteSpace( AllowedExtensions ) )
+            {
+                var accept = string.Join( ",", AllowedExtensions
+                    .Split( ',' )
+                    .Select( x => x.Trim().TrimStart( '.' ) )
+                    .Where( x => x.Length > 0 )
+                    .Select( x => "." + x ) );
+                writer.AddAttribute( "accept", accept );
+            }
+            writer.RenderBeginTag( HtmlTextWriterTag.Input );
+            writer.RenderEndTag();
+
+            writer.RenderEndTag(); // div
+
+            RegisterClientScript();
+        }
+
+        private void RenderListItem( HtmlTextWriter writer, int id, Guid guid, string fileName )
+        {
+            writer.AddAttribute( "data-file-id", id.ToString() );
+            writer.RenderBeginTag( HtmlTextWriterTag.Li );
+
+            writer.AddAttribute( HtmlTextWriterAttribute.Href, "/GetFile.ashx?guid=" + guid );
+            writer.AddAttribute( HtmlTextWriterAttribute.Target, "_blank" );
+            writer.RenderBeginTag( HtmlTextWriterTag.A );
+            writer.WriteEncodedText( string.IsNullOrWhiteSpace( fileName ) ? "(file)" : fileName );
+            writer.RenderEndTag(); // a
+
+            writer.Write( " " );
+
+            writer.AddAttribute( HtmlTextWriterAttribute.Type, "button" );
+            writer.AddAttribute( HtmlTextWriterAttribute.Class, "btn btn-xs btn-link js-mfu-remove" );
+            writer.AddAttribute( "title", "Remove" );
+            writer.RenderBeginTag( HtmlTextWriterTag.Button );
+            writer.Write( "&times;" );
+            writer.RenderEndTag(); // button
+
+            writer.RenderEndTag(); // li
+        }
+
+        private void RegisterClientScript()
+        {
+            var uploadQs = "?isBinaryFile=T";
+            if ( BinaryFileTypeGuid.HasValue )
+            {
+                uploadQs += "&fileTypeGuid=" + BinaryFileTypeGuid.Value;
+            }
+
+            var allowedExtsJs = ( AllowedExtensions ?? string.Empty ).Replace( "\\", "\\\\" ).Replace( "'", "\\'" );
+
+            var script = @"
+(function() {
+    var clientId = '" + ClientID + @"';
+    var hf = document.getElementById('" + _hfFileIds.ClientID + @"');
+    var list = document.getElementById(clientId + '_list');
+    var picker = document.getElementById(clientId + '_picker');
+    if (!hf || !list || !picker) { return; }
+    var maxFiles = " + MaxFiles + @";
+    var allowed = '" + allowedExtsJs + @"'.split(',')
+        .map(function(s){ return s.trim().toLowerCase().replace(/^\./,''); })
+        .filter(function(s){ return s.length > 0; });
+    var uploadUrl = '/FileUploader.ashx" + uploadQs + @"';
+
+    function getIds() {
+        return (hf.value || '').split(',').filter(function(s){ return s.length > 0; });
+    }
+    function setIds(arr) { hf.value = arr.join(','); }
+    function makeRemoveBtn() {
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn btn-xs btn-link js-mfu-remove';
+        btn.title = 'Remove';
+        btn.innerHTML = '&times;';
+        return btn;
+    }
+
+    function showWarning(msg) {
+        var prior = document.querySelector('.js-mfu-alert[data-mfu=""' + clientId + '""]');
+        if (prior && prior.parentNode) { prior.parentNode.removeChild(prior); }
+
+        var wrap = document.getElementById(clientId + '_wrap');
+        if (!wrap || !wrap.parentNode) { return; }
+
+        var alertDiv = document.createElement('div');
+        alertDiv.className = 'alert alert-warning alert-dismissable js-mfu-alert';
+        alertDiv.setAttribute('data-mfu', clientId);
+
+        var closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.className = 'close';
+        closeBtn.setAttribute('data-dismiss', 'alert');
+        closeBtn.setAttribute('aria-hidden', 'true');
+        closeBtn.innerHTML = '&times;';
+        alertDiv.appendChild(closeBtn);
+
+        var label = document.createElement('strong');
+        label.innerHTML = '<i class=""fa fa-exclamation-triangle""></i> Warning ';
+        alertDiv.appendChild(label);
+
+        alertDiv.appendChild(document.createTextNode(msg));
+
+        wrap.parentNode.insertBefore(alertDiv, wrap);
+    }
+
+    list.addEventListener('click', function(e) {
+        var btn = e.target;
+        while (btn && btn !== list && !(btn.classList && btn.classList.contains('js-mfu-remove'))) {
+            btn = btn.parentNode;
+        }
+        if (!btn || btn === list) { return; }
+        e.preventDefault();
+        var li = btn.parentNode;
+        var id = li.getAttribute('data-file-id');
+        setIds(getIds().filter(function(x){ return x !== id; }));
+        li.parentNode.removeChild(li);
+    });
+
+    picker.addEventListener('change', function() {
+        // Clear any prior warning — user is taking a new upload action.
+        var priorAlert = document.querySelector('.js-mfu-alert[data-mfu=""' + clientId + '""]');
+        if (priorAlert && priorAlert.parentNode) { priorAlert.parentNode.removeChild(priorAlert); }
+
+        var files = picker.files ? Array.prototype.slice.call(picker.files) : [];
+        if (files.length === 0) { return; }
+
+        // ---- Pre-check 1: extensions (if a whitelist is configured) ----
+        if (allowed.length > 0) {
+            var invalid = files.filter(function(f) {
+                var ext = (f.name.split('.').pop() || '').toLowerCase();
+                return allowed.indexOf(ext) === -1;
+            }).map(function(f) { return f.name; });
+
+            if (invalid.length > 0) {
+                showWarning(
+                    'Cannot upload — invalid file extension' +
+                    (invalid.length === 1 ? '' : 's') + ': ' + invalid.join(', ') +
+                    '. Allowed: ' + allowed.join(', ') + '. No files were uploaded.'
+                );
+                picker.value = '';
+                return;
+            }
+        }
+
+        // ---- Pre-check 2: max files ----
+        if (maxFiles > 0) {
+            var existingCount = getIds().length;
+            var projected = existingCount + files.length;
+            if (projected > maxFiles) {
+                showWarning(
+                    'Cannot upload — would exceed the maximum of ' + maxFiles +
+                    ' file' + (maxFiles === 1 ? '' : 's') +
+                    ' (you have ' + existingCount + ' attached and selected ' +
+                    files.length + ' more). No files were uploaded.'
+                );
+                picker.value = '';
+                return;
+            }
+        }
+
+        // ---- All pre-checks passed; upload each file ----
+        files.forEach(function(file) {
+            var fd = new FormData();
+            fd.append('file', file);
+            var xhr = new XMLHttpRequest();
+            xhr.open('POST', uploadUrl, true);
+            xhr.onload = function() {
+                if (xhr.status !== 200) {
+                    var msg = (xhr.status === 406)
+                        ? 'File type not allowed.'
+                        : (xhr.responseText || ('Unable to upload (HTTP ' + xhr.status + ').'));
+                    showWarning(msg);
+                    return;
+                }
+                var resp;
+                try { resp = JSON.parse(xhr.responseText); }
+                catch (err) { showWarning('Upload response parse error: ' + err); return; }
+                var id = (resp.Id || resp.id || '').toString();
+                var guid = resp.Guid || resp.guid || '';
+                var fileName = resp.FileName || resp.fileName || file.name;
+                if (!id) { showWarning('Upload response missing Id.'); return; }
+                var ids = getIds();
+                if (ids.indexOf(id) !== -1) { return; }
+                ids.push(id);
+                setIds(ids);
+                var li = document.createElement('li');
+                li.setAttribute('data-file-id', id);
+                var a = document.createElement('a');
+                a.href = guid ? ('/GetFile.ashx?guid=' + guid) : ('/GetFile.ashx?id=' + id);
+                a.target = '_blank';
+                a.textContent = fileName;
+                li.appendChild(a);
+                li.appendChild(document.createTextNode(' '));
+                li.appendChild(makeRemoveBtn());
+                list.appendChild(li);
+            };
+            xhr.onerror = function() {
+                showWarning('Unable to upload ""' + file.name + '"" — network error.');
+            };
+            xhr.send(fd);
+        });
+        picker.value = '';
+    });
+})();
+";
+            ScriptManager.RegisterStartupScript( this, GetType(), "mfu_" + ClientID, script, true );
+        }
+
+        private class FileDisplay
+        {
+            public int Id { get; set; }
+            public Guid Guid { get; set; }
+            public string FileName { get; set; }
+        }
+    }
+}

--- a/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
+++ b/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
+++ b/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
@@ -1,0 +1,443 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Web;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+using org.secc.Attributes.Controls;
+using Rock;
+using Rock.Data;
+using Rock.Field;
+using Rock.Model;
+using Rock.Web.Cache;
+using Rock.Web.UI.Controls;
+
+namespace org.secc.Attributes.FieldTypes
+{
+    /// <summary>
+    /// Field type that accepts multiple file uploads against a single attribute.
+    /// Files are stored as BinaryFiles; the attribute value is an AttributeMatrix Guid
+    /// whose rows each reference one BinaryFile.
+    /// </summary>
+    [Serializable]
+    public class MultiFileFieldType : Rock.Field.FieldType
+    {
+        #region Constants
+
+        // Well-known Guid for the system-managed AttributeMatrixTemplate that backs every
+        // MultiFile attribute. Auto-provisioned on first use. Do not change.
+        // Generated via PowerShell [guid]::NewGuid() (CSPRNG-backed); not LLM-invented.
+        public const string SHARED_TEMPLATE_GUID = "D95683B6-3587-43A6-8317-F48A79340175";
+        public const string TEMPLATE_FILE_ATTRIBUTE_KEY = "File";
+
+        private const string CONFIG_BINARY_FILE_TYPE = "binaryfiletype";
+        private const string CONFIG_MAX_FILES = "maxfiles";
+        private const string CONFIG_ALLOWED_EXTENSIONS = "allowedextensions";
+
+        private static int? _sharedTemplateIdCache;
+
+        #endregion
+
+        #region Configuration
+
+        public override List<string> ConfigurationKeys()
+        {
+            var keys = base.ConfigurationKeys();
+            keys.Add( CONFIG_BINARY_FILE_TYPE );
+            keys.Add( CONFIG_MAX_FILES );
+            keys.Add( CONFIG_ALLOWED_EXTENSIONS );
+            return keys;
+        }
+
+        public override List<Control> ConfigurationControls()
+        {
+            var controls = new List<Control>();
+
+            var ddlBinaryFileType = new RockDropDownList
+            {
+                Label = "Binary File Type",
+                Help = "The binary file type that uploads will be stored under.",
+                AutoPostBack = true,
+                Required = true
+            };
+            using ( var rockContext = new RockContext() )
+            {
+                foreach ( var bft in new BinaryFileTypeService( rockContext ).Queryable().OrderBy( b => b.Name ) )
+                {
+                    ddlBinaryFileType.Items.Add( new System.Web.UI.WebControls.ListItem( bft.Name, bft.Guid.ToString() ) );
+                }
+            }
+            ddlBinaryFileType.SelectedIndexChanged += OnQualifierUpdated;
+            controls.Add( ddlBinaryFileType );
+
+            var nbMaxFiles = new NumberBox
+            {
+                Label = "Max Files",
+                Help = "Maximum number of files allowed. Set to 0 for unlimited.",
+                NumberType = ValidationDataType.Integer,
+                MinimumValue = "0",
+                AutoPostBack = true
+            };
+            nbMaxFiles.TextChanged += OnQualifierUpdated;
+            controls.Add( nbMaxFiles );
+
+            var tbAllowedExtensions = new RockTextBox
+            {
+                Label = "Allowed Extensions",
+                Help = "Comma-separated list of allowed file extensions (e.g. \"pdf,docx,jpg\"). Leave blank to allow any.",
+                AutoPostBack = true
+            };
+            tbAllowedExtensions.TextChanged += OnQualifierUpdated;
+            controls.Add( tbAllowedExtensions );
+
+            return controls;
+        }
+
+        public override Dictionary<string, ConfigurationValue> ConfigurationValues( List<Control> controls )
+        {
+            var values = new Dictionary<string, ConfigurationValue>
+            {
+                { CONFIG_BINARY_FILE_TYPE, new ConfigurationValue( "Binary File Type", "The binary file type that uploads will be stored under.", string.Empty ) },
+                { CONFIG_MAX_FILES, new ConfigurationValue( "Max Files", "Maximum number of files allowed. 0 = unlimited.", "0" ) },
+                { CONFIG_ALLOWED_EXTENSIONS, new ConfigurationValue( "Allowed Extensions", "Comma-separated allowed extensions.", string.Empty ) }
+            };
+
+            if ( controls != null )
+            {
+                if ( controls.Count > 0 && controls[0] is RockDropDownList ddl )
+                {
+                    values[CONFIG_BINARY_FILE_TYPE].Value = ddl.SelectedValue;
+                }
+                if ( controls.Count > 1 && controls[1] is NumberBox nb )
+                {
+                    values[CONFIG_MAX_FILES].Value = nb.Text;
+                }
+                if ( controls.Count > 2 && controls[2] is RockTextBox tb )
+                {
+                    values[CONFIG_ALLOWED_EXTENSIONS].Value = tb.Text;
+                }
+            }
+
+            return values;
+        }
+
+        public override void SetConfigurationValues( List<Control> controls, Dictionary<string, ConfigurationValue> configurationValues )
+        {
+            if ( controls == null || configurationValues == null )
+            {
+                return;
+            }
+
+            if ( controls.Count > 0 && controls[0] is RockDropDownList ddl && configurationValues.ContainsKey( CONFIG_BINARY_FILE_TYPE ) )
+            {
+                ddl.SetValue( configurationValues[CONFIG_BINARY_FILE_TYPE].Value );
+            }
+            if ( controls.Count > 1 && controls[1] is NumberBox nb && configurationValues.ContainsKey( CONFIG_MAX_FILES ) )
+            {
+                nb.Text = configurationValues[CONFIG_MAX_FILES].Value;
+            }
+            if ( controls.Count > 2 && controls[2] is RockTextBox tb && configurationValues.ContainsKey( CONFIG_ALLOWED_EXTENSIONS ) )
+            {
+                tb.Text = configurationValues[CONFIG_ALLOWED_EXTENSIONS].Value;
+            }
+        }
+
+        #endregion
+
+        #region Edit Control
+
+        public override Control EditControl( Dictionary<string, ConfigurationValue> configurationValues, string id )
+        {
+            Guid? binaryFileTypeGuid = null;
+            int maxFiles = 0;
+            string allowedExtensions = string.Empty;
+
+            if ( configurationValues != null )
+            {
+                if ( configurationValues.ContainsKey( CONFIG_BINARY_FILE_TYPE ) )
+                {
+                    binaryFileTypeGuid = configurationValues[CONFIG_BINARY_FILE_TYPE].Value.AsGuidOrNull();
+                }
+                if ( configurationValues.ContainsKey( CONFIG_MAX_FILES ) )
+                {
+                    maxFiles = configurationValues[CONFIG_MAX_FILES].Value.AsIntegerOrNull() ?? 0;
+                }
+                if ( configurationValues.ContainsKey( CONFIG_ALLOWED_EXTENSIONS ) )
+                {
+                    allowedExtensions = configurationValues[CONFIG_ALLOWED_EXTENSIONS].Value ?? string.Empty;
+                }
+            }
+
+            return new MultiFileUpload
+            {
+                ID = id,
+                BinaryFileTypeGuid = binaryFileTypeGuid,
+                MaxFiles = maxFiles,
+                AllowedExtensions = allowedExtensions
+            };
+        }
+
+        public override string GetEditValue( Control control, Dictionary<string, ConfigurationValue> configurationValues )
+        {
+            var ctrl = control as MultiFileUpload;
+            if ( ctrl == null )
+            {
+                return string.Empty;
+            }
+
+            var pendingFileIds = ctrl.GetCurrentFileIds();
+
+            using ( var rockContext = new RockContext() )
+            {
+                // Resolve BinaryFile Ids to Guids
+                var binaryFileService = new BinaryFileService( rockContext );
+                var idToGuid = pendingFileIds
+                    .Select( i => binaryFileService.Get( i ) )
+                    .Where( bf => bf != null )
+                    .ToDictionary( bf => bf.Id, bf => bf.Guid );
+
+                var pendingFileGuids = idToGuid.Values.ToList();
+
+                var matrixService = new AttributeMatrixService( rockContext );
+                AttributeMatrix matrix = null;
+
+                var existingMatrixGuid = ctrl.Value.AsGuidOrNull();
+                if ( existingMatrixGuid.HasValue )
+                {
+                    matrix = matrixService.Get( existingMatrixGuid.Value );
+                }
+
+                // No existing matrix and no files to store - just return empty
+                if ( matrix == null && !pendingFileGuids.Any() )
+                {
+                    return string.Empty;
+                }
+
+                if ( matrix == null )
+                {
+                    matrix = new AttributeMatrix
+                    {
+                        AttributeMatrixTemplateId = EnsureSharedTemplate( rockContext ),
+                        AttributeMatrixItems = new List<AttributeMatrixItem>()
+                    };
+                    matrixService.Add( matrix );
+                    rockContext.SaveChanges();
+                }
+
+                // Reconcile rows: index existing items by their File attribute Guid
+                var itemService = new AttributeMatrixItemService( rockContext );
+                var existingItems = matrix.AttributeMatrixItems.ToList();
+                var existingByFileGuid = new Dictionary<Guid, AttributeMatrixItem>();
+                foreach ( var item in existingItems )
+                {
+                    item.LoadAttributes();
+                    var fileGuid = item.GetAttributeValue( TEMPLATE_FILE_ATTRIBUTE_KEY ).AsGuidOrNull();
+                    if ( fileGuid.HasValue )
+                    {
+                        existingByFileGuid[fileGuid.Value] = item;
+                    }
+                }
+
+                // Remove rows whose file is no longer in the pending list
+                foreach ( var kv in existingByFileGuid.Where( x => !pendingFileGuids.Contains( x.Key ) ).ToList() )
+                {
+                    matrix.AttributeMatrixItems.Remove( kv.Value );
+                    itemService.Delete( kv.Value );
+                }
+
+                // Add rows for newly uploaded files
+                foreach ( var newGuid in pendingFileGuids.Where( g => !existingByFileGuid.ContainsKey( g ) ) )
+                {
+                    var newItem = new AttributeMatrixItem { AttributeMatrix = matrix };
+                    matrix.AttributeMatrixItems.Add( newItem );
+                    rockContext.SaveChanges();
+                    newItem.LoadAttributes();
+                    newItem.SetAttributeValue( TEMPLATE_FILE_ATTRIBUTE_KEY, newGuid.ToString() );
+                    newItem.SaveAttributeValues( rockContext );
+                }
+
+                rockContext.SaveChanges();
+                return matrix.Guid.ToString();
+            }
+        }
+
+        public override void SetEditValue( Control control, Dictionary<string, ConfigurationValue> configurationValues, string value )
+        {
+            var ctrl = control as MultiFileUpload;
+            if ( ctrl == null )
+            {
+                return;
+            }
+
+            ctrl.Value = value ?? string.Empty;
+
+            var matrixGuid = value.AsGuidOrNull();
+            if ( !matrixGuid.HasValue )
+            {
+                ctrl.SetCurrentFileIds( new List<int>() );
+                return;
+            }
+
+            using ( var rockContext = new RockContext() )
+            {
+                var matrix = new AttributeMatrixService( rockContext ).Get( matrixGuid.Value );
+                if ( matrix == null )
+                {
+                    ctrl.SetCurrentFileIds( new List<int>() );
+                    return;
+                }
+
+                var fileGuids = new List<Guid>();
+                foreach ( var item in matrix.AttributeMatrixItems )
+                {
+                    item.LoadAttributes();
+                    var fg = item.GetAttributeValue( TEMPLATE_FILE_ATTRIBUTE_KEY ).AsGuidOrNull();
+                    if ( fg.HasValue )
+                    {
+                        fileGuids.Add( fg.Value );
+                    }
+                }
+
+                var ids = new BinaryFileService( rockContext ).Queryable()
+                    .Where( bf => fileGuids.Contains( bf.Guid ) )
+                    .Select( bf => bf.Id )
+                    .ToList();
+
+                ctrl.SetCurrentFileIds( ids );
+            }
+        }
+
+        #endregion
+
+        #region Formatting
+
+        public override string FormatValue( Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues, bool condensed )
+        {
+            var matrixGuid = value.AsGuidOrNull();
+            if ( !matrixGuid.HasValue )
+            {
+                return string.Empty;
+            }
+
+            using ( var rockContext = new RockContext() )
+            {
+                var matrix = new AttributeMatrixService( rockContext ).Get( matrixGuid.Value );
+                if ( matrix == null || matrix.AttributeMatrixItems == null || !matrix.AttributeMatrixItems.Any() )
+                {
+                    return string.Empty;
+                }
+
+                var fileGuids = new List<Guid>();
+                foreach ( var item in matrix.AttributeMatrixItems )
+                {
+                    item.LoadAttributes();
+                    var fg = item.GetAttributeValue( TEMPLATE_FILE_ATTRIBUTE_KEY ).AsGuidOrNull();
+                    if ( fg.HasValue )
+                    {
+                        fileGuids.Add( fg.Value );
+                    }
+                }
+
+                if ( !fileGuids.Any() )
+                {
+                    return string.Empty;
+                }
+
+                if ( condensed )
+                {
+                    return fileGuids.Count == 1 ? "1 file" : ( fileGuids.Count + " files" );
+                }
+
+                var files = new BinaryFileService( rockContext ).Queryable()
+                    .Where( bf => fileGuids.Contains( bf.Guid ) )
+                    .Select( bf => new { bf.Guid, bf.FileName } )
+                    .ToList();
+
+                var links = files
+                    .Select( f => string.Format( "<a href=\"/GetFile.ashx?guid={0}\">{1}</a>", f.Guid, HttpUtility.HtmlEncode( f.FileName ?? string.Empty ) ) )
+                    .ToList();
+
+                return string.Join( "<br />", links );
+            }
+        }
+
+        #endregion
+
+        #region Template Provisioning
+
+        /// <summary>
+        /// Ensures the shared AttributeMatrixTemplate that backs all MultiFile attributes
+        /// exists, creating it with a single "File" column if needed. Returns the template's Id.
+        /// </summary>
+        private static int EnsureSharedTemplate( RockContext rockContext )
+        {
+            if ( _sharedTemplateIdCache.HasValue )
+            {
+                return _sharedTemplateIdCache.Value;
+            }
+
+            var templateGuid = SHARED_TEMPLATE_GUID.AsGuid();
+            var templateService = new AttributeMatrixTemplateService( rockContext );
+            var template = templateService.Get( templateGuid );
+
+            if ( template == null )
+            {
+                template = new AttributeMatrixTemplate
+                {
+                    Guid = templateGuid,
+                    Name = "Multi-File Upload (system)",
+                    Description = "System-managed template used by org.secc.Attributes MultiFileFieldType. Do not edit.",
+                    IsActive = true
+                };
+                templateService.Add( template );
+                rockContext.SaveChanges();
+
+                var fileFieldTypeId = FieldTypeCache.All()
+                    .FirstOrDefault( ft => ft.Class == "Rock.Field.Types.FileFieldType" )?.Id;
+
+                if ( !fileFieldTypeId.HasValue )
+                {
+                    throw new Exception( "Rock.Field.Types.FileFieldType not found in FieldTypeCache." );
+                }
+
+                var attributeMatrixItemEntityTypeId = EntityTypeCache.Get( typeof( AttributeMatrixItem ) ).Id;
+
+                var fileAttribute = new Rock.Model.Attribute
+                {
+                    Key = TEMPLATE_FILE_ATTRIBUTE_KEY,
+                    Name = "File",
+                    EntityTypeId = attributeMatrixItemEntityTypeId,
+                    EntityTypeQualifierColumn = "AttributeMatrixTemplateId",
+                    EntityTypeQualifierValue = template.Id.ToString(),
+                    FieldTypeId = fileFieldTypeId.Value,
+                    Order = 0,
+                    IsRequired = false,
+                    IsGridColumn = true,
+                    AllowSearch = false
+                };
+                new AttributeService( rockContext ).Add( fileAttribute );
+                rockContext.SaveChanges();
+            }
+
+            _sharedTemplateIdCache = template.Id;
+            return template.Id;
+        }
+
+        #endregion
+    }
+}

--- a/Plugins/org.secc.Attributes/org.secc.Attributes.csproj
+++ b/Plugins/org.secc.Attributes/org.secc.Attributes.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -67,8 +68,10 @@
     <Compile Include="Attributes\DynamicPhoneNumber.cs" />
     <Compile Include="Controls\CascadingDropDownList.cs" />
     <Compile Include="Controls\DynamicPhoneNumberPicker.cs" />
+    <Compile Include="Controls\MultiFileUpload.cs" />
     <Compile Include="FieldTypes\CascadingDropDownFieldType.cs" />
     <Compile Include="FieldTypes\DynamicPhoneNumberFieldType.cs" />
+    <Compile Include="FieldTypes\MultiFileFieldType.cs" />
     <Compile Include="Helpers\KeyValueList.cs" />
     <Compile Include="Helpers\KeyValueMatrix.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -79,6 +82,10 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)\DotLiquid\DotLiquid.csproj">
+      <Project>{00edcb8d-ef33-459c-ad62-02876bd24dff}</Project>
+      <Name>DotLiquid</Name>
+    </ProjectReference>
     <ProjectReference Include="$(SolutionDir)\Rock\Rock.csproj">
       <Project>{185A31D7-3037-4DAE-8797-0459849A84BD}</Project>
       <Name>Rock</Name>
@@ -86,6 +93,10 @@
     <ProjectReference Include="$(SolutionDir)\Rock.Common\Rock.Common.csproj">
       <Project>{13568622-324e-4493-b605-c9896e725d30}</Project>
       <Name>Rock.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Rock.Lava.Shared\Rock.Lava.Shared.csproj">
+      <Project>{8820cd93-70ee-496d-b17b-0c4c68dd4957}</Project>
+      <Name>Rock.Lava.Shared</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Plugins/org.secc.Workflow/org.secc.Workflow.csproj
+++ b/Plugins/org.secc.Workflow/org.secc.Workflow.csproj
@@ -142,9 +142,18 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Y /R "$(ProjectDir)bin\Debug\FFmpeg.NET.dll" "$(SolutionDir)RockWeb\bin"
-xcopy /Y /R "$(ProjectDir)bin\Debug\Magick*" "$(SolutionDir)RockWeb\bin"
-xcopy /Y /R "$(ProjectDir)bin\Debug\org.secc.Workflow.dll" "$(SolutionDir)RockWeb\bin"
-xcopy /Y /R /E /I "$(ProjectDir)org_secc" "$(SolutionDir)RockWeb\Plugins\org_secc"</PostBuildEvent>
+    <PostBuildEvent>
+    robocopy "$(ProjectDir)bin\Debug" "$(SolutionDir)RockWeb\bin" "FFmpeg.NET.dll" /R:1 /W:1
+    if %ERRORLEVEL% LEQ 7 set ERRORLEVEL=0
+
+    robocopy "$(ProjectDir)bin\Debug" "$(SolutionDir)RockWeb\bin" "Magick*" /R:1 /W:1
+    if %ERRORLEVEL% LEQ 7 set ERRORLEVEL=0
+
+    robocopy "$(ProjectDir)bin\Debug" "$(SolutionDir)RockWeb\bin" "org.secc.Workflow.dll" /R:1 /W:1
+    if %ERRORLEVEL% LEQ 7 set ERRORLEVEL=0
+
+    robocopy "$(ProjectDir)org_secc" "$(SolutionDir)RockWeb\Plugins\org_secc" /E /R:1 /W:1
+    if %ERRORLEVEL% LEQ 7 set ERRORLEVEL=0
+    </PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Plugins/org.secc.Workflow/org.secc.Workflow.csproj
+++ b/Plugins/org.secc.Workflow/org.secc.Workflow.csproj
@@ -144,16 +144,16 @@
   <PropertyGroup>
     <PostBuildEvent>
     robocopy "$(ProjectDir)bin\Debug" "$(SolutionDir)RockWeb\bin" "FFmpeg.NET.dll" /R:1 /W:1
-    if %ERRORLEVEL% LEQ 7 set ERRORLEVEL=0
+    if %ERRORLEVEL% GTR 7 exit /b %ERRORLEVEL%
 
     robocopy "$(ProjectDir)bin\Debug" "$(SolutionDir)RockWeb\bin" "Magick*" /R:1 /W:1
-    if %ERRORLEVEL% LEQ 7 set ERRORLEVEL=0
+    if %ERRORLEVEL% GTR 7 exit /b %ERRORLEVEL%
 
     robocopy "$(ProjectDir)bin\Debug" "$(SolutionDir)RockWeb\bin" "org.secc.Workflow.dll" /R:1 /W:1
-    if %ERRORLEVEL% LEQ 7 set ERRORLEVEL=0
+    if %ERRORLEVEL% GTR 7 exit /b %ERRORLEVEL%
 
     robocopy "$(ProjectDir)org_secc" "$(SolutionDir)RockWeb\Plugins\org_secc" /E /R:1 /W:1
-    if %ERRORLEVEL% LEQ 7 set ERRORLEVEL=0
+    if %ERRORLEVEL% GTR 7 exit /b %ERRORLEVEL%
     </PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR introduces multi-file upload functionality through a new custom field type in the `org.secc.Attributes` plugin. The upload block uses dynamically generated JavaScript to handle client-side file upload and interaction, following the same pattern as Rock's core `FileUploader.cs`.

The new field type is backed by a constant attribute matrix template. Its Guid was programmatically generated with PowerShell and hardcoded into the field type definition — the same pattern Rock core uses. The template is instantiated on first use, which avoids the need for a formal database migration so long as the hardcoded `SHARED_TEMPLATE_GUID` is never changed.

A multi-file value is stored as follows: the attribute's value is an `AttributeMatrix.Guid`, which is relationally connected to multiple `AttributeMatrixItem.Id`s. Those Ids appear as the `EntityId` on `AttributeValue` records whose `AttributeId` points to the 'File' attribute on the shared `AttributeMatrixTemplate`.

Multi-file upload also supports the same warning banner pattern already used by single-file upload: files that exceed upload limits or use disallowed extensions are flagged in a banner that blocks the offending uploads.