### PR TITLE
ROCK-8615: Plugin documentation — pilot READMEs (format review)

### DIFF
--- a/Plugins/org.secc.PastoralCare/README.md
+++ b/Plugins/org.secc.PastoralCare/README.md
@@ -1,0 +1,75 @@
+# org.secc.PastoralCare
+
+> Block-based lists that let Pastoral Care staff track hospital, homebound, nursing-home, and communion visits.
+
+## Overview
+
+PastoralCare provides the Rock UI for Southeast's Pastoral Care ministry. Each block summarizes a
+category of people who have been reported to Pastoral Care — hospital admissions, homebound
+residents, nursing-home residents, and communion requests — driven by workflows and defined types
+that the plugin's migrations install. Staff use these lists to see who needs a visit and to launch
+the associated visit workflow.
+
+## Project Info
+
+- **Project file:** `org.secc.PastoralCare.csproj`
+- **Root namespace:** `org.secc.PastoralCare`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup)
+
+## Project Layout
+
+```
+/org_secc/PastoralCare/   UI blocks (.ascx + .ascx.cs)
+/Migrations/              Rock plugin migrations (pages, defined types, workflows)
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Pastoral Care**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Hospital List | Summary of current hospitalizations reported to Pastoral Care. | Hospital Admission Workflow, Hospital List defined type, Volunteer Group, Display Pastoral Minister |
+| Homebound List | Summary of current homebound residents. | Homebound Person Workflow |
+| Nursing Home List | Summary of current nursing-home residents. | Nursing Home Resident Workflow, Nursing Home List defined type |
+| Communion List | List of pastoral-care patients/residents who have requested communion. | (driven by the lists above) |
+
+Blocks are configured via Rock block settings — chiefly `WorkflowTypeField` (which workflow a
+list launches/closes), `DefinedTypeField` (the list of hospitals / nursing homes), a `GroupField`
+for the volunteer group, and a `BooleanField` to show the assigned pastoral minister.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, Rock workflow engine, defined types, the Rock block/UI framework.
+- No third-party APIs.
+
+## Migrations
+
+Ships Rock plugin migrations that stand up the plugin's data and pages:
+
+- `001_Pastoral_DefinedTypes` — hospital / nursing-home defined types.
+- `002_Pastoral_WorkflowData` — the pastoral visit workflows.
+- `003_Pastoral_Pages` — Rock pages/blocks for the lists.
+- `004`–`006` — fixes and additions (nursing-home fix, visit-cancel, legacy-Lava fix,
+  show-name-in-visit).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** These blocks surface sensitive health/PII — hospitalizations, homebound
+  status, nursing-home residency. Make sure the Rock **page/block security** for these is locked to
+  Pastoral Care staff roles and not inadvertently viewable by broader admin/staff groups.
+
+## Making Changes
+
+- To change what a list shows, edit the matching `*.ascx.cs` in `org_secc/PastoralCare/`; the
+  block's behavior keys off its configured workflow/defined-type settings.
+- New pages, workflows, or defined-type values belong in a new numbered migration under
+  `/Migrations/` (don't hand-edit existing migrations that have already run).
+- Related: [org.secc.Workflow](../org.secc.Workflow/README.md) (the `DeleteVisitActivity` action and
+  pastoral workflow helpers) and the `CloseDeseasedPastoralWorkflows` job in
+  [org.secc.Jobs](../org.secc.Jobs/README.md).

--- a/Plugins/org.secc.QRManager/README.md
+++ b/Plugins/org.secc.QRManager/README.md
@@ -1,0 +1,74 @@
+# org.secc.QRManager
+
+> Generates QR-code images and Lava filters that turn a person into a scannable check-in / Fast Pass QR URL.
+
+## Overview
+
+QRManager exposes a REST endpoint that renders a QR-code PNG for an arbitrary code string,
+plus a set of Lava filters that build the QR URL (and an `<img>` tag) for a person. It is used
+to produce personal check-in codes and "Personal Fast Pass" (PFP) codes that can be embedded in
+emails, statements, and Lava templates and scanned at a kiosk.
+
+## Project Info
+
+- **Project file:** `org.secc.QRManager.csproj`
+- **Root namespace:** `org.secc.QRManager`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `QRCoder.dll`)
+
+## Project Layout
+
+```
+/Lava/         CustomFilters.cs   — Lava filters (QRUrl, QRImage, PersonalFastPass*)
+/Controllers/  QRController        — REST endpoint that renders the QR PNG
+/Startup/      LoadCustomFilters   — IRockOwinStartup hook that registers the filters
+```
+
+## Components
+
+### REST Endpoints
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `api/qr/{code}` | GET (authenticated) | Returns a PNG QR-code image encoding `{code}`. |
+
+### Lava Filters
+
+Registered at startup via `LoadCustomFilters` (`IRockOwinStartup`).
+
+| Filter | Purpose |
+|--------|---------|
+| `QRUrl` | Builds the QR URL for a person (accepts `Person`, `PersonAlias`, `GroupMember`, `RegistrationRegistrant`, or a person Id). |
+| `QRImage` | Same as `QRUrl` but returns an `<img>` tag (optional `width`, default 300). |
+| `PersonalFastPassUrl` | QR URL using the `PFP` (Personal Fast Pass) prefix. |
+| `PersonalFastPassImage` | `<img>` tag variant of the Fast Pass URL. |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, `PersonService`, Rock REST (`ApiControllerBase`).
+- **Third-party:** `QRCoder` (QR generation), `System.Drawing` (PNG output), DotLiquid (Lava).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** The QR "code" is a person's randomly-generated **Alternate Id** search key
+  (`GenerateRandomAlternateId`), not a sequential/guessable Id or the person Guid — so codes aren't
+  easily enumerable. The `api/qr/{code}` endpoint is `[Authenticate]`-gated and only renders the
+  string as an image, so it doesn't leak data on its own. Worth confirming the alternate-id search
+  path that *consumes* these codes is itself access-controlled.
+- **Improvement:** `GetURL` is a **Lava filter that writes to the database** — when a person has no
+  alternate-id search key it creates one and calls `SaveChanges()`. Template rendering should be
+  side-effect-free; as written, rendering a Lava template can mutate data and isn't idempotent.
+  Consider provisioning the search key up front (job/workflow) and keeping the filter read-only.
+- **Improvement:** A new `RockContext` is constructed on every filter call, so rendering a list of N
+  people spins up N contexts. Acceptable for one-offs, wasteful in loops.
+
+## Making Changes
+
+- To add or change a filter, edit `Lava/CustomFilters.cs`; filters are auto-registered because
+  the whole `CustomFilters` type is passed to `Template.RegisterFilter` in
+  `Startup/LoadCustomFilters.Partial.cs`.
+- The person-resolution logic (which input types map to a `Person`) lives in the private
+  `GetURL` helper in `CustomFilters.cs`.
+- See [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md) for where these codes are scanned.

--- a/Plugins/org.secc.Workflow/README.md
+++ b/Plugins/org.secc.Workflow/README.md
@@ -1,0 +1,111 @@
+# org.secc.Workflow
+
+> A library of custom Rock workflow actions (plus two bulk-workflow admin blocks) covering people, communications, registrations, media, and workflow control.
+
+## Overview
+
+This is Southeast's catch-all workflow-extension plugin. It supplies ~29 custom workflow
+**actions** that drop into Rock's workflow engine, organized by area (person matching, SMS,
+connections, registrations/discount codes, attribute-matrix manipulation, media processing,
+and workflow control). It also ships two admin blocks for selecting and updating workflows in
+bulk.
+
+## Project Info
+
+- **Project file:** `org.secc.Workflow.csproj`
+- **Root namespace:** `org.secc.Workflow`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `FFmpeg.NET.dll`, `Magick*`) and
+  `RockWeb/Plugins/org_secc/` (block markup)
+
+## Project Layout
+
+Actions are grouped into one folder per area; each folder maps roughly to an action category in
+the Rock workflow editor.
+
+```
+/Person/              person matching & history actions
+/Communication/       SMS
+/Connections/         connection-request actions
+/Registrations/       discount codes & registrant field mapping
+/WorkflowAttributes/  attribute & attribute-matrix manipulation
+/WorkflowControl/     activate / reactivate / process / cache actions
+/Schedule/            schedule helpers
+/SignatureDocument/   signed-document storage
+/Media/               FFmpeg / ImageMagick actions
+/Twilio/              Twilio lookup
+/CMS/                 cache-tag actions
+/org_secc/Workflow/   admin blocks (.ascx)
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Workflow**.
+
+| Block | Purpose |
+|-------|---------|
+| Workflow Bulk Select | Tool for bulk-selecting workflows. |
+| Workflow Bulk Update | Tool for updating workflows in bulk. |
+
+### Workflow Actions
+
+| Action | Area | Purpose |
+|--------|------|---------|
+| GetPersonFromFields | Person | Set an attribute to a person via SECC custom matching; optionally create a new person. |
+| PersonAddHistory | Person | Add a history record to the selected person. |
+| SendSms | Communication | Send an SMS to a person or a phone number in the `To` field. |
+| SetConnectionRequestGroup | Connections | Set the group of a connection request. |
+| SetConnectionAttributeValue | Connections | Set attributes of a connection request. |
+| AutoApplyDiscountCode | Registrations | Apply a discount code to an unpersisted RegistrationState. |
+| GenerateDiscountCode | Registrations | Generate a new discount code on a registration template. |
+| UpdateDiscountCodeWithAttribute | Registrations | Update an existing discount code on a registration template. |
+| SetAttributeFromRegistrantField | Registrations | Set an attribute from a registrant field by key + registrant index. |
+| UpdateRegistrationGroupWithPlacementGroup | Registrations | Sync a registration group with its placement group. |
+| SetAttributeValue | WorkflowAttributes | Set an attribute's value to the selected value. |
+| CopyAttributesFromWorkflow | WorkflowAttributes | Copy attribute values from one workflow to another. |
+| AttributeMatrixAddRow / UpdateRow / DeleteRow / Copy | WorkflowAttributes | Add / update / delete / clone attribute-matrix rows. |
+| BinaryFileFromBase64String | WorkflowAttributes | Save a Base64 string as a Binary File. |
+| ActivateWorkflowWithLava | WorkflowControl | Activate a new workflow with provided attribute values. |
+| ProcessWorkflow | WorkflowControl | Process another workflow with provided attribute values. |
+| ReActivateActivity | WorkflowControl | Reactivate an activity instance and its actions. |
+| DeleteVisitActivity | WorkflowControl | Delete a visit activity instance and its actions. |
+| ClearAuthCache | WorkflowControl | Clear the authorization cache. |
+| ScheduleNextStartDate | Schedule | Get the next start date for a schedule. |
+| StoreSignedDocument | SignatureDocument | Create a new signature document. |
+| ClearCacheTags | CMS | Clear all cached items with the selected tag(s). |
+| Lookup | Twilio | Make a Twilio Lookup API call. |
+| FFmpeg | Media | Run FFmpeg commands. |
+| ImageMontage | Media | Create JPG montages of image tiles. |
+| BinaryFileRemove | Media | Remove a Binary File. |
+
+## Dependencies & Integrations
+
+- **Rock:** workflow engine (`ActionComponent`), `RockContext`, connections, registrations, CMS cache.
+- **Cross-plugin:** references [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) (used by `GetPersonFromFields`).
+- **Third-party:** Twilio (lookup), FFmpeg.NET (video/audio), Magick.NET / ImageMagick (image montages).
+
+## Observations
+
+*Noticed while documenting — not a full audit; the `Media/FFmpeg` action stood out.*
+
+- **Security (review):** `FFmpeg` resolves the admin-configured `Command` (Lava, including the
+  `{{file}}` and `{{outputPath}}` merge fields) and passes it straight to the FFmpeg engine. If the
+  `File` workflow attribute can be populated from untrusted input (e.g. a registrant upload/field),
+  that string is interpolated into the command — an argument/command-injection vector. Treat this
+  action as admin-trusted-only and validate/sanitize the `file` value. `OutputPath` is also used to
+  `Directory.CreateDirectory` with no path-traversal guard, so it can write outside the intended root.
+- **Improvement:** `Task.Run( … ).Wait()` is sync-over-async — it blocks the workflow thread on an
+  external process and risks deadlock; there's also no timeout on the FFmpeg run. The default
+  `FFmpegExecutable` is a hardcoded path into an ImageMagick install folder
+  (`C:\Program Files\ImageMagick-…\ffmpeg.exe`), which is brittle and likely wrong on most servers.
+
+## Making Changes
+
+- To add an action, create a class in the appropriate area folder that subclasses Rock's
+  `ActionComponent` and carries the standard `[Description]` / `[ActionCategory]` /
+  `[Export]` attributes; follow an existing sibling as a template.
+- Media actions require the `FFmpeg.NET` and `Magick*` assemblies to be present in `RockWeb/bin`
+  (handled by the PostBuildEvent).
+- `GetPersonFromFields` depends on [org.secc.PersonMatch](../org.secc.PersonMatch/README.md); person-matching changes may belong there.


### PR DESCRIPTION
## ROCK-8615 — Document Rock Plugins in Markdown

Draft PR for **format review** before documenting all ~54 plugins. This is the pilot: one `README.md` per plugin for three representative plugins (small / medium / large).

### What's here
- [`Plugins/org.secc.QRManager/README.md`](../blob/claude/sharp-gagarin-7e1a78/Plugins/org.secc.QRManager/README.md) — small (Lava filters + a REST endpoint)
- [`Plugins/org.secc.PastoralCare/README.md`](../blob/claude/sharp-gagarin-7e1a78/Plugins/org.secc.PastoralCare/README.md) — medium (blocks + migrations)
- [`Plugins/org.secc.Workflow/README.md`](../blob/claude/sharp-gagarin-7e1a78/Plugins/org.secc.Workflow/README.md) — large (29 workflow actions + 2 blocks)

### README format (each plugin)
Overview → Project Info → Project Layout → Components → Dependencies & Integrations → Migrations → **Observations** → Making Changes.

- **Audience:** internal SECC developers + AI coding agents.
- **Observations** captures security/improvement notes found while documenting (not a full audit). Notable example: the `Media/FFmpeg` workflow action interpolates Lava merge fields into a command string — worth a look.
- A top-level `Plugins/README.md` index (catalog grouped by inferred category) will be added with the full set.

### What we're asking reviewers
1. Is the **format/depth** right for devs opening a plugin cold and for AI agents?
2. Keep the **Observations** section (security/improvement notes), or split that out?
3. Any structure changes before we generate the remaining ~51 plugin READMEs?

### Not in scope (separate follow-up ticket)
Repo-root README, ARCHITECTURE.md, CONTRIBUTING.md, AGENTS.md/CLAUDE.md, CI link-checker.