### PR TITLE
Replace robocopy with xcopy in post-build events

### DIFF
--- a/Plugins/org.secc.Workflow/org.secc.Workflow.csproj
+++ b/Plugins/org.secc.Workflow/org.secc.Workflow.csproj
@@ -145,17 +145,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>
-    robocopy "$(ProjectDir)bin\Debug" "$(SolutionDir)RockWeb\bin" "FFmpeg.NET.dll" /R:1 /W:1
-    if %ERRORLEVEL% GTR 7 exit /b %ERRORLEVEL%
-
-    robocopy "$(ProjectDir)bin\Debug" "$(SolutionDir)RockWeb\bin" "Magick*" /R:1 /W:1
-    if %ERRORLEVEL% GTR 7 exit /b %ERRORLEVEL%
-
-    robocopy "$(ProjectDir)bin\Debug" "$(SolutionDir)RockWeb\bin" "org.secc.Workflow.dll" /R:1 /W:1
-    if %ERRORLEVEL% GTR 7 exit /b %ERRORLEVEL%
-
-    robocopy "$(ProjectDir)org_secc" "$(SolutionDir)RockWeb\Plugins\org_secc" /E /R:1 /W:1
-    if %ERRORLEVEL% GTR 7 exit /b %ERRORLEVEL%
+      xcopy /Y /R "$(ProjectDir)bin\Debug\FFmpeg.NET.dll" "$(SolutionDir)RockWeb\bin"
+      xcopy /Y /R "$(ProjectDir)bin\Debug\Magick*" "$(SolutionDir)RockWeb\bin"
+      xcopy /Y /R "$(ProjectDir)bin\Debug\org.secc.Workflow.dll" "$(SolutionDir)RockWeb\bin"
+      xcopy /Y /R /E /I "$(ProjectDir)org_secc" "$(SolutionDir)RockWeb\Plugins\org_secc"
     </PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Reverting the use of robocopy to fix build pipeline