### PR TITLE
ROCK-8615: Plugin documentation — pilot READMEs (format review)

### DIFF
--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -1,0 +1,134 @@
+# SECC Rock Plugins
+
+This folder holds Southeast Christian Church's custom [Rock RMS](https://www.rockrms.com/) plugins —
+each `org.secc.*` directory is one plugin (a Visual Studio project or a set of RockWeb-compiled
+blocks/themes). Every plugin has its own `README.md` documenting what it does, its components
+(blocks, REST endpoints, Lava filters, workflow actions, jobs, field types, models, migrations),
+its dependencies, and notes found while documenting.
+
+**Audience:** internal SECC developers and AI coding agents working in this repo.
+
+**Doc tiers:** most plugins use the **standard** tier (overview → components → dependencies →
+observations → making changes). High-traffic, complex, or externally-facing plugins use the
+**deep** tier, which adds a data-flow diagram, per-component config-attribute tables, edge cases,
+and an extending guide. The Tier column below flags which is which.
+
+Each plugin's **Observations** section captures security/improvement notes spotted *while
+documenting* — they are starting points, not a completed security audit.
+
+---
+
+## Check-In & Attendance
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [FamilyCheckin](./org.secc.FamilyCheckin/README.md) | standard | Southeast's custom check-in stack — kiosk/kiosk-type models, a library of check-in workflow actions, a cached check-in state layer, mobile/touchless check-in, and consent/quick-check-in UI blocks. |
+| [CheckinMonitor](./org.secc.CheckinMonitor/README.md) | standard | Staff-facing check-in admin blocks: room-ratio management, a live attendance monitor, mobile check-in printing, a cache inspector, and an advanced "Super" check-in/search tool. |
+| [RoomScanner](./org.secc.RoomScanner/README.md) | standard | A REST API (plus two admin blocks) that lets a kids' room-scanner app move children and volunteers in and out of check-in rooms with PIN-authorized overrides and two-volunteer safety rules. |
+| [SportsAndFitness](./org.secc.SportsAndFitness/README.md) | standard | Rock blocks and a theme for Southeast's Activities Center — member/guest check-in, group-fitness session tracking, guest self-registration, and a staff "control center". |
+| [Microframe](./org.secc.Microframe/README.md) | standard | Drives physical Microframe LED paging signs over TCP — pushing child-pickup codes from Rock so they display (and clear) on the boards. |
+| [QRManager](./org.secc.QRManager/README.md) | standard | Generates QR-code images and Lava filters that turn a person into a scannable check-in / Fast Pass QR URL. |
+
+## Connections & Groups
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [Connection](./org.secc.Connection/README.md) | standard | Public-facing volunteer signup blocks that turn Rock connection opportunities into configurable, partition-driven signup pages. |
+| [ConnectionCards](./org.secc.ConnectionCards/README.md) | standard | A Rock block that ingests a scanned PDF sheet of physical connection cards, slices it into a grid of per-card images, and launches a workflow for each one. |
+| [ConnectionsDigest](./org.secc.ConnectionsDigest/README.md) | standard | A scheduled job that emails each connector a periodic digest of their connection requests (new, active, idle, critical) for the selected opportunities. |
+| [GroupManager](./org.secc.GroupManager/README.md) | standard | A suite of Rock blocks for self-service group management — leader rosters, attendance, group finder, and a "Publish Group" model that lets ministries advertise and register groups. |
+| [GroupTrackerDemo](./org.secc.GroupTrackerDemo/README.md) | standard | REST endpoints that list a leader's groups and let a client view and toggle today's attendance for a group's members. |
+| [FamilyOnMission](./org.secc.FamilyOnMission/README.md) | standard | A Rock block that lists the "Family on Mission" classes by time slot and lets a logged-in person sign up for an open one. |
+
+## Communications
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [Communication](./org.secc.Communication/README.md) | standard | SMS/keyword administration, communication-list tooling, schedule-reminder jobs, and a Twilio message-history sync for Southeast's messaging. |
+| [RecurringCommunications](./org.secc.RecurringCommunications/README.md) | standard | Lets staff define email/SMS/push communications that re-send on a Rock schedule to a Data View audience, sent by a scheduled job. |
+
+## Finance & Payments
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [Finance](./org.secc.Finance/README.md) | standard | Generates and serves annual giving (contribution) statements — workflow action + merge-field builder, launch/list/print blocks, a download handler, a generation job, plus a bulk registration-refund block. |
+| [PayFlowPro](./org.secc.PayFlowPro/README.md) | deep | A custom Rock financial gateway component subclassing Rock's stock PayFlow Pro gateway to add an "Every 4 Weeks" frequency, friendlier invalid-saved-account handling, and a recurring-billing reconciliation report. |
+| [PayPalExpress](./org.secc.PayPalExpress/README.md) | deep | A Rock financial gateway component for PayPal Express Checkout (Classic Merchant API), plus a drop-in Transaction Entry block that adds a PayPal tab to Rock's giving flow. |
+| [PayPalReporting](./org.secc.PayPalReporting/README.md) | deep | A scheduled job that pulls PayFlow Pro transaction reports out of PayPal into a custom Rock table, with a block to view/edit individual rows. |
+| [Purchasing](./org.secc.Purchasing/README.md) | standard | Southeast's in-house purchasing system — requisitions, purchase orders, receiving, vendors, payment methods, and capital requests — on a custom LINQ-to-SQL data layer with Sage Intacct GL validation. |
+
+## Events, Registration & Learning
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [Event](./org.secc.Event/README.md) | standard | Southeast's custom event/registration blocks — calendar Lava, a heavily-customized registration entry/detail pair, QR event passes, SignNow signing, camp-placement import, and the Community Gives Back program. |
+| [Equip](./org.secc.Equip/README.md) | standard | A self-contained learning-management system (LMS) for Rock — courses, chapters, multi-format lesson pages, quizzes, and per-person completion tracking with group/data-view requirements. |
+
+## Workflow & Automation
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [Workflow](./org.secc.Workflow/README.md) | deep | A library of custom Rock workflow actions (plus two bulk-workflow admin blocks) covering people, communications, registrations, media, and workflow control. |
+| [WorkflowLauncher](./org.secc.WorkflowLauncher/README.md) | standard | Tools for launching and bulk-managing Rock workflows over groups, registrations, data views, and arbitrary SQL result sets. |
+| [Jobs](./org.secc.Jobs/README.md) | standard | A grab-bag of Southeast's custom Rock scheduled jobs (Quartz `IJob`s) for data maintenance, attendance, communications, and one-off migrations. |
+| [PDF](./org.secc.PDF/README.md) | standard | Workflow actions that generate PDFs — render Lava/HTML to PDF, fill a PDF form template, and combine two PDFs — outputting to a binary-file workflow attribute. |
+| [SignNowWorkflow](./org.secc.SignNowWorkflow/README.md) | standard | Two Rock workflow actions that push a PDF into SignNow for e-signature and pull the signed copy back when it's done. |
+
+## Security & Identity
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [Authentication](./org.secc.Authentication/README.md) | deep | A passwordless SMS one-time-code authentication provider for Rock — texts a 6-digit code to a person's mobile number and logs them in with it. |
+| [OAuth](./org.secc.OAuth/README.md) | deep | A self-hosted OAuth 2.0 authorization server for Rock — issues tokens against Rock `UserLogin` credentials, with admin-managed clients/scopes and profile REST endpoints. |
+| [Security](./org.secc.Security/README.md) | deep | A grab-bag of SECC security/identity Rock blocks — Wi-Fi captive portals, SAML/SSO redirects (WellRight, Church Online), PIN management, self-service account blocks — plus a reusable SAML 2.0 assertion library. |
+| [Search](./org.secc.Search/README.md) | standard | Custom Rock person-search components (address, DOB, envelope) plus admin blocks for person, bulk, and Apple Pass lookups. |
+
+## Reporting & Monitoring
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [Reporting](./org.secc.Reporting/README.md) | standard | Southeast's custom reporting surface — admin/ministry report blocks, a "SQL Filter" data-view component, a camp-medication Excel export workflow action, and supporting EF models, migrations, and SQL objects. |
+| [MetricsDigest](./org.secc.MetricsDigest/README.md) | standard | A scheduled job that emails a per-campus "metric entry progress" digest, showing how many selected metrics have values entered for a date range. |
+| [SystemsMonitor](./org.secc.SystemsMonitor/README.md) | standard | A pluggable system-monitoring framework: define HTTP/SQL/Lava "system tests", run them on a schedule, record pass/fail history, and alert staff by email/SMS on an alarm condition. |
+
+## Pastoral Care & Safety
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [PastoralCare](./org.secc.PastoralCare/README.md) | standard | Block-based lists that let Pastoral Care staff track hospital, homebound, nursing-home, and communion visits. |
+| [SafetyAndSecurity](./org.secc.SafetyAndSecurity/README.md) | standard | Campus lock-down SMS alerting plus workflow actions for volunteer background-check applications, incident-report PDFs, and MinistrySafe training. |
+
+## Third-party Integrations
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [EMS](./org.secc.EMS/README.md) | standard | Thin SOAP client + Rock block that pulls room/event bookings from the EMS (Event Management System) facility-scheduling product and lists them in Rock. |
+| [LeagueApps](./org.secc.LeagueApps/README.md) | standard | Imports sports-league programs and members from the LeagueApps API into Rock as a year/category/league group hierarchy with matched people. |
+| [ServiceReef](./org.secc.ServiceReef/README.md) | standard | Scheduled jobs that pull mission-trip events, participants, and payments from the ServiceReef API into Rock as groups, people, and financial transactions. |
+| [Trak1](./org.secc.Trak1/README.md) | standard | A Rock background-check provider that submits applicant data to the Trak-1 web service and polls back report status/results through a workflow action. |
+| [Mapping](./org.secc.Mapping/README.md) | standard | Computes and caches driving distance/time from an address to a set of Rock entities (campuses, groups) via the Azure Maps Route Matrix API, exposed as a REST endpoint and a workflow action. |
+| [Imaging](./org.secc.Imaging/README.md) | standard | Renders HTML/Lava into PNG images over REST, and bulk-updates person photos by AI face-cropping existing binary files via Azure Cognitive Services Face. |
+
+## CMS, Theming & UI
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [Cms](./org.secc.Cms/README.md) | standard | A grab-bag of Southeast's custom Rock CMS blocks — login/profile UI, section/topper page chrome, content-channel and Twitter Lava, QR-code shortlinks, cache/Font-Awesome admin tools — plus a styled `SectionZone` control. |
+| [Widgities](./org.secc.Widgities/README.md) | standard | A drag-and-drop content-builder: admins define reusable "widgity" types (a Lava/Markdown template + an attribute schema), then place and configure them against any Rock entity. |
+| [Attributes](./org.secc.Attributes/README.md) | standard | Three custom Rock attribute field types — a cascading (dependent) dropdown, a typed phone-number picker, and a multi-file uploader — with their edit controls and `[FieldAttribute]` decorators. |
+| [Themes](./org.secc.Themes/README.md) | standard | Southeast's Rock site themes — the master pages, page layouts, and styling that skin Rock's external and check-in sites. |
+| [CustomIcons](./org.secc.CustomIcons/README.md) | standard | Ships a Southeast-branded icon webfont (`se-*` classes) and the LESS that wires it into Rock's Font Awesome stack. |
+| [LessInclude](./org.secc.LessInclude/README.md) | standard | A CMS block that lets admins edit LESS variables/theme per page and compiles them to CSS on save, swapping the page's stylesheet for the result. |
+| [Sass](./org.secc.Sass/README.md) | standard | Adds SCSS/SASS compilation to Rock themes — Rock natively compiles only LESS, so this compiles each theme's `Styles/*.scss` to CSS on startup and from the CMS theme blocks. |
+
+## Platform, APIs & Developer Tools
+
+| Plugin | Tier | What it does |
+|--------|------|--------------|
+| [Rest](./org.secc.Rest/README.md) | deep | Custom Rock REST controllers for SECC's apps — account/SMS login, the Groups mobile app, content-channel/sermon feeds, person matching, and financial-statement data. |
+| [PersonMatch](./org.secc.PersonMatch/README.md) | standard | A `PersonService.GetByMatch` extension method that resolves loose name/contact fields to existing Rock people (nickname-aware), with optional nameless-person creation. |
+| [Administration](./org.secc.Administration/README.md) | standard | A grab-bag of admin-only Rock UI blocks — system diagnostics, one-off data migrations, and group/device housekeeping tools. |
+| [ChangeManager](./org.secc.ChangeManager/README.md) | standard | A change-request/approval framework that captures edits to any Rock entity as reviewable `ChangeRecord`s and applies (or reverses) them transactionally on approval. |
+| [DevLib](./org.secc.DevLib/README.md) | standard | A small shared library of developer utilities for other SECC plugins — a MEF-backed "settings component" base, EF-migration helper extensions, and a search DTO. |
+| [Migrations](./org.secc.Migrations/README.md) | standard | A library of Rock plugin migrations that install SECC's pages, workflows, defined types, attributes, stored procedures, and DB triggers at startup. |
+| [AI](./org.secc.AI/README.md) | standard | Empty scaffold project — no functionality yet; reserved as the home for future AI-related Rock code. |

--- a/Plugins/org.secc.AI/README.md
+++ b/Plugins/org.secc.AI/README.md
@@ -1,0 +1,59 @@
+# org.secc.AI
+
+> Empty scaffold project — no functionality yet; reserved as the home for future AI-related Rock code.
+
+## Overview
+
+This is a freshly-scaffolded, **empty** plugin. It contains a single placeholder type
+(`Class1`, with no members) and the default project metadata — nothing is wired into Rock.
+It exists as a reserved namespace/assembly (`org.secc.AI`) for future AI-related work, but as
+shipped it has no REST endpoints, Lava filters, blocks, jobs, field types, models, or migrations.
+
+## Project Info
+
+- **Project file:** `org.secc.AI.csproj`
+- **Root namespace:** `org.secc.AI`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** nothing — no `PostBuildEvent` is defined, so the build output is not copied to `RockWeb/bin/`
+
+## Project Layout
+
+```
+Class1.cs               Empty placeholder class (no members)
+/Properties/            AssemblyInfo.cs — default scaffolded assembly metadata
+org.secc.AI.csproj      Library project; references Rock.dll / Rock.Rest.dll but uses none of them
+```
+
+## Components
+
+None. The only compiled type is an empty `Class1`; there is no Rock-facing functionality to document.
+
+The `.csproj` already references the usual Rock plugin assemblies (`Rock`, `Rock.Rest`, `DotLiquid`,
+`EntityFramework.SqlServer`, `Newtonsoft.Json`), so the project is set up to grow into a real plugin
+without further reference wiring.
+
+## Dependencies & Integrations
+
+- **Rock:** References `Rock.dll` and `Rock.Rest.dll` but does not call into them yet.
+- **Third-party:** References DotLiquid, EntityFramework, and Newtonsoft.Json (unused as shipped).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** The plugin is an empty scaffold. `Class1.cs` should be replaced with real code or
+  the project removed/renamed before relying on the `org.secc.AI` assembly in production.
+- **Improvement:** No `PostBuildEvent` `xcopy` to `RockWeb/bin/` is defined (unlike sibling plugins
+  such as [org.secc.Jobs](../org.secc.Jobs/README.md)), so even if code were added, the build output
+  would not be deployed until that step is added.
+- **Improvement:** `AssemblyInfo.cs` carries empty `AssemblyCompany`/`AssemblyDescription` and a
+  generic `"Copyright ©  2024"` rather than Southeast Christian Church attribution.
+
+## Making Changes
+
+- This is the place to add Southeast's AI integrations. Add new `.cs` files and reference them in the
+  `<Compile>` list of `org.secc.AI.csproj` (or replace the placeholder `Class1.cs`).
+- Before the assembly can load in Rock, add a `PostBuildEvent` `xcopy` of the output to `RockWeb/bin/`
+  — copy the pattern from [org.secc.Jobs](../org.secc.Jobs/README.md) or another deploying sibling.
+- For component patterns (REST controllers, Lava filters, jobs), follow established examples such as
+  [org.secc.QRManager](../org.secc.QRManager/README.md) and [org.secc.Jobs](../org.secc.Jobs/README.md).

--- a/Plugins/org.secc.Administration/README.md
+++ b/Plugins/org.secc.Administration/README.md
@@ -1,0 +1,79 @@
+# org.secc.Administration
+
+> A grab-bag of admin-only Rock UI blocks for Southeast staff — system diagnostics, one-off data migrations, and group/device housekeeping tools.
+
+## Overview
+
+Administration is a small set of Rock **UI blocks** in the `SECC > Administration` category, used by
+Rock admins for maintenance and one-off data work. It covers system diagnostics (a SECC variant of
+Rock's System Info), bulk data migrations (baptism attribute-matrix → Step records), group surgery
+(change a group's type, merge neighborhood-group rosters), and personal-device management synced to
+the Front Porch WiFi API. There is no service layer or REST surface — each block is a standalone
+admin tool dropped on a page.
+
+## Project Info
+
+- **Project file:** none — no `.csproj`; RockWeb-compiled (block `.ascx` + `.ascx.cs` only).
+- **Root namespace:** `RockWeb.Plugins.org_secc.Administration`
+- **Target framework:** compiles in-place under RockWeb (ASP.NET WebForms / .NET Framework).
+- **Deploys to:** `RockWeb/Plugins/org_secc/Administration/` (the `.ascx` markup + code-behind).
+
+## Project Layout
+
+```
+/org_secc/Administration/   UI blocks (.ascx + .ascx.cs), category "SECC > Administration"
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Administration**.
+
+| Block (`DisplayName`) | Purpose | Key settings |
+|-----------------------|---------|--------------|
+| `System Information` | SECC variant of Rock's System Info — version, DB info/size/snapshot-isolation, migrations, cache stats, routes, transaction queue; buttons to clear cache, restart the app, and dump a diagnostics text file. | (none) |
+| `Baptism Data Migrator` | One-off migration: converts baptism data stored in a person attribute-matrix into Step records of a Baptism Step Type. Runs as a SignalR background task with live progress. | **BaptismStepType** (StepProgramStepType), **StepStatus** (completed status), **BaptismPersonAttribute** (matrix person attribute) |
+| `Group Type Changer` | Changes a group's `GroupType`, remapping member roles and group-member attributes onto the new type via UI dropdowns. | (none — driven by `GroupId` page param) |
+| `Neighborhood Group Merge` | Merges a source neighborhood group into a target: adds missing members as Inactive, repoints attendance occurrences, and unions the `LWYACycle` attribute. | (none — group pickers in UI) |
+| `Personal Devices` | Person-context block listing a person's `PersonalDevice` rows (Lava-rendered); add/edit/inactivate devices and sync MAC addresses to the Front Porch WiFi API. | **InteractionsPage** (LinkedPage), **LavaTemplate**, **Remove Device** (bool), **SecureNetworkSSID** |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockBlock` / WebForms UI framework, `RockContext` and Rock services (`Group`, `GroupType`,
+  `Attendance`, `Step`, `PersonalDevice`, `Attribute`/`AttributeValue`, `Person`), attribute-matrix
+  model, Step program model, `RockCache` / cache & migration introspection, SignalR (`RockMessageHub`),
+  DotLiquid/Lava.
+- **Third-party APIs:** Front Porch WiFi user API (`PersonalDevices` — add/modify/delete/get users by
+  MAC; host + token from Global Attributes `FrontporchHost` / `FrontporchAPIToken`).
+- **Cross-plugin:** none in code. Front Porch device removal is also done by the
+  `FrontPorchDeviceRemoval` job in [org.secc.Jobs](../org.secc.Jobs/README.md).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** `System Information`'s diagnostics dump and restart/clear-cache actions are
+  high-privilege operations (it can `UnloadAppDomain`, delete `App_Data/Cache`, and emit server
+  variables/DB details). Confirm the page hosting this block is locked to admins. The dump explicitly
+  skips `HTTP_COOKIE` but still includes all other server variables.
+- **Security (low):** `Personal Devices` reaches the Front Porch API with a token from the
+  `FrontporchAPIToken` Global Attribute. Confirm that attribute is stored encrypted and not broadly
+  readable, and that MAC addresses (PII-adjacent) are only exposed to authorized staff.
+- **Improvement:** Several blocks open multiple `new RockContext()` instances within one operation and
+  call `SaveChanges()` mid-flow (e.g. `GroupTypeChanger` loads `group` on one context but resolves the
+  new group type on a throwaway context in `OnLoad`; `NeighborhoodGroupMerge` saves between steps).
+  These multi-context, multi-save flows aren't transactional — a partial failure can leave a half-merged
+  group or half-remapped roles. Worth confirming these tools are run carefully / on backed-up data.
+- **Improvement:** `Baptism Data Migrator`, `Group Type Changer`, and `Neighborhood Group Merge` read as
+  one-off / occasional-use migration tools. If they've already served their purpose, consider retiring
+  the blocks (and their pages) rather than leaving destructive group/attribute edits a click away.
+
+## Making Changes
+
+- Each block is self-contained — edit the matching `*.ascx.cs` (and `.ascx` markup) under
+  `org_secc/Administration/`. There's no shared service layer, no migrations, and no DI to thread through.
+- `Personal Devices` is `[ContextAware(typeof(Person))]` and also accepts a `PersonGuid` page param;
+  its Front Porch endpoints (`/api/user/add|modify|delete|get`) live in the private FP helper methods.
+- Front Porch host/token come from Global Attributes (`FrontporchHost`, `FrontporchAPIToken`); see the
+  `FrontPorchDeviceRemoval` job in [org.secc.Jobs](../org.secc.Jobs/README.md) for the batch counterpart.

--- a/Plugins/org.secc.Attributes/README.md
+++ b/Plugins/org.secc.Attributes/README.md
@@ -1,0 +1,130 @@
+# org.secc.Attributes
+
+> Three custom Rock attribute field types — a cascading (dependent) dropdown, a typed phone-number picker, and a multi-file uploader — with their edit controls and `[FieldAttribute]` decorators.
+
+## Overview
+
+This plugin adds custom **field types** to Rock's attribute framework. Each field type plugs into the
+standard Rock attribute editor (configure once, then attach to any entity) and provides its own edit
+control and value-formatting logic. The three types are a **cascading dropdown** (chained dropdowns
+filtered by the prior selection, driven by a key^value matrix or a SQL query), a **dynamic phone
+number** (phone-type defined value + number), and a **multi-file upload** (multiple `BinaryFile`s
+stored behind a single attribute via an `AttributeMatrix`). Two of them ship a strongly-typed
+`FieldAttribute` subclass so they can be applied to blocks/components in code.
+
+## Project Info
+
+- **Project file:** `org.secc.Attributes.csproj`
+- **Root namespace:** `org.secc.Attributes`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`, via the PostBuildEvent `xcopy`)
+
+## Project Layout
+
+```
+/FieldTypes/   The three Rock FieldType implementations (config / format / edit-value)
+/Controls/     The IRockControl edit controls each field type renders
+/Attributes/   FieldAttribute subclasses for applying the field types in code
+/Helpers/      KeyValueList / KeyValueMatrix — parsing + filtering for the cascading dropdown
+```
+
+## Components
+
+### Field Types
+
+Each extends `Rock.Field.FieldType` and is registered with Rock by class name (no startup hook).
+
+| Field type (class) | Stored value | Config keys | Edit control |
+|--------------------|--------------|-------------|--------------|
+| `CascadingDropDownFieldType` | `\|`-joined selected keys (one per level) | `configuration` (the data matrix) | `CascadingDropDownList` |
+| `DynamicPhoneNumberFieldType` | `{phoneTypeDefinedValueId}\|{number}` | (none) | `DynamicPhoneNumberPicker` |
+| `MultiFileFieldType` | an `AttributeMatrix` Guid (rows reference `BinaryFile`s) | `binaryfiletype`, `maxfiles`, `allowedextensions` | `MultiFileUpload` |
+
+**`CascadingDropDownFieldType`** — one config textarea (**`configuration`**, the "Data Matrix")
+defines the option tree. `KeyValueMatrix` parses it three ways (tried in order): JSON, a SQL `SELECT`
+(detected by containing both `SELECT` and `FROM`; each row column is a `key^value` pair, run via
+`Rock.Data.DbService.GetDataTable`), or a plain matrix where each **line** is a row and the row's
+levels are **comma-separated** `key^value` cells. The control renders one dropdown per matrix column;
+selecting a value filters the next dropdown's options to descendants of that key.
+
+**`DynamicPhoneNumberFieldType`** — no configuration. The picker pairs a phone-type dropdown (sourced
+from the `PERSON_PHONE_TYPE` defined type) with a `PhoneNumberBox`. `FormatValue` resolves the stored
+defined-value Id back to its label (e.g. `Mobile: 555-1234`).
+
+**`MultiFileFieldType`** — the most involved. Uploaded files become `BinaryFile`s; the attribute value
+is the Guid of an `AttributeMatrix` whose items each hold one file in a `File` column. On first use it
+auto-provisions a single shared `AttributeMatrixTemplate` (well-known Guid `D95683B6-…-F48A79340175`,
+cached in a static field). `GetEditValue` reconciles rows against the picker's current file Ids
+(adds new, deletes removed). Config attributes:
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **`binaryfiletype`** | Binary File Type (Guid) | Required. Which `BinaryFileType` uploads are stored under. |
+| **`maxfiles`** | int | `0` = unlimited. Enforced client-side before upload. |
+| **`allowedextensions`** | csv | Comma-separated extension whitelist (e.g. `pdf,docx,jpg`); blank = any. Enforced client-side. |
+
+### Edit Controls
+
+| Control | Implements | Renders |
+|---------|------------|---------|
+| `CascadingDropDownList` | `CompositeControl`, `IRockControl` | N chained `RockDropDownList`s, re-filtered on `SelectedIndexChanged` postback. |
+| `DynamicPhoneNumberPicker` | `CompositeControl`, `IRockControl` | Phone-type `RockDropDownList` + `PhoneNumberBox` in a Bootstrap row. |
+| `MultiFileUpload` | `CompositeControl`, `IRockControl` | HTML5 multi-file `<input>` + a server-rendered removable file list; uploads each file to `/FileUploader.ashx` over XHR and tracks resulting Ids in a hidden field. |
+
+### Field Attributes
+
+`FieldAttribute` subclasses that let the field types be declared on a block/component in code.
+
+| Attribute | Applies | Notes |
+|-----------|---------|-------|
+| `CascadingDropDownFieldAttribute` | `CascadingDropDownFieldType` | Takes a `matrix` ctor arg, stored as the `configuration` value. `AllowMultiple`, `Inherited`. |
+| `DynamicPhoneNumber` | `DynamicPhoneNumberFieldType` | Thin wrapper; no extra config. |
+
+(`MultiFileFieldType` has no companion `FieldAttribute`; it is applied through the Rock admin UI.)
+
+## Dependencies & Integrations
+
+- **Rock:** `Rock.Field.FieldType`, the attribute/qualifier framework, `IRockControl` + `RockControlHelper`,
+  `RockDropDownList` / `PhoneNumberBox` / `NumberBox`, defined-type cache (`PERSON_PHONE_TYPE`),
+  `BinaryFile` / `BinaryFileType`, `AttributeMatrix` / `AttributeMatrixTemplate` / `AttributeMatrixItem`,
+  `FieldTypeCache` / `EntityTypeCache`, `Rock.Data.DbService` (raw SQL), and the `/FileUploader.ashx` /
+  `/GetFile.ashx` handlers.
+- **Third-party:** Newtonsoft.Json (matrix (de)serialization), EntityFramework (transitive via Rock).
+- No REST endpoints, jobs, migrations, or Lava filters.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** `CascadingDropDownFieldType`'s "Data Matrix" config can be a raw SQL `SELECT`
+  executed via `DbService.GetDataTable( config, CommandType.Text, null )` (any string containing
+  `SELECT` and `FROM`). This runs with the app's DB credentials. The config is only editable by users
+  with attribute-edit rights, so the threat surface is limited to admins, but it is effectively
+  arbitrary SQL stored in an attribute qualifier — worth confirming who can edit these attributes and
+  that the SQL is trusted.
+- **Security (low):** `MultiFileFieldType`/`MultiFileUpload` enforce the allowed-extension whitelist
+  and max-file count **client-side only** (JS pre-checks before the XHR upload). The actual
+  `/FileUploader.ashx` upload and `BinaryFileType` rules are the real gate; a crafted request could
+  bypass the client checks. Confirm the chosen `BinaryFileType` has appropriate server-side
+  restrictions if extension filtering matters for security (vs. UX).
+- **Improvement:** `MultiFileFieldType.GetEditValue` performs several `SaveChanges()` calls and
+  per-row `LoadAttributes()` inside a loop — workable for a handful of files, but chatty for large
+  sets. The shared-template Id is cached statically (`_sharedTemplateIdCache`), which is fine, but the
+  template is never re-validated if deleted out from under the cache.
+- **Improvement:** Removing files from a `MultiFileUpload` deletes the `AttributeMatrixItem` rows but
+  does not delete the orphaned `BinaryFile`s themselves; they remain in storage unless cleaned up
+  elsewhere.
+
+## Making Changes
+
+- To add a new field type, drop a `FieldType` subclass in `/FieldTypes/`, give it an edit control in
+  `/Controls/` implementing `IRockControl`, and (optionally) a `FieldAttribute` subclass in
+  `/Attributes/`; register it as a Rock Field Type in the admin UI. Add all files to the `.csproj`
+  `<Compile>` list. Follow an existing trio (e.g. `DynamicPhoneNumber*`) as a template.
+- Cascading-dropdown parsing/filtering lives entirely in `Helpers/KeyValueMatrix.cs`
+  (`BuildFromConfiguration` for parsing, `FormatValue` for display).
+- The multi-file template provisioning and row reconciliation live in `MultiFileFieldType`
+  (`EnsureSharedTemplate`, `GetEditValue`); the client-side upload/remove behavior is the inline JS in
+  `Controls/MultiFileUpload.cs` (`RegisterClientScript`).
+</content>
+</invoke>

--- a/Plugins/org.secc.Authentication/README.md
+++ b/Plugins/org.secc.Authentication/README.md
@@ -1,0 +1,134 @@
+# org.secc.Authentication
+
+> A passwordless **SMS one-time-code** authentication provider for Rock — texts a 6-digit code to a person's mobile number and logs them in with it.
+
+> **Doc tier: deep.** Small surface (one auth component + one login block) but it's a credential-issuing authentication path — documented at the deeper tier so the code lifecycle, rate limiting, and security trade-offs are explicit. Most SECC plugins use the lighter standard tier.
+
+## Overview
+
+Authentication lets a person sign in to Rock with their cell phone instead of a password: they enter their mobile number, Rock looks up the (single) owner of that number, generates a random 6-digit code, BCrypt-hashes it into a per-person `UserLogin`, and texts it to them. They type the code back and are logged in. It plugs into Rock's standard auth stack as an `AuthenticationComponent` (`Rock.Security.ExternalAuthentication.SMSAuthentication`) and ships one block (**SMS Login**) that drives the two-step UI. Used for low-friction member login on public-facing pages where a stored password is undesirable.
+
+## Project Info
+
+- **Project file:** `org.secc.Authentication.csproj`
+- **Root namespace:** `org.secc.Authentication`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block markup), via the `PostBuildEvent` `xcopy`.
+- **No /Migrations** — the auth component and block self-register through Rock's MEF / block discovery; the SMS Login page is referenced by Guid (`C137E7F2-…`) but not created by this plugin.
+
+## Project Layout
+
+```
+/                              SMSAuthentication.cs — the AuthenticationComponent + SMSRecords/SMSRecord rate-limit helpers
+/org_secc/Authentication/      SMSLogin.ascx (+ .ascx.cs) — the two-step phone-number / code login block
+/Properties/                   AssemblyInfo.cs
+```
+
+## How SMS Login Works
+
+The block and the component split the work: the block owns the UI and the final sign-in; the component owns code generation, the SMS send, validation, and rate limiting. Both the "generate" and "verify" steps re-derive the `UserLogin` from the phone number (`SMS_<personId>`), so there is no server-side session between the two postbacks.
+
+```mermaid
+flowchart TD
+    A[User enters mobile number<br/>SMSLogin block] --> B[btnGenerate_Click]
+    B --> C["SendSMSAuthentication(phone)"]
+    C --> D{GetNumberOwner:<br/>exactly one living<br/>person owns number?}
+    D -->|no / 0 / >1 / under MinimumAge| E[Show Resolve panel]
+    D -->|yes| F[Upsert UserLogin 'SMS_personId'<br/>generate 6-digit code<br/>BCrypt-hash into Password<br/>stamp LastPasswordChangedDateTime]
+    F --> G{SMSRecords.ReserveItems<br/>ip + phone not in flight?}
+    G -->|no| H[Log rate-limit exception, no text]
+    G -->|yes| I[Task.Run -> SendSMS<br/>exp. backoff delay, then send]
+    F --> J[Show Code panel]
+    J --> K[User enters code<br/>btnLogin_Click]
+    K --> L["Authenticate(userLogin, code)"]
+    L --> M{code <30 min old?<br/>attempts <=4?<br/>BCrypt.Verify?}
+    M -->|no| N[Increment FailedPasswordAttemptCount<br/>show error]
+    M -->|yes| O[CheckUser -> Authorization.SetAuthCookie<br/>redirect returnurl / RedirectPage]
+```
+
+**Conventions / contracts:**
+- The component is discovered by MEF: `[Export(typeof(AuthenticationComponent))]` + `[ExportMetadata("ComponentName", "SMS Authentication")]`, registered under the type name `Rock.Security.ExternalAuthentication.SMSAuthentication` (note: the class lives in the Rock namespace, not `org.secc`).
+- `ServiceType` is `External` and `RequiresRemoteAuthentication` is `true` — Rock treats it like a third-party provider. (OAuth's resource-owner grant special-cases this same type; see [org.secc.OAuth](../org.secc.OAuth/README.md).)
+- The OTP is the `UserLogin.Password`: a `Random.Next(100000, 999999)` value, BCrypt-hashed via the **BCrypt Cost Factor** attribute. The code's validity window is enforced off `LastPasswordChangedDateTime` (30 minutes), and the attempt cap off `FailedPasswordAttemptCount` (5).
+- One `UserLogin` per person, keyed `SMS_<person.Id>`. It is upserted on each generate (resets failed-attempt count, re-stamps the timestamp, sets `IsConfirmed = true`).
+- Phone-number ownership must resolve to **exactly one** living person; 0, >1, or deceased fails closed with a generic "There was an issue with your request" message.
+- Rate limiting is **in-process static state** (`SMSRecords`) keyed on IP + phone number — not persisted, so it resets on app-pool recycle and is per-server.
+
+## Components
+
+### Authentication Component — `SMSAuthentication`
+
+Category: standard Rock authentication providers (Admin Tools > Security > Authentication Services). Settings below show the attribute **name**; the code reads them by their space-stripped key (`SMS Login Page` -> `SMSLoginPage`, `BCrypt Cost Factor` -> `BCryptCostFactor`, `Minimum Age` -> `MinimumAge`).
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **SMS Login Page** | linked page (default `C137E7F2-DDB6-404F-AFD3-4D741E0DA43A`) | Page hosting the SMS Login block; used by `GenerateLoginUrl` to redirect into the flow. |
+| **BCrypt Cost Factor** | integer (default `11`) | Work factor for hashing the OTP. Higher = slower/more secure. |
+| **From** | defined value (`COMMUNICATION_SMS_FROM`), required | The SMS From number the code is sent from. |
+| **Message** | text, required | Body of the code text. `{{ password }}` merges in the 6-digit code; default also merges `OrganizationName`. |
+| **Minimum Age** | integer (default `13`) | Minimum age allowed to log in; `0` disables the check. Unknown age fails when a minimum is set. |
+
+Notable methods: `SendSMSAuthentication(phone)` (generate + send), `Authenticate(userLogin, code)` (verify), `GetNumberOwner(...)` (single-owner resolution + age gate). `EncodePassword`, `ChangePassword`, and `SetPassword` throw `NotImplementedException`; `IsReturningFromAuthentication` and the request-based `Authenticate` overload are no-ops that always return `false` (`SupportsChangePassword` is `false` and `ImageUrl()` returns `""`). Code generation is driven by the block, not by Rock's standard remote-auth round-trip.
+
+### Block — SMS Login (`org_secc/Authentication/SMSLogin.ascx`)
+
+Category in Rock: **SECC > Security**. Three panels (phone → code → resolve) in a single `UpdatePanel`. Client-side JS submits on Enter and auto-submits when 6 digits are entered.
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Prompt Message** | code editor (HTML) | Shown above the phone-number entry. |
+| **Resolve Number Page** | linked page, required | Where to send a user whose number couldn't be resolved (to add/fix a mobile number). |
+| **Resolve Message** | code editor (HTML) | Shown when the number can't be resolved to a single account. |
+| **Redirect Page** | linked page, required | Where to send on successful login (falls back to `returnurl`, then site default). |
+
+## Dependencies & Integrations
+
+- **Rock:** `AuthenticationComponent`, `UserLogin`/`UserLoginService`, `PhoneNumberService`, `RockSMSMessage`/`RockSMSMessageRecipient`, `Authorization.SetAuthCookie`, `DefinedValueCache`/`EntityTypeCache`, `ExceptionLogService`, `RockBlock`.
+- **Third-party:** `BCrypt.Net` (OTP hashing); the OTP text rides Rock's configured SMS transport (Twilio etc.).
+- **Cross-plugin:** none required. Related: [org.secc.OAuth](../org.secc.OAuth/README.md) explicitly permits this provider in its resource-owner grant.
+
+## Edge Cases & Constraints
+
+- **Number must map to exactly one living person.** `GetNumberOwner` rejects 0 matches, >1 matches, and deceased people — all with the same generic error (the **Resolve Number Page** is the escape hatch for shared/duplicate numbers).
+- **Code lifetime is 30 minutes, hard-coded.** `Authenticate` rejects any code whose `LastPasswordChangedDateTime` is older than 30 minutes (or null). Not configurable.
+- **Two failed-attempt caps exist and disagree.** The component rejects once `FailedPasswordAttemptCount > 4` (i.e. on the 6th attempt); the block's `CheckUser` separately checks `> 5`. Generating a new code resets the count to 0.
+- **Rate limiting is best-effort and in-memory.** `SMSRecords` reserves an IP+phone pair while a send is in flight and applies an exponential backoff (`2^count` ms) based on a rolling 1-hour window. State is static/per-process — it does not survive recycles and isn't shared across web servers. If a pair is already reserved, the request is dropped and logged (the user simply doesn't get a text).
+- **Send is fire-and-forget.** The text goes out on a `Task.Run(...)` `async void` (`SendSMS`); failures are logged but never surfaced to the user, who still sees the code-entry panel.
+- **Page is referenced, not created.** The default **SMS Login Page** Guid must already exist in the target Rock instance; this plugin ships no migration to create it.
+
+## Observations
+
+*Noticed while documenting — not a full audit; the auth path was the focus.*
+
+- **Security (review):** The OTP is generated with `new Random().Next(100000, 999999)` — `System.Random` is **not** a cryptographic RNG, and a fresh instance is seeded from the clock per call. Combined with a 6-digit space (~900k) and a 30-minute window, consider `RNGCryptoServiceProvider`/`RandomNumberGenerator` for code generation. (It is BCrypt-hashed at rest, which is good.)
+- **Security (review):** Lockout is per-issued-code, not durable — requesting a new code resets `FailedPasswordAttemptCount` to 0, so an attacker who can trigger generation can keep refreshing the 5-guess budget. The IP/phone rate limiter mitigates send-flooding but not guess-resetting. Worth confirming the abuse model is acceptable.
+- **Security (low):** Login resolution trusts an exact `PhoneNumber.Number` string match (`GetPhoneNumber` strips non-digits client-side). Numbers stored with country code / extension differences won't match; not a vulnerability but a UX/lookup gap that routes users to the Resolve page.
+- **Improvement:** `AuthenticateBcrypt` computes `currentCost = hash.Substring(4,2)...` and never uses it — dead code. `GetNumberOwner` calls `.ToList()` then `DistinctBy` in memory; fine for the expected tiny result set.
+- **Improvement:** `SendSMS`'s parameters are declared `(smsMessage, phoneNumber, ipAddress, delay)` but the call site passes `(smsMessage, ipAddress, phoneNumber, delay)` — the `ipAddress`/`phoneNumber` arguments are swapped. They're only used together in `ReleaseItems`, so release still works, but the names are misleading; worth aligning.
+
+## Extending
+
+To change how the code is generated, hashed, or validated, edit `SMSAuthentication.cs` — `SendSMSAuthentication` (issue) and `Authenticate` (verify) are the two halves. The block calls only those public methods plus `GetNumberOwner`, so a UI variant can reuse the component as-is:
+
+```csharp
+// New login surface reusing the component
+var sms = new Rock.Security.ExternalAuthentication.SMSAuthentication();
+if ( sms.SendSMSAuthentication( phone ) )      // issues + texts the code
+{
+    // ... collect the code from the user ...
+    var userLogin = new UserLoginService( rockContext ).GetByUserName( "SMS_" + personId );
+    if ( sms.Authenticate( userLogin, code ) ) // verifies window + attempts + BCrypt
+    {
+        Rock.Security.Authorization.SetAuthCookie( userLogin.UserName, true, false );
+    }
+}
+```
+
+No registration step is needed for the component — MEF discovers `[Export(typeof(AuthenticationComponent))]` at startup and renders its attributes in the authentication-services admin UI.
+
+## Making Changes
+
+- Code lifecycle, rate limiting, age/owner rules, and the SMS body live in `SMSAuthentication.cs`.
+- Login screen, panel flow, and the Enter/auto-submit JS live in `org_secc/Authentication/SMSLogin.ascx(.cs)`.
+- The **From** number, **Message**, **BCrypt Cost Factor**, and **Minimum Age** are component attributes (Admin Tools > Security > Authentication Services), not block settings.
+- This provider is allowed by [org.secc.OAuth](../org.secc.OAuth/README.md)'s resource-owner grant — coordinate changes to the `Rock.Security.ExternalAuthentication.SMSAuthentication` type name with that plugin.

--- a/Plugins/org.secc.ChangeManager/README.md
+++ b/Plugins/org.secc.ChangeManager/README.md
@@ -1,0 +1,96 @@
+# org.secc.ChangeManager
+
+> A change-request/approval framework that captures edits to any Rock entity as reviewable `ChangeRecord`s and applies (or reverses) them transactionally on approval.
+
+## Overview
+
+ChangeManager lets users propose edits to Rock data — a person's profile, phone numbers, addresses, attribute values — without writing them straight to the live record. Each submission becomes a `ChangeRequest` holding one or more `ChangeRecord` rows (the old/new value for a property, attribute, create, or delete). Public self-service blocks (profile edit, family-member removal) generate these requests; staff blocks review and approve them. Approved changes are applied to the target entity via reflection inside a DB transaction, and rejected ones can be undone. It's used for self-service profile updates where some people's edits auto-apply and others (staff, VIPs) get held for review.
+
+## Project Info
+
+- **Project file:** `org.secc.ChangeManager.csproj`
+- **Root namespace:** `org.secc.ChangeManager`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup), via the PostBuildEvent `xcopy`
+
+## Project Layout
+
+```
+/Model/        EF entities — ChangeRequest, ChangeRecord (+ services); BasicEntity (Hashids-keyed IEntity stub)
+/Data/         ChangeManagerContext (DbContext on RockContext, NullDatabaseInitializer) + base ChangeManagerService<T>
+/Utilities/    PropertyChangeEvaluators (extension methods that diff an entity into ChangeRecords); SecurityChangeDetail DTO
+/org_secc/ChangeManager/   UI blocks (.ascx + .ascx.cs)
+/Migrations/   Rock plugin migrations (tables, family-group column, campus-type defined value)
+```
+
+## Components
+
+### Models
+
+EF entities on `ChangeManagerContext` (shares the `RockContext` connection; initializer set to null — no auto-migration). Both are `Rock.Data.Model<T>`, `ISecured`, `IRockEntity`.
+
+| Entity | Table | Notes |
+|--------|-------|-------|
+| `ChangeRequest` | `_org_secc_ChangeManager_ChangeRequest` | One proposed change-set against an entity (`EntityTypeId` + `EntityId`). Holds requestor/approver aliases, comments, `IsComplete`, and an optional `FamilyGroupOfPersonAliasId` (head-of-household snapshot, for family-merge resilience). `PreSaveChanges` resolves the target entity's display name into `Name`. |
+| `ChangeRecord` | `_org_secc_ChangeManager_ChangeRecord` | A single field/attribute/create/delete within a request: `OldValue`/`NewValue` (JSON or string), `Property`, `Action` enum, `IsRejected`, `WasApplied`, and an optional `RelatedEntityType`/`RelatedEntityId` for changes to a related entity (e.g. a phone number on a person). |
+
+`ChangeRecordAction` enum: `Update (0)`, `Create (1)`, `Delete (2)`, `Attribute (3)`.
+
+`ChangeRequest.CompleteChanges(...)` is the core apply engine: inside a `BeginTransaction`, it applies pending records (set property via reflection, set attribute, create/delete related entity) and reverses any `WasApplied && IsRejected` records, committing only if no errors accumulate. Person email/phone changes are collected into a `SecurityChangeDetail` and, if any, launch the workflow named in the **`ChangeManagerSecurityWorkflow`** global attribute.
+
+### Utilities
+
+`PropertyChangeEvaluators` — extension methods on `ChangeRequest` that diff a proposed value against the current entity and append a `ChangeRecord` only when something actually changed:
+
+| Method | Purpose |
+|--------|---------|
+| `EvaluatePropertyChange(...)` | Overloaded for `string`, `int?`, `bool`, `Enum`, `DateTime?`, `IEntity`, `IEntityCache`; emits an `Update` record on a diff. |
+| `AddEntity(...)` | Emits a `Create` record (serialized new entity). |
+| `DeleteEntity(...)` | Emits a `Delete` record (serialized old entity). |
+| `EvaluateAttributes(...)` | Loads the persisted entity's attributes and emits an `Attribute` record per changed attribute value. |
+
+### Blocks
+
+Category in Rock: **SECC > CRM**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Change Managed Public Profile Edit (`CMPublicProfileEdit`) | Public self-service profile editor; writes edits as a `ChangeRequest` instead of directly. | Default Connection Status, Disable Name Edit, Address Type, Show Phone Numbers, Phone Types, Required Adult Phone Types, Require Adult Email Address, Show Communication Preference, Display Terms of Service (`DisplayTerms`) / Terms of Service Text (`TermsOfServiceText`), Show Campus Selector, Person Attributes (adults) / (children), Campus Types to Display (`CampusTypes`) |
+| Change Managed Profile Remove Family Member (`CMPublicProfileRemovePerson`) | Public block to move/remove a family member, recorded as a change request. | `DisplayPhone`, `DisplayEmail` |
+| Change Entry (`ChangeEntry`) | Staff/entry block to enter changes for later review; can auto-apply based on data views. | `AutoApply`, Approved Updaters Data View (`ApprovedDataView`), Blacklist Data View (`BlacklistDataView`), Workflow, `SimpleMode` |
+| Change Request Detail (`ChangeRequestDetail`) | Review a single request's records and approve/reject. | Blacklist Data View (`BlacklistDataView`), Workflow |
+| Change Requests (`ChangeRequests`) | Grid of all requests, filterable by entity type / completion. | Details Page (linked) |
+| Managed Attribute Values (`ManagedAttributeValues`) | Person-detail block to edit a category of person attributes via Change Manager. | Category (attribute category), Attribute Order |
+
+**Auto-apply gating:** `ChangeEntry` applies changes immediately when `AutoApply` is on, but a requestor in the **Blacklist Data View** is always held for review, and an **Approved Updaters Data View** overrides `AutoApply`. `ChangeRequests`/`ChangeRequestDetail` restrict non-`EDIT`-authorized users to requests where they are the requestor.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext` / `Rock.Data.DbContext`, `Rock.Data.Model<T>` + `ISecured`, EntityType/DefinedValue/GroupType caches, `Reflection.GetServiceForEntityType` (reflection-based entity service resolution), `IHasAttributes` (load/set/save attribute values), the workflow engine (`LaunchWorkflow`), `GlobalAttributesCache`, the Rock block/UI framework, plugin migrations (`Rock.Plugin`).
+- **Third-party:** `Hashids.net` (used only by `BasicEntity.IdKey`), EntityFramework 6.
+- **Cross-plugin:** none at build time.
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/`:
+
+- `001_Init` — creates `_org_secc_ChangeManager_ChangeRequest` and `_org_secc_ChangeManager_ChangeRecord` (keys, FKs to PersonAlias/EntityType, indexes).
+- `002_FamilyGroupOfPerson` — adds `FamilyGroupOfPersonAliasId` to `ChangeRequest` (head-of-household snapshot for family-merge cases).
+- `003_InternalCampusTypeValue` — seeds an "Internal" Campus Type defined value (`DF089AAE-…`).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** These blocks let users propose edits to live person/family data, and `CompleteChanges` applies them by reflecting over arbitrary entity properties and attributes. Confirm the review blocks (`ChangeRequestDetail`/`ChangeRequests`) are page/block-secured to trusted staff, that the **Blacklist Data View** is populated with staff/VIP records that must never auto-apply, and that `AutoApply` on `ChangeEntry` is set deliberately per-instance.
+- **Improvement:** `CompleteChanges` applies values through reflection (`SetProperty` via `PropertyInfo.GetSetMethod`, attribute set/save, related-entity create/delete) with no allow-list of editable properties — the property to write comes from the stored `ChangeRecord.Property`. The set of editable fields is bounded only by what the generating blocks emit; if a request can be crafted with an arbitrary `Property`, that breadth is worth confirming. Errors are accumulated into a list and the whole transaction rolls back on any failure, which is good — but the security-notice workflow only fires for person email/phone changes.
+- **Improvement:** `EvaluateAttributes` news up its own `RockContext` per call to reload the persisted entity, separate from any context the caller holds. Fine for one-offs, an extra round-trip in loops.
+
+## Making Changes
+
+- To change what the public editor exposes or how it builds requests, edit `org_secc/ChangeManager/CMPublicProfileEdit.ascx.cs`; the diffing helpers it calls live in `Utilities/PropertyChangeEvaluators.cs`.
+- The apply/reverse engine is `ChangeRequest.CompleteChanges` in `Model/ChangeRequest.cs` — add new `ChangeRecordAction` handling there and a matching evaluator in `PropertyChangeEvaluators`.
+- New tables/columns or seed data belong in a new numbered migration under `/Migrations/` — don't hand-edit migrations that have already run.
+- The security-notice workflow is keyed off the `ChangeManagerSecurityWorkflow` global attribute; related workflow helpers live in [org.secc.Workflow](../org.secc.Workflow/README.md).
+</content>
+</invoke>

--- a/Plugins/org.secc.CheckinMonitor/README.md
+++ b/Plugins/org.secc.CheckinMonitor/README.md
@@ -1,0 +1,137 @@
+# org.secc.CheckinMonitor
+
+> Staff-facing check-in admin blocks: room-ratio management, a live attendance monitor, mobile check-in printing, a cache inspector, and an advanced "Super" check-in/search tool.
+
+## Overview
+
+CheckinMonitor is Southeast's collection of staff/volunteer UI blocks that sit on top of the
+custom check-in stack in [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md). The blocks
+let staff manage room capacity and ratios, watch check-ins as they happen across all campuses,
+print mobile (parent-pickup) labels, inspect the custom check-in caches, and drive a manual
+"Super Checkin" desk that can add people, phone numbers, and PINs. There is no `.csproj` — these
+are RockWeb-compiled `.ascx` blocks that link against the FamilyCheckin assemblies at runtime.
+
+## Project Info
+
+- **Project file:** none — no `.csproj`; RockWeb-compiled `.ascx`/`.ascx.cs` blocks.
+- **Root namespace:** `RockWeb.Plugins.org_secc.CheckinMonitor`
+- **Target framework:** compiled in-place by RockWeb (.NET Framework 4.7.2).
+- **Deploys to:** `RockWeb/Plugins/org_secc/CheckinMonitor/` (the `.ascx` markup + code-behind).
+- **Cross-plugin dependency:** [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md) (cache, model, utilities).
+
+## Project Layout
+
+```
+/org_secc/CheckinMonitor/
+  CheckinMonitor.ascx        Room/ratio management (soft & firm thresholds, location labels)
+  LiveMonitor.ascx           Live, auto-refreshing feed of recent check-ins system-wide
+  MobileCheckinViewer.ascx   Lists active mobile check-in records for label printing
+  CacheInspect.ascx          Grid view + flush/verify of the FamilyCheckin custom caches
+  SuperCheckin.ascx          Advanced manual check-in desk (add person/phone/PIN, reprint)
+  SuperSearch.ascx           Phone/name keypad search that seeds the check-in workflow
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Check-in**.
+
+| Block | Base | Purpose |
+|-------|------|---------|
+| Check-In Monitor | `CheckInBlock` | Manage rooms: view/edit soft & firm room thresholds, room ratios, print a location label. |
+| Live Monitor | `RockBlock` | Auto-refreshing feed of the latest ~100 attendances today, a per-minute count, and a server CPU readout. |
+| Mobile Check-in Viewer | `CheckInBlock` | Lists active `MobileCheckinRecord`s for the current kiosk type and prints (aggregated) pickup labels. |
+| Cache Inspect | `RockBlock` | Browse/verify/flush the FamilyCheckin caches (occurrences, attendances, mobile records, kiosk types). |
+| Super Checkin | `CheckInBlock` | Manual check-in desk: search, edit attributes, add phone, add a PIN login, complete/reprint tags. |
+| Super Search | `CheckInBlock` | On-screen keypad searching by phone number or name; hands the result to the check-in workflow. |
+
+### Block Settings
+
+Keys in **bold** are the attribute keys used in code.
+
+#### Check-In Monitor
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Room Ratio Attribute Key** | text (default `RoomRatio`) | Location attribute key the ratio editor reads/writes. |
+| **Approved People** | data view (Person) | Members who may check in. |
+| **Location Label** | binary file (`CHECKIN_LABEL`) | Label printed for a location. |
+| **EnableHardLimit** | bool (default true) | Allow editing the firm/hard room limit on a location. |
+
+#### Live Monitor
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Volunteer Group Attribute** | attribute (Group) | Group attribute used by the monitor view. |
+
+#### Mobile Check-in Viewer
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Aggregated Label** | binary file (`CHECKIN_LABEL`) | Parent-pickup ("aggregated") label to print. |
+
+#### Super Checkin
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Connection Status** | defined value (Person Connection Status) | Connection status for newly created people. |
+| **Checkin Category** | attribute category (Person) | Person attribute category surfaced for editing. |
+| **Checkin Activity** | text (required) | Workflow activity name that completes check-in. |
+| **Reprint Activity** / **Child Reprint Activity** | text (required) | Activity names for reprinting the family / child tag. |
+| **SMS Phone** / **Other Phone** | defined value (Phone Type) | Phone type to save when SMS is / isn't enabled. |
+| **Allow Reprint** | bool (default false) | Allow reprinting parent tags from this page. |
+| **Approved People** | data view (Person) | People allowed to check in. |
+| **AllowNonApproved** | bool (default false) | Allow adults not in the approved list to check in. |
+| **Security Role Dataview** | data view (Person) | People in a security role; blocks adding a PIN for them (see Observations). |
+| **Data Error URL** | text | Iframe URL for data-error workflow (e.g. `WorkflowEntry/12?PersonId={0}`). |
+| **QRCodeCheckReprint** / **QRCodeCheckCheckin** | bool (default false) | Require a QR-code scan to complete a reprint / a super check-in. |
+| **ReprintSecurityGroup** | security role (default Staff Members) | Group allowed to reprint tags. |
+| **SuperCheckInGroup** | security role (required) | Group allowed to perform super check-in. |
+
+#### Super Search
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Add Family Option** | bool (default true) | Show an "Add New Family" button after search. |
+
+## Dependencies & Integrations
+
+- **Rock:** `CheckInBlock` / `RockBlock`, the Rock check-in workflow engine (`CurrentCheckInState`,
+  `ProcessActivity`), `RockContext` and Rock services (`AttendanceService`, `PersonService`,
+  `UserLoginService`, `DataViewService`, `GroupMemberService`), `AuthenticationContainer`
+  (`PINAuthentication`), binary-file labels, Lava merge fields, the Zebra print client
+  (`~/Scripts/CheckinClient/ZebraPrint.js`).
+- **Cross-plugin:** [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md) — `Cache`
+  (`OccurrenceCache`, `AttendanceCache`, `MobileCheckinRecordCache`, `CheckinKioskTypeCache`),
+  `Model` (`MobileCheckinRecord`/`MobileCheckinStatus`), and `Utilities`.
+- **Third-party:** Newtonsoft.Json (Mobile Check-in Viewer); `System.Diagnostics.PerformanceCounter`
+  (Live Monitor CPU readout).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (review):** In `SuperCheckin.mdPIN_SaveClick`, when the selected person is found in the
+  **Security Role Dataview** it shows a warning and hides the modal but does **not** `return` — code
+  execution falls through and still creates the `PINAuthentication` `UserLogin`. The guard intended
+  to block adding a PIN to security-role members appears ineffective; worth confirming and adding an
+  early `return`. (PINs are also only validated as numeric and length `> 7`.)
+- **Security (low):** This whole plugin lets staff create logins (PINs), edit person attributes/phone
+  numbers, and reprint tags. Confirm Rock **page/block security** for these blocks (and the configured
+  `SuperCheckInGroup` / `ReprintSecurityGroup`) is locked to trusted check-in staff.
+- **Improvement:** `LiveMonitor.OnLoad` calls `Thread.Sleep(200)` on the request thread to sample a
+  `PerformanceCounter` ("% Processor Time") on every load, and re-queries the last 100 attendances
+  each refresh. The CPU sample blocks the page and the counter is constructed (not disposed) per load.
+- **Improvement:** `LiveMonitor` special-cases a campus short code (`"920"` -> `"c920"`) inline for a
+  CSS icon class — a hardcoded campus assumption worth pulling into config.
+
+## Making Changes
+
+- Room thresholds / ratios and location-label printing live in `CheckinMonitor.ascx.cs`; the
+  firm-vs-soft logic keys off `FirmRoomThreshold` / `SoftRoomThreshold` and the `RoomRatio` location
+  attribute.
+- Manual check-in behavior (add person/phone/PIN, QR validation, reprint) is all in
+  `SuperCheckin.ascx.cs`; the workflow activity names it drives come from the **Checkin Activity** /
+  **Reprint Activity** block settings, so wiring it to a different check-in template is a config change.
+- The cache types browsed/flushed by `CacheInspect` are defined in
+  [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md), not here — add cache fields there.
+- Search input is seeded into the standard check-in workflow in `SuperSearch.ascx.cs`
+  (`ProcessActivity`), so the matching/family logic lives in the configured workflow, not this block.
+</content>
+</invoke>

--- a/Plugins/org.secc.Cms/README.md
+++ b/Plugins/org.secc.Cms/README.md
@@ -1,0 +1,122 @@
+# org.secc.Cms
+
+> A grab-bag of Southeast's custom Rock CMS blocks — login/profile UI, section/topper page chrome, content-channel and Twitter Lava, QR-code shortlinks, and cache/Font-Awesome admin tools — plus a styled `SectionZone` control.
+
+## Overview
+
+Cms is Southeast's collection of custom Rock **CMS blocks** used to build public-facing pages:
+login and account-management blocks, page-layout chrome (section headers, parallax topper), a
+timed content-channel renderer, a Twitter timeline block, a QR-code/shortlink generator, and a few
+admin utilities (cache-tag clearing, Font Awesome config). Most of the work lives in `.ascx`/`.ascx.cs`
+blocks that Rock compiles at runtime; the compiled assembly itself ships only the `SectionZone` Zone
+control and a single migration.
+
+## Project Info
+
+- **Project file:** `org.secc.Cms.csproj`
+- **Root namespace:** `org.secc.Cms`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup) — see the `PostBuildEvent` `xcopy`
+- **Build note:** Only `SectionZone.cs`, `Migrations/001_Init.cs`, and `AssemblyInfo.cs` are in the
+  `.csproj` `<Compile>` list. The `org_secc/Cms/*.ascx.cs` blocks are **RockWeb-compiled at runtime**,
+  not part of the assembly.
+
+## Project Layout
+
+```
+SectionZone.cs        Custom Rock Zone that wraps its contents in a styled <section> (reads a Section Header block's SectionType class)
+/org_secc/Cms/        UI blocks (.ascx + .ascx.cs) — login, profile, layout chrome, content, QR, admin tools
+/Migrations/          Single Rock plugin migration (adds HtmlContent.Name column)
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > CMS** (except where noted).
+
+| Block (class) | Category | Purpose |
+|---------------|----------|---------|
+| `LoginJS` | SECC > CMS | Builds the login / user menu via JavaScript. |
+| `LoginStatus` | SECC > Security | Shows the logged-in user's name with log-in/out + account links; optional new-workflow/connection notifications. |
+| `PublicProfileEdit` | SECC > CMS | Public block for users to view/edit their own (and family members') profile, addresses, phones, and attributes. |
+| `SectionHeader` | SECC > CMS | Renders a styled section header; its `SectionType` defined value drives the CSS class used by `SectionZone`. |
+| `Topper` | SECC > CMS | Parallax header/title with an optional info panel (`RockBlockCustomSettings`). |
+| `TimedContentChannel` | SECC > CMS | Renders a content channel's items through a Lava template with a per-item timer and cache window. |
+| `TwitterLava` | SECC > CMS | Fetches a Twitter user timeline (app-only OAuth2) and renders it via Lava. |
+| `ContactGroupLeaders` | SECC > CMS | Public form that emails (or SMS-es) a small group's leaders; optional communication-history record. |
+| `QRCodeGenerator` | SECC > CMS | Creates a `PageShortLink` from a URL and returns a QR code (via `GetQRCode.ashx`). |
+| `LinkListEditUsers` | SECC > CRM | Add/remove the people allowed to edit a given link-list content channel; manages a per-list security role group. |
+| `CacheTagsCheckList` | SECC > CMS | Admin block: checkboxes of cache tags to clear/expire as a group. |
+| `FontAwesomeSettings` | SECC > CMS | Admin block to configure Font Awesome. |
+
+Blocks are configured through standard Rock block attributes. Notable settings:
+
+- **ContactGroupLeaders** — `LeaderGroup` (default contact group), `DefaultRecipient`, `Subject`,
+  `Message Body`/`Response Message` (Lava), `Enable SMS` + `SMS From Number` + `SMS Message Body`,
+  `Save Communication History`, `Enabled Lava Commands`.
+- **PublicProfileEdit** — `Show Family Members`, `Address Type`, `Phone Numbers`, family/adult/child
+  `AttributeField`s, `Connection Status` for new people.
+- **LoginStatus** — `Logged In Page List` (key/value, Lava links), `Enable Notifications`,
+  `ConnectionRequestMaxDays`, `WorkflowActivityMaxDays`.
+- **TimedContentChannel** — `Content Channel`, `Timer Attribute Key`, `Maximum Cache` (seconds),
+  `Lava`, `Enabled Lava Commands`.
+- **QRCodeGenerator** — `SiteField` (for the shortlink token), minimum-token-length `IntegerField`,
+  a `FileField`, and a URL `TextField`.
+- **CacheTagsCheckList** — `Cache Tags` (`DefinedValueField` on the Cache Tags defined type, multi).
+
+### Controls
+
+| Type | Purpose |
+|------|---------|
+| `SectionZone` (`: Rock.Web.UI.Controls.Zone`) | A Rock Zone that renders its block content inside a `<section>` whose CSS class comes from the contained **Section Header** block's `SectionType` defined value (`ClassName` attribute). |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockBlock` / `RockBlockCustomSettings`, the Rock Zone/UI framework, `RockContext` and
+  Rock services (`PageShortLinkService`, `GroupService`, `AuthService`, communication services),
+  defined types/values, attribute framework, `Rock.Plugin` migrations.
+- **Third-party APIs:** Twitter (`api.twitter.com` — app-only OAuth2 bearer token via the
+  `/oauth2/token` endpoint, then `1.1/statuses/user_timeline.json`) in `TwitterLava`.
+- **Other:** Newtonsoft.Json, EntityFramework 6, DotLiquid (Lava). QR rendering is delegated to
+  Rock's `GetQRCode.ashx` handler, not generated in-plugin.
+- **Cross-plugin:** none required at build time. See [org.secc.QRManager](../org.secc.QRManager/README.md)
+  for the other (person-centric) QR path.
+
+## Migrations
+
+Ships a single Rock plugin migration under `/Migrations/`:
+
+- `001_Init` (`MigrationNumber 1`, `1.13.0`) — adds a nullable `Name NVARCHAR(100)` column to the
+  core `HtmlContent` table (idempotent; guarded by an `INFORMATION_SCHEMA` check).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (review):** `ContactGroupLeaders` and `PublicProfileEdit` are **public-facing** blocks
+  that send communications / edit person + family data. Confirm anti-abuse expectations (who can
+  email a group's leaders, rate limiting) and that profile edits are scoped to the current user's
+  own family. `LinkListEditUsers` creates/edits **security role groups** and `Auth` rows — make sure
+  that block is restricted to trusted staff.
+- **Improvement:** `TwitterLava` reaches an external API (`api.twitter.com` v1.1) from inside a CMS
+  block. The v1.1 `statuses/user_timeline` endpoint has been deprecated/retired by X/Twitter, so this
+  block may no longer return data — worth confirming it still works or retiring it.
+- **Improvement:** `SectionZone.RenderControl` walks the control tree matching block type names with
+  `GetType().ToString().Contains("org_secc_cms_sectionheader")` (string matching on the runtime-compiled
+  type name). This is fragile to renames/namespace changes; a type/interface check would be sturdier.
+- **Improvement:** `AssemblyInfo.cs` still carries the scaffolded `AssemblyProduct "Cms"` and
+  `Copyright © 2016` with an empty `AssemblyCompany` rather than Southeast Christian Church.
+
+## Making Changes
+
+- To change a block's behavior or markup, edit the matching `*.ascx` / `*.ascx.cs` in
+  `org_secc/Cms/`; these are runtime-compiled by RockWeb (no rebuild of the plugin assembly needed),
+  but the `PostBuildEvent` `xcopy` is what stages them into `RockWeb/Plugins/org_secc/`.
+- Section styling is split between `SectionHeader` (sets the `SectionType` defined value) and
+  `SectionZone.cs` (reads it to pick the `<section>` CSS class) — change both together. `SectionZone`
+  is in the compiled assembly, so editing it requires a rebuild.
+- New schema/data belongs in a new numbered migration under `/Migrations/` — don't hand-edit
+  `001_Init`, which has already run.
+- Related: [org.secc.QRManager](../org.secc.QRManager/README.md) (person QR/Fast-Pass filters and
+  endpoint).

--- a/Plugins/org.secc.Communication/README.md
+++ b/Plugins/org.secc.Communication/README.md
@@ -1,0 +1,122 @@
+# org.secc.Communication
+
+> SMS/keyword administration, communication-list tooling, schedule-reminder jobs, and a Twilio message-history sync for Southeast's messaging.
+
+## Overview
+
+This plugin bundles Southeast's messaging extensions: admin blocks for managing Twilio-backed
+phone numbers and their keywords (via an external SECC Messaging API), self-service and staff
+communication-list tooling, a job that builds reminder communications ahead of a schedule, and a
+job/block that pulls Twilio SMS delivery history into a local `TwilioHistory` table for reporting.
+It talks to a SECC-hosted Messaging API (REST) for phone/keyword data and directly to Twilio for
+message history.
+
+## Project Info
+
+- **Project file:** `org.secc.Communication.csproj`
+- **Root namespace:** `org.secc.Communication`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup)
+- **Cross-plugin dependency:** `org.secc.DevLib` (`SettingsComponent` infrastructure)
+
+## Project Layout
+
+```
+/Components/        MessagingServiceSettings — DevLib SettingsComponent (API url/key, SMS defined type, approver roles)
+/Data/              CommunicationDataContext + generic CommunicationDataService<T>
+/Messaging/         MessagingClient DTOs (Keyword, MessagingPhoneNumber, MessagingPerson, ...) + reorder item
+/Model/             TwilioHistory entity + TwilioHistoryService (maps Twilio MessageResource -> entity)
+/Jobs/              SendScheduleReminder, SyncTwilioHistory (SycnTwilioHistory) Quartz jobs
+/Twilio/            TwilioDownloader — pulls Twilio MessageResource records via the SDK
+/Migrations/        Rock plugin migrations (TwilioHistory table + indexes)
+/org_secc/Communication/   UI blocks (.ascx + .ascx.cs)
+MessagingClient.cs  REST client for the external SECC Messaging API
+SECCMessagingSettings.cs   Plain settings POCO returned by the settings component
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Communication**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Communication List Wizard | Build a communication targeted at a public communication-list group. | (none) |
+| Manage Communication Lists | Let users manage their communication-list subscriptions; can confirm via SMS keyword. | `AttributeKey` (Type), `KeywordKey` (Keyword), `FromSMSNumber` (confirmation SMS from) |
+| Messaging Phone Numbers | List active phone numbers from the SECC Messaging API. | `DetailPage` (linked page) |
+| Messaging Phone Number Detail | View/edit a phone number and its keywords via the Messaging API. | (none) |
+| Messaging Phone Number Keywords | List/manage keywords for a phone number, with an approval flow. | `ShowFilter` (bool, default true), `EnforceResponseLimit` (bool, default true) |
+| Sync Twilio History | Manually trigger a Twilio history sync for a date range. | (none) |
+
+The Messaging blocks call `MessagingClient`, which reads its base URL and function key from the
+**SECC Messaging Settings** component.
+
+### Jobs
+
+| Job (class) | Purpose | Key settings |
+|-------------|---------|--------------|
+| `SendScheduleReminder` (DisplayName **SECC \| Send Schedule Reminders**) | A configured number of days before a schedule's occurrence, create Approved Email and/or SMS communications from a `SystemCommunication` template to everyone in a dataview. | `Schedule`, `CommunicationTemplate`, `DistributionDataview` (Person dataview), `DaysBeforeToSend` (default 1), `SendTime` (default `08:00 am`), `CommunicationMethod` (Email/SMS check-list; empty = all) |
+| `SycnTwilioHistory` (no `[DisplayName]` — registered under the class name) | Loop back `DaysBack` days (default 2) and upsert each day's Twilio messages into `TwilioHistory`. | `DaysBack` (default 2) |
+
+### Settings Component
+
+`MessagingServiceSettings` (exported as a DevLib `SettingsComponent`, display name **SECC Messaging
+Settings**) holds the integration config consumed by `MessagingClient`.
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **MessagingApiUrl** | url (required) | Base URL of the SECC Messaging API. |
+| **MessagingApiKey** | encrypted text (required) | Function key; decrypted before use. |
+| **SMSDefinedType** | defined type | "Twilio SMS Phone Numbers" defined type (default Guid = `COMMUNICATION_SMS_FROM`). |
+| **KeywordApproverRoles** | group list | Security roles allowed to approve keyword updates. |
+
+### Migrations-driven data
+
+`TwilioHistory` (`_org_secc_Communication_TwilioHistory`) stores synced Twilio messages: `SID`,
+`Body`, `DateCreated`/`DateSent`, `Direction`, `To`/`From`, `Status`, `Price`, `NumberOfSegments`.
+`Direction` and `Status` are persisted as a local enum mapping (see `TwilioHistoryService`) so the
+Twilio SDK enums aren't needed to read the data.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, Rock job framework (Quartz `IJob`), `CommunicationService` /
+  `SystemCommunicationService`, `ScheduleService`, `DataViewService`, the block/UI framework, and
+  the Twilio `TransportComponent` (read for the account SID/token).
+- **Third-party:** Twilio .NET SDK (`MessageResource.Read`), RestSharp (Messaging API calls),
+  Newtonsoft.Json.
+- **External service:** SECC Messaging API (REST) for phone-number and keyword CRUD/reorder.
+- **Cross-plugin:** [org.secc.DevLib](../org.secc.DevLib/README.md) (`SettingsComponent`).
+
+## Migrations
+
+- `001_Init` — creates `_org_secc_Communication_TwilioHistory` (PK, person-alias FKs, Guid index).
+- `002_Index` — adds non-unique indexes on `SID` and `DateCreated`.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** `MessagingClient` passes the decrypted Messaging API function key as a `code`
+  query-string parameter on every request (`?code={MessagingKey}`). Query-string secrets can land
+  in proxy/server logs; worth confirming the API can't accept the key via header instead, and that
+  the configured URL is HTTPS.
+- **Improvement:** The job class is misspelled `SycnTwilioHistory` (typo for "Sync") — renaming the
+  class would break the existing scheduled-job registration in the database, so review before
+  changing.
+- **Improvement:** `SendScheduleReminder.Execute` opens one `RockContext` and then
+  `CreateCommunications` opens a second, and `TwilioDownloader.SyncItems` opens a fresh
+  `RockContext` per message inside its loop (`MessagingClient` likewise news up a `RestClient` per
+  call). Fine for jobs/one-offs but wasteful at scale.
+
+## Making Changes
+
+- To change phone/keyword admin behavior, edit the matching `*.ascx.cs` under
+  `org_secc/Communication/`; remote calls go through `MessagingClient.cs`. To change which API it
+  hits, update the **SECC Messaging Settings** component, not code.
+- Reminder-communication logic lives in `Jobs/SendScheduleReminder.cs`; Twilio history sync lives
+  in `Jobs/SyncTwilioHistory.cs` + `Twilio/TwilioDownloader.cs`.
+- New columns on `TwilioHistory` need a matching property in `Model/TwilioHistory.cs` and a new
+  numbered migration under `/Migrations/` (don't hand-edit migrations that have already run).
+- Related: [org.secc.Workflow](../org.secc.Workflow/README.md) (the `SMS Send` workflow action and
+  Twilio Lookup action).

--- a/Plugins/org.secc.Connection/README.md
+++ b/Plugins/org.secc.Connection/README.md
@@ -1,0 +1,132 @@
+# org.secc.Connection
+
+> Public-facing volunteer signup blocks that turn Rock connection opportunities into configurable, partition-driven signup pages.
+
+## Overview
+
+This is Southeast's volunteer "Signup Wizard" plugin (packaged as `SignupWizard.plugin`). It
+provides Rock blocks that let a person browse and sign up for connection opportunities from the
+public website: a wizard block that renders a configurable, multi-partition signup grid (campus /
+defined-type / role / schedule) via Lava, and a form block that captures the registrant, matches or
+creates the person, and writes a `ConnectionRequest`. A third block (Opportunity Search) is a Rock
+opportunity-search variant kept in source but excluded from the packaged plugin.
+
+## Project Info
+
+- **Packaged plugin:** `SignupWizard.plugin` (built by `BuildPlugin.ps1`, zipped via 7-Zip)
+- **Root namespace:** `org.secc.Connection`
+- **Build model:** No `.csproj` / compiled assembly — block code-behind (`.ascx.cs`) compiles in
+  RockWeb; the plugin ships markup + Lava only.
+- **Deploys to:** `RockWeb/Plugins/org_secc/Connection/` (block `.ascx`/`.ascx.cs`, Lava templates,
+  CSS)
+
+## Project Layout
+
+```
+/org_secc/Connection/
+  VolunteerSignupWizard.ascx(.cs)            Configurable signup-grid block (RockBlockCustomSettings)
+  VolunteerSignupFormConnections.ascx(.cs)   Registrant form → person match/create → ConnectionRequest
+  ConnectionOpportunitySearch.ascx(.cs)      Opportunity search block (excluded from the .plugin package)
+  VolunteerSignupWizard.css                  Styles for the card layouts
+  VolunteerGenius.lava / VolunteerGenius/    "Genius" table-style signup output
+  CardPage.lava       / CardPage/            Single-page card-panel output
+  CardWizard.lava     / CardWizard/          Animated left-to-right card output (Single/Multiple mode)
+BuildPlugin.ps1                              Packages /org_secc into SignupWizard.plugin
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Connection**.
+
+| Block | Type | Purpose |
+|-------|------|---------|
+| Volunteer Signup Wizard | `RockBlockCustomSettings` | Renders a configurable signup grid from a set of partitions (campus / defined type / role / schedule) and a selectable Lava output template. |
+| Volunteer Signup Form - Connections | `RockBlock` | Collects a registrant, matches or creates the person, and creates a `ConnectionRequest` for the chosen opportunity. |
+| Connection Opportunity Search | `RockBlock` | Lists active opportunities for a configured connection type with name/campus/attribute filters. Present in source but removed by `BuildPlugin.ps1`, so not shipped in the `.plugin`. |
+
+### Block Settings
+
+**Volunteer Signup Wizard** — settings are edited through the block's custom-settings panel:
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Settings** | code (JSON) | Serialized `SignupSettings` (partitions, entity type/guid, signup page). |
+| **Counts** / **Groups** | key-value list | Count and group maps used to build the partition tree. |
+| **Lava** | code | Output template; defaults to a switch that `include`s `VolunteerGenius`, `CardPage`, or `CardWizard`. |
+| **Enable Debug** | bool (default false) | Show available Lava merge fields. |
+
+**Volunteer Signup Form - Connections** — standard block attributes:
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| Display Phone / Birthdate / Comments | bool | Toggle form fields. |
+| **Connect Button Text** | text (default "Connect") | Submit button label. |
+| **Lava Template** | code (Lava) | Response message; default `OpportunityResponseMessage.lava`. |
+| Enable Campus Context | bool (default true) | Use page campus context as a filter. |
+| **Connection Status** | defined value | Status for newly created individuals (default Web Prospect). |
+| **Record Status** | defined value | Record status for newly created individuals (default Pending). |
+| **UrlKeys** / **FormKeys** | text (CSV) | Group-member attribute keys set from the URL / shown as edit controls. |
+| Display Add Another | bool (default false) | Show "Connect and Add Another". |
+| Comment label text / Comments Required | text / bool | Comment box label and requirement. |
+
+**Connection Opportunity Search** — `Lava Template`, `Enable Debug`, `Enable Campus Context`,
+`Set Page Title`, `Display Name/Campus/Attribute Filters`, `Detail Page` (linked page),
+`Connection Type Id` (integer).
+
+### Lava Output Templates
+
+The wizard's `Lava` setting selects one of three prebuilt outputs. Each delegates row rendering to
+a `Partition.lava` partial in a matching folder; `CardPage/` and `CardWizard/` additionally carry
+per-partition-type partials (`CardCampus`, `CardDefinedType`, `CardRole`, `CardSchedule`), while
+`VolunteerGenius/` has only `Partition.lava`.
+
+| Template | Output style |
+|----------|--------------|
+| `VolunteerGenius.lava` | Structured table, similar to common signup-genius tools. |
+| `CardPage.lava` | Single page of card panels (best for 1–2 partitions). |
+| `CardWizard.lava` | Animated left-to-right cards; `CardWizardMode` `Single` or `Multiple` (default `Single`). |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, connection model (`ConnectionRequest`, `ConnectionOpportunity`,
+  `ConnectionType`), `PersonService` (`FindPersons`, `SaveNewPerson`), `GroupService`,
+  `GroupTypeRoleService`, `ScheduleService`, defined types/values, `HistoryService`, the Rock
+  block/Lava framework, campus context.
+- **Cross-plugin:** [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) — the form loads it
+  **reflectively** (`org.secc.PersonMatch.Extension.GetByMatch`) for person matching, falling back
+  to `PersonService.FindPersons` when the assembly isn't present.
+- No third-party APIs.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** *Volunteer Signup Form - Connections* is a public-facing block that, on
+  submit, will **create a new `Person` and a `ConnectionRequest`** when no match is found
+  (`PersonService.SaveNewPerson` at `VolunteerSignupFormConnections.ascx.cs:321`). Person matching
+  uses name + email/birthdate, so unauthenticated form posts can both enumerate-by-side-effect and
+  add records. Confirm the page is intended for anonymous use, and consider spam/rate protection
+  (e.g. CAPTCHA) — worth confirming.
+- **Security (low):** The form sets group-member attributes from URL parameters via the `UrlKeys`
+  setting (`PageParameter(urlKey)`). Only keys the admin lists are honored, but those values are
+  attacker-controllable in the link; review which attributes are exposed this way.
+- **Improvement:** Several services are constructed with their own `new RockContext()` inline
+  (e.g. `GroupTypeRoleService`, `ScheduleService`, `DefinedTypeService`) rather than reusing one
+  per request, so a single render/bind can spin up multiple contexts. Acceptable, but tidy-able.
+- **Improvement:** `ConnectionOpportunitySearch` is shipped in source but explicitly deleted by
+  `BuildPlugin.ps1` before packaging. If it's genuinely unused it could be removed; if it's meant
+  to ship, the build script's `rm` line is hiding it. Worth confirming intent.
+
+## Making Changes
+
+- To change the signup grid's appearance, edit the Lava in `VolunteerGenius/`, `CardPage/`, or
+  `CardWizard/` (the wizard's `Lava` block setting chooses which one is `include`d); copy a template
+  rather than editing the defaults, as the in-code default comment advises.
+- To change registrant capture, person matching, or `ConnectionRequest` creation, edit
+  `VolunteerSignupFormConnections.ascx.cs` (`btnConnect_Click`).
+- Person-matching behavior lives in [org.secc.PersonMatch](../org.secc.PersonMatch/README.md); this
+  plugin only calls into it reflectively.
+- Re-package with `BuildPlugin.ps1` (Windows + 7-Zip) — note it intentionally excludes
+  `ConnectionOpportunitySearch.ascx*` from the `.plugin`.

--- a/Plugins/org.secc.ConnectionCards/README.md
+++ b/Plugins/org.secc.ConnectionCards/README.md
@@ -1,0 +1,87 @@
+# org.secc.ConnectionCards
+
+> A Rock block that ingests a scanned PDF sheet of physical connection cards, slices it into a grid of per-card images, and launches a workflow for each one.
+
+## Overview
+
+ConnectionCards digitizes the paper "connection card" sheets that ministries hand out and collect.
+Staff scan a full sheet to PDF and upload it to the block; the block rasterizes the PDF to a PNG,
+lets the user rotate and set a row/column grid, then chops the image into one binary file per card
+and launches a configured workflow for each card (so they can be reviewed/keyed individually).
+
+## Project Info
+
+- **Project file:** `org.secc.ConnectionCards.csproj`
+- **Root namespace:** `org.secc.ConnectionCards`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `Ghostscript.NET.dll`) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup)
+
+## Project Layout
+
+```
+/org_secc/ConnectionCards/   ConnectionCardEntry  — upload / rotate / crop UI block (.ascx + .ascx.cs)
+/Utilities/                  ConnectionCardsUtilties — PDF→image, rotate, grid-chop, whitespace-crop helpers
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Connection Cards**.
+
+| Block | Purpose |
+|-------|---------|
+| Connection Card Entry | Upload a scanned PDF sheet, preview/rotate/crop it, chop it into a grid, and launch a workflow per card. |
+
+Block settings:
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **WorkflowType** | WorkflowTypeField | Workflow launched once per chopped card (named "New Connection Card Workflow"); passes `Initiator` = current person alias Guid. |
+| **BinaryFileType** | BinaryFileTypeField | Binary file type assigned to the rasterized sheet/cards. |
+| **cols** | IntegerField ("Number of Columns") | Default column count for the chop grid (pre-fills the Columns control). |
+| **rows** | IntegerField ("Number of Rows") | Default row count for the chop grid (pre-fills the Rows control). |
+
+### Utilities
+
+`ConnectionCardsUtilties` (static helpers used by the block):
+
+| Method | Purpose |
+|--------|---------|
+| `ConvertPDFToImage` | Rasterizes page 1 of the uploaded PDF to a 96-dpi PNG `BinaryFile` via Ghostscript. |
+| `RotateImage` | Rotates the stored image 90/270 and saves it back. |
+| `ChopImage` | Splits the image into `cols` x `rows` cells, whitespace-crops each, and persists one `BinaryFile` per cell. |
+| `Crop` | Trims surrounding white border from a single card bitmap (scans rows/columns, averaging each pixel's red channel and treating an average > 235 as "white"). |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, `BinaryFileService` / `BinaryFileTypeService`, `BinaryFile`, the Rock block/UI framework (`RockBlock`, `FileUploader`), and the workflow engine (`LaunchWorkflow`).
+- **Third-party:** `Ghostscript.NET` (PDF rasterization — requires the native Ghostscript runtime on the server), `System.Drawing` (image rotate/crop/PNG output).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** `ConvertPDFToImage` only ever rasterizes **page 1** (`rasterizer.GetPage( ..., 1 )`).
+  A multi-page scanned PDF silently drops every page after the first — worth confirming sheets are
+  always single-page.
+- **Improvement:** `fMainSheet_FileUploaded` guards with `mainSheetId != null || mainSheetId != 0`,
+  which is always true (an `||` that can never be false). The intended check was likely
+  `!= null && != 0`; as written it relies on the later `binaryFileService.Get(...) != null` to bail.
+- **Improvement:** The chop loop in `ChopImage` clones `new Rectangle( x + 4, y + 4, elementWidth - 4, elementHeight - 4 )`
+  and `Crop` calls `GetPixel` per pixel across the whole cell. For large/high-dpi sheets this is slow
+  and the `+4`/`-4` insets can throw if a cell is near the image edge; review bounds for non-evenly-divisible sizes.
+- **Improvement:** `Ghostscript.NET` depends on a native Ghostscript install being present on the
+  server; failures there surface only at upload time. Worth documenting the server prerequisite.
+- **Improvement:** `RotateImage` writes the rotated PNG into a `MemoryStream` declared in a `using`
+  block, assigns it to `inputFile.ContentStream`, then calls `SaveChanges()` — the stream is
+  disposed when the `using` exits, so whether the rotated bytes persist depends on Rock reading the
+  stream before disposal. Worth confirming rotation actually survives a save.
+
+## Making Changes
+
+- The upload → rotate → crop → chop flow lives in `org_secc/ConnectionCards/ConnectionCardEntry.ascx.cs`;
+  the image math (rasterize, rotate, chop, whitespace-crop) lives in `Utilities/ConnectionCardsUtilties.cs`.
+- The per-card workflow is configured via the block's **WorkflowType** setting and launched in
+  `btnCrop_Click`; the downstream review/keying logic lives in that workflow, not in this plugin.
+  See [org.secc.Workflow](../org.secc.Workflow/README.md) for related workflow actions.

--- a/Plugins/org.secc.ConnectionsDigest/README.md
+++ b/Plugins/org.secc.ConnectionsDigest/README.md
@@ -1,0 +1,115 @@
+# org.secc.ConnectionsDigest
+
+> A single scheduled job that emails each connector a periodic digest of their connection requests (new, active, idle, critical) for the selected opportunities.
+
+## Overview
+
+ConnectionsDigest ships one Rock scheduled job (`ConnectionsDigest`) that scans connection
+requests across a configured set of connection opportunities, groups them by the assigned
+connector, and sends each connector a summary email. The email rolls up counts of new, active,
+idle, and critical requests since the job's last run. It's used to keep connectors aware of
+requests assigned to them without their having to poll the Rock connection board.
+
+## Project Info
+
+- **Project file:** `org.secc.ConnectionsDigest.csproj`
+- **Root namespace:** `org.secc.ConnectionsDigest` (note: the `ConnectionsDigest` class itself is
+  declared in namespace `org.secc.Jobs`)
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly, via a PostBuildEvent `xcopy` that copies
+  `bin\Debug\org.secc.ConnectionsDigest.*` — note it copies the Debug output unconditionally,
+  regardless of build configuration)
+
+## Project Layout
+
+```
+ConnectionsDigest.cs                         The scheduled job (Quartz IJob)
+/Migrations/20180629120000_InitialCreate.cs  Installs the "Connection Digest Email" SystemEmail
+/Properties/AssemblyInfo.cs                  Assembly metadata
+org.secc.ConnectionsDigest.csproj            Project file
+packages.config                              NuGet packages (EntityFramework 6.1.3)
+App.config                                   App config
+BuildPlugin.ps1                              Plugin packaging script
+```
+
+## Components
+
+### Jobs
+
+A Quartz `IJob` decorated `[DisallowConcurrentExecution]`; wired up as a Rock Job (Admin > System
+Settings > Jobs) and configured through the job attributes below (read from the `JobDataMap`).
+
+| Job (class) | Purpose | Key settings |
+|-------------|---------|--------------|
+| `ConnectionsDigest` | Group active/future-follow-up connection requests by connector and email each connector a digest. | Connection Opportunities, Email, Save Communication History |
+
+Configuration attributes:
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **ConnectionOpportunities** | custom checkbox list | Opportunities to include; values are opportunity Guids (sourced via SQL on `ConnectionOpportunity WHERE IsActive = 1`). |
+| **Email** | `SystemCommunicationField` (required) | The communication template sent to connectors. (See Observations — the seeded template ships as a legacy `SystemEmail` row, not a `SystemCommunication`.) |
+| **SaveCommunicationHistory** | bool (default false) | If true, persists a communication record to each recipient's profile. |
+
+What the job selects and the merge fields it exposes to the email template:
+
+- Considers requests in `ConnectionState.Active`, plus `FutureFollowUp` requests whose
+  `FollowupDate` is before midnight today, that have a `ConnectorPersonAliasId` set.
+- Groups by connector person; for each, computes **new** (created since `job.LastRunDateTime`),
+  **idle**, and **critical** (`ConnectionStatus.IsCritical`) request sets.
+- A request is **idle** when its newest `ConnectionRequestActivity.CreatedDateTime` is older than
+  `ConnectionType.DaysUntilRequestIdle` days ago — or, if it has no activities at all, when its own
+  `CreatedDateTime` is older than that threshold. Note the threshold lives on the
+  `ConnectionType` (`cr.ConnectionOpportunity.ConnectionType.DaysUntilRequestIdle`), not on the
+  opportunity.
+- Merge fields passed to the template: `ConnectionOpportunities`, `ConnectionRequests`,
+  `NewConnectionRequests`, `IdleConnectionRequestIds`, `CriticalConnectionRequestIds`, `Person`,
+  `LastRunDate`.
+
+## Dependencies & Integrations
+
+- **Rock:** Quartz job framework (`IJob`, `JobDataMap`), `RockContext`, `ConnectionRequestService`,
+  `PersonService`, `ServiceJobService`, Rock communication (`RockEmailMessage`,
+  `RockEmailMessageRecipient`), Lava merge fields (`Rock.Lava.LavaHelper`), plugin migrations
+  (`Rock.Plugin`). Project references `Rock`, `Rock.Common`, and `DotLiquid` (the Lava engine).
+- **NuGet:** EntityFramework 6.1.3.
+- No third-party APIs.
+
+## Migrations
+
+Ships one Rock plugin migration under `/Migrations/`:
+
+- `20180629120000_InitialCreate` (`MigrationNumber 1`, `1.7.0`) — inserts the **"Connection Digest
+  Email"** `SystemEmail` (Guid `10059716-8B49-46EA-BEDF-AE388DE9F7FF`) with the full digest Lava
+  template under the `Plugins` category. `Down()` deletes that row by Guid.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** The job reads its Rock Job Id from `context.JobDetail.Description`
+  (`Convert.ToInt16( context.JobDetail.Description )`) to look up `LastRunDateTime`. This is fragile
+  — it assumes the job's Description field is set to the numeric Job Id, and overloads a free-text
+  field for an identifier. Worth confirming this convention is documented wherever the job is
+  configured.
+- **Inconsistency:** The `Email` job attribute is a `[SystemCommunicationField]` (picks a
+  `SystemCommunication`), but the migration seeds a row in the legacy **`SystemEmail`** table and
+  the job sends via `new RockEmailMessage( systemEmail.Value )`. So the seeded template the picker
+  is presumably meant to select is in the wrong entity table — an admin would have to recreate it
+  as a SystemCommunication for the picker to find it.
+- **Improvement:** The migration's inserted Lava template hardcodes production URLs
+  (`https://rock.secc.org/page/407`, `/page/408`) and page Ids, so the template is
+  environment-specific and won't link correctly in non-prod or if those pages change.
+- **Improvement:** `AssemblyInfo.cs` still carries the default scaffolded company/copyright
+  (`"Microsoft"`, `"Copyright © Microsoft 2017"`) rather than Southeast Christian Church, despite
+  the source-file copyright header naming SECC.
+
+## Making Changes
+
+- To change which requests are summarized or how new/idle/critical sets are computed, edit the
+  LINQ in `ConnectionsDigest.cs`; the merge fields it adds drive what the email template can show.
+- To change the email's appearance, edit the **"Connection Digest Email"** SystemEmail in Rock
+  (or ship a new numbered migration that updates the template — don't hand-edit the existing one
+  that has already run).
+- This job lives in namespace `org.secc.Jobs`; sibling/related scheduled jobs are in
+  [org.secc.Jobs](../org.secc.Jobs/README.md).

--- a/Plugins/org.secc.CustomIcons/README.md
+++ b/Plugins/org.secc.CustomIcons/README.md
@@ -1,0 +1,96 @@
+# org.secc.CustomIcons
+
+> Ships a Southeast-branded icon webfont (`se-*` classes) and the LESS that wires it into Rock's Font Awesome stack.
+
+## Overview
+
+CustomIcons is a static front-end resource plugin, not a behavioral one. It bundles an
+IcoMoon-generated icon font (Southeast ministry/brand glyphs) plus the LESS needed to register
+the `@font-face` and expose `se-*` CSS classes, then hooks that LESS into Rock's Font Awesome
+override file so the glyphs are usable anywhere Rock renders an icon (block icons, page icons,
+Lava). There is no compiled code path of consequence — the assembly is effectively a content
+container, and a pre-build step copies the fonts/styles into RockWeb.
+
+## Project Info
+
+- **Project file:** `org.secc.CustomIcons.csproj`
+- **Root namespace:** `CustomIcons`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** Pre-build `xcopy` into RockWeb — `Fonts\*` to `RockWeb/Assets/Fonts` (landing in a
+  `CustomIcons/` subfolder), `Styles\*` to `RockWeb/Styles`, and `Overrides\*` to
+  `RockWeb/Styles/FontAwesome`. (At runtime the LESS references the font via
+  `../../../Assets/fonts/CustomIcons` — note the lowercase `fonts`.) The built `CustomIcons.dll`
+  carries no runtime logic — only `AssemblyInfo`.
+
+## Project Layout
+
+```
+/Fonts/CustomIcons/    CustomIcons.{eot,svg,ttf,woff} — the IcoMoon webfont files
+/Styles/CustomIcons/   style.less (@font-face + .se / .se-* classes), variables.less (glyph codepoints)
+/Overrides/            font-awesome.less — imports fontawesome.less then CustomIcons style.less
+/Properties/           AssemblyInfo.cs (stub — still titled "ClassLibrary1")
+selection.json         IcoMoon project export (regenerate the font from this)
+```
+
+## Components
+
+No REST endpoints, blocks, jobs, field types, Lava filters, or migrations — this plugin only
+contributes CSS/font assets.
+
+### CSS Classes
+
+`.se` is the base class (sets `font-family: CustomIcons`); each `.se-*` class sets the glyph via a
+`:before` `content` codepoint defined in `variables.less`.
+
+| Class | Codepoint |
+|-------|-----------|
+| `.se-c920` | `\e900` |
+| `.se-bb`   | `\e901` |
+| `.se-ciw`  | `\e902` |
+| `.se-cw`   | `\e903` |
+| `.se-et`   | `\e904` |
+| `.se-hsm`  | `\e905` |
+| `.se-in`   | `\e906` |
+| `.se-la`   | `\e907` |
+| `.se-lwya` | `\e908` |
+| `.se-msm`  | `\e909` |
+| `.se-rv`   | `\e90a` |
+| `.se-sw`   | `\e90b` |
+| `.se-kids` | `\e90c` |
+| `.se-rock` | `\e90d` |
+| `.se-se`   | `\e90e` |
+
+Usage mirrors Font Awesome: `<i class="se se-rock"></i>`.
+
+## Dependencies & Integrations
+
+- **Rock:** Hooks into Rock's Font Awesome LESS pipeline by overriding
+  `RockWeb/Styles/FontAwesome/font-awesome.less` (imports the stock `fontawesome.less` first, then
+  the custom `style.less`). No Rock runtime APIs.
+- **Third-party:** IcoMoon (font generation; `selection.json` is the source export). No NuGet
+  packages, no managed dependencies.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** `AssemblyInfo.cs` still carries the default scaffold metadata
+  (`AssemblyTitle` / `AssemblyProduct` = `"ClassLibrary1"`, copyright `2016`). Cosmetic, but worth
+  correcting for a clean assembly identity.
+- **Improvement:** `Overrides/font-awesome.less` *replaces* RockWeb's stock `font-awesome.less` via
+  the pre-build `xcopy`. A Rock core upgrade that changes that file could be silently clobbered (or
+  this override could go stale against a newer Font Awesome). Worth confirming the override stays in
+  sync on Rock upgrades.
+- **Improvement:** Deployment relies entirely on a Visual Studio `PreBuildEvent` `xcopy`; there's no
+  runtime/Startup registration. A non-VS or CI build that skips the pre-build step would compile the
+  (empty) DLL without copying the assets.
+
+## Making Changes
+
+- To add or rename a glyph: re-import `selection.json` into IcoMoon, export, drop the new font files
+  in `Fonts/CustomIcons/`, then add the new codepoint to `Styles/CustomIcons/variables.less` and the
+  matching `.se-*` rule to `style.less`.
+- The cache-buster query string (`?hhvrrz`) in `style.less` is the IcoMoon export hash — bump it when
+  you ship a new font so browsers don't serve a stale cached font.
+- This plugin has no C#/runtime behavior; for plugins that *use* icons in UI, see the block-based
+  plugins such as [org.secc.PastoralCare](../org.secc.PastoralCare/README.md).

--- a/Plugins/org.secc.DevLib/README.md
+++ b/Plugins/org.secc.DevLib/README.md
@@ -1,0 +1,91 @@
+# org.secc.DevLib
+
+> A small shared library of developer utilities for other SECC plugins — a MEF-backed "settings component" base, EF-migration helper extensions, and a stray search DTO.
+
+## Overview
+
+DevLib is a low-level helper assembly, not an end-user feature. It has no blocks, jobs, REST
+endpoints, or migrations of its own — it exists to be referenced by other SECC plugins. Two of its
+three pieces are genuinely reusable infrastructure: a base class + MEF container for storing plugin
+configuration as a Rock `Component` (attribute-backed "settings"), and a set of extension methods
+that let plugin EF migrations emit primary-key / foreign-key / index SQL the way Rock expects. The
+third file is a single DTO that looks misplaced.
+
+## Project Info
+
+- **Project file:** `org.secc.DevLib.csproj`
+- **Root namespace:** `org.secc.DevLib`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly, via the PostBuildEvent `xcopy`)
+
+## Project Layout
+
+```
+/Components/             SettingsComponent (Rock.Extension.Component base) + SettingsContainer (MEF singleton)
+/Extensions/Migration/   RockMigrationExtensions + TableBuilderExtensions — EF migration SQL helpers for Rock.Plugin.Migration
+/SportsAndFitness/        ControlCenterSearchItem — a lone search DTO (JSON-serializable)
+/Properties/             AssemblyInfo
+```
+
+## Components
+
+### Types
+
+| Type | Kind | Purpose |
+|------|------|---------|
+| `SettingsComponent` | abstract `Rock.Extension.Component` | Base for a "settings as a Rock component" pattern; declares an abstract `Name` property. Static `GetComponent<T>()` resolves the registered component by matching `EntityType.Name` against `typeof(T).FullName` over `SettingsContainer.Instance.Dictionary`, then force-reloads its attributes (safe on multi-server). |
+| `SettingsContainer` | `Container<SettingsComponent, IComponentData>` | MEF singleton (`[ImportMany]`) that discovers `SettingsComponent` implementations; `GetComponent`/`GetComponentName` look one up by entity-type string. |
+| `ControlCenterSearchItem` | plain DTO | `SearchTerm` + `SearchByPIN` / `SearchByPhone` flags; `ToString()` returns `ToJson()`. No callers in this assembly. |
+
+### Migration extension methods
+
+Extend `Rock.Plugin.Migration` so plugin migrations can add keys/indexes that the EF `TableBuilder`
+flow doesn't emit cleanly. The key/index helpers build operations on a throwaway `MiniMigration`
+(a private `DbMigration` subclass), run them through `SqlServerMigrationSqlGenerator`, and hand the
+resulting SQL to `migration.Sql(...)`. All three helpers ship single-column and `string[]`
+multi-column overloads. Both files default a missing FK principal column to `Id`, and pick SQL Server
+`"2008"` vs `"2005"` syntax based on `SqlConnection.ServerVersion`.
+
+| Method | On | Purpose |
+|--------|----|---------|
+| `AddPrimaryKey` | `Rock.Plugin.Migration` | Emit an `ADD PRIMARY KEY` (single- or multi-column). |
+| `AddForeignKey` | `Rock.Plugin.Migration` | Emit an `ADD FOREIGN KEY`; defaults a missing principal column to `Id`. |
+| `CreateIndex` | `Rock.Plugin.Migration` | Emit a `CREATE INDEX` (single- or multi-column, optional unique/clustered). |
+| `TableBuilder<T>.Run(migration)` | EF `TableBuilder<TColumns>` | Reflects the builder's `_migration` field and its `Operations`; rewrites each generated `CREATE TABLE` statement into an `ALTER TABLE … ADD CONSTRAINT` so the PK/constraints layer onto a Rock-created table. |
+
+## Dependencies & Integrations
+
+- **Rock:** project references to `Rock`, `Rock.Common`, and `DotLiquid` (per the `.csproj`). Uses
+  `Rock.Extension.Component` / `Container<,>` (MEF component framework), `Rock.Plugin.Migration`, and
+  `RockContext`-backed attribute loading (`LoadAttributes`).
+- **Third-party:** EntityFramework 6.1.3 (`DbMigration`, `SqlServerMigrationSqlGenerator`,
+  `MigrationOperation`); used reflectively in places.
+- **Consumed by:** other SECC plugins that reference this assembly (no inbound calls within DevLib itself).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** `SettingsComponent.GetComponent<T>()` will throw a `NullReferenceException` if no
+  matching component is registered — `FirstOrDefault()` can return `null`, but the next line
+  immediately sets `component.Attributes = null`. Worth a null guard.
+- **Improvement:** Both migration helpers reach into EF internals via reflection on the non-public
+  `Operations` property; `TableBuilderExtensions.Run` additionally reflects the `_migration` private
+  field of the `TableBuilder`. This is brittle across EF upgrades. The `Operations` lookup is
+  null-guarded and silently no-ops if missing, but `Run`'s `_migration` reflection is **not** guarded —
+  a missing/renamed field would throw a `NullReferenceException` on `fiMigration.GetValue(...)`. Worth
+  confirming against the pinned EntityFramework 6.1.3 before any EF bump.
+- **Improvement:** `SportsAndFitness/ControlCenterSearchItem` has no references inside this assembly
+  and reads like it was orphaned here rather than living with its Sports/Fitness feature. Worth
+  confirming whether anything still consumes it; otherwise it's a candidate to move or delete.
+
+## Making Changes
+
+- To add a new settings-style component, subclass `SettingsComponent` in a consuming plugin and
+  decorate it for MEF export; `SettingsContainer` will discover it. Resolve it via
+  `SettingsComponent.GetComponent<YourType>()`.
+- To extend the migration helpers, add methods to `Extensions/Migration/RockMigrationExtensions.cs`
+  (key/index helpers) or `TableBuilderExtensions.cs` (table-builder rewriting); keep the reflection
+  member names in sync with the referenced EntityFramework version.
+- This is a library — there are no pages, jobs, or endpoints to wire up here. Behavior surfaces in
+  whichever plugin references the assembly.

--- a/Plugins/org.secc.EMS/README.md
+++ b/Plugins/org.secc.EMS/README.md
@@ -1,0 +1,101 @@
+# org.secc.EMS
+
+> Thin SOAP client + Rock block that pulls room/event bookings from the EMS (Event Management System) facility-scheduling product and lists them in Rock.
+
+## Overview
+
+EMS is Southeast's integration with the **EMS Software** room/facility-booking system. The plugin
+wraps the EMS SOAP web service behind a small `API` facade, normalizes raw bookings into web-friendly
+`webEvent` objects, and surfaces them through a single Rock block ("View Events") that
+shows the day's scheduled events. The facade also exposes HVAC-zone logic (`GetHVACZones` /
+`CombineAdjacentEventsInZone`, producing `zoneEvent` objects) that coalesces adjacent bookings per HVAC
+zone — but nothing in this plugin calls it; the View Events block only uses `GetWebEvents`. All data is
+read-only and fetched live from EMS on each request.
+
+## Project Info
+
+- **Project file:** `org.secc.EMS.csproj`
+- **Root namespace:** `org.secc.EMS`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup), via the PostBuildEvent `xcopy`
+- **Service reference:** WCF/SOAP `basicHttpBinding` proxy generated under `Service References/EMSServiceRef/` (`ServiceSoapClient`)
+
+## Project Layout
+
+```
+API.cs          Public facade — GetWebEvents / GetHVACZones and the filtering/zone-combining logic
+APIMethods.cs   Internal SOAP calls (GetAllBookings, GetEventTypes) + XML deserialization
+APIData.cs      Auto-generated (xsd) DTOs: Bookings/BookingsData, EventTypes, Errors
+Events.cs       Plain output models: webEvent, zoneEvent
+Settings.cs     EMS credentials (app settings) + hard-coded status-id filters
+app.config      WCF basicHttpBinding config for the EMS SOAP endpoint
+Service References/EMSServiceRef/   Generated WCF proxy (Reference.cs) + WSDL/svcmap
+/org_secc/EMS/  ViewEvents block (.ascx + .ascx.cs)
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > EMS**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| View Events | Grid of EMS events for a chosen day; user-pref date picker and "Show All Events" toggle (off = web-enabled event types only). | **Building IDs** (`TextField`, comma-separated EMS building ids; blank = all buildings) |
+
+### Public API (facade — `API` class)
+
+Not a Rock REST endpoint — a plain C# facade other code (the block, and potentially jobs/Lava) calls in-process.
+
+| Method | Purpose |
+|--------|---------|
+| `GetWebEvents(...)` | Fetch bookings for a date range across one or more buildings, then filter to web-displayable events (optionally web-enabled-only). Returns `List<webEvent>`. |
+| `FilterEventsForWeb(...)` | Filter raw `BookingsData` to `webEvent`s: restrict to allowed status ids, and (optionally) only event types flagged `DisplayOnWeb`. Has a `showSetup` flag to drop `SET UP` rows, but the block's call path always passes `showSetup: true`, so `SET UP` rows are *not* filtered out on the web path. |
+| `GetHVACZones(...)` | Fetch bookings and group them into combined per-zone occupancy windows (`zoneEvent`). Not called anywhere in this plugin — available for external callers. |
+| `CombineAdjacentEventsInZone(...)` | Merge contiguous/overlapping bookings within the same HVAC zone into a single time window. |
+
+### Output models (`Events.cs`)
+
+| Type | Purpose |
+|------|---------|
+| `webEvent` | Booking/event start+end times, activity name, location, optional `DisplayOnWeb`. Bound to the grid. |
+| `zoneEvent` | An HVAC zone with a combined occupancy window and the rooms it covers. |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockBlock`, Rock grid/filter UI (`Rock:Grid`, `GridFilter`, `DatePicker`), block attributes, user preferences. No `RockContext`/EF — the plugin reads no Rock data.
+- **Third-party:** EMS Software SOAP web service (`ServiceSoapClient` over `basicHttpBinding`); `System.Runtime.Serialization` / `System.Xml.Serialization` for the response XML.
+- No migrations, jobs, Lava filters, or field types.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** The SOAP binding in `app.config` uses `<security mode="None">`, so EMS
+  credentials (`Settings.UserName` / `Settings.Password`) and all booking data travel **unencrypted**
+  unless the EMS endpoint URL is itself HTTPS. Worth confirming the configured endpoint is `https://`
+  and that the binding/transport security matches.
+- **Security (low):** EMS credentials are read from plain Rock/web `AppSettings` keys (`EmsUser`,
+  `EmsPassword`) via `ConfigurationManager`, not Rock's encrypted attribute storage. Confirm
+  `web.config` is not exposed and that these keys are managed as secrets.
+- **Improvement:** `Settings.HVAC_enabled_booking_status_ids` and `Default_web_event_status_ids` are
+  hard-coded to `{ "1" }` in code. Changing which EMS booking statuses are considered "confirmed"
+  requires a recompile rather than configuration.
+- **Improvement:** Filtering keys off English string matching — `CombineAdjacentEventsInZone` (HVAC path)
+  drops bookings whose name begins with `"SET UP"`, and event-type web-enablement is compared against the
+  literal string `"true"`. Both are brittle to data-entry/casing changes in EMS. (Note: the block's web
+  path passes `showSetup: true`, so `SET UP` rows are *not* dropped there.)
+- **Improvement:** `BindGrid` (block) sets `gScroll.PageSize = 5000` and pulls a full day of bookings on
+  every load with no server-side paging — fine for a day view, but a wide building/date range could be heavy.
+
+## Making Changes
+
+- To change what the block shows (columns, date handling, the "Show All" behavior), edit
+  `org_secc/EMS/ViewEvents.ascx[.cs]`; building scope comes from the block's **Building IDs** setting.
+- To change which EMS statuses/event types count as web-displayable or HVAC-relevant, edit the filter
+  logic in `API.cs` and the hard-coded lists in `Settings.cs`.
+- The only EMS SOAP operations actually wired up are `GetAllBookings` and `GetEventTypes` (in
+  `APIMethods.cs`); the generated proxy exposes many more (`GetRooms`, `AddReservation`, `GetStatuses`,
+  etc.) that are available but unused. Add new calls there, following the existing error-XML-detection pattern.
+- EMS endpoint/credentials live in `app.config` (binding) and host `web.config` AppSettings
+  (`EmsUser` / `EmsPassword`), surfaced through `Settings.cs`.

--- a/Plugins/org.secc.Equip/README.md
+++ b/Plugins/org.secc.Equip/README.md
@@ -1,0 +1,181 @@
+# org.secc.Equip
+
+> A self-contained learning-management system (LMS) for Rock — courses, chapters, multi-format lesson pages, quizzes, and per-person completion tracking with group/data-view requirements.
+
+## Overview
+
+Equip ("the learning tool") lets Southeast author and deliver online courses inside Rock. A
+**Course** contains ordered **Chapters**, each containing ordered **Course Pages** (HTML, YouTube,
+Vimeo, quiz, or drag-and-drop lessons). As a person works through a course, the plugin records
+their progress and pass/fail per page, chapter, and course. **Course Requirements** assign a course
+to a group or data view and track who still owes it (and when their completion expires), surfaced
+through Lava and report data filters. Staff manage all of this through a set of admin blocks under
+**SECC > Equip**; learners consume courses through the Course Entry / Course Lava blocks.
+
+## Project Info
+
+- **Project file:** `org.secc.Equip.csproj`
+- **Root namespace:** `org.secc.Equip`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup
+  and `.js`), via the PostBuildEvent `xcopy`
+- **Cross-plugin dependency:** [org.secc.Widgities](../org.secc.Widgities/README.md) (the Drag &
+  Drop page uses its `WidgityControl`)
+
+## Project Layout
+
+```
+/Model/             8 EF entities + their RockContext services (Course, Chapter, CoursePage,
+                    CourseRecord, ChapterRecord, CoursePageRecord, CourseRequirement,
+                    CourseRequirementStatus)
+/Data/              LearningContext — a Rock DbContext over the Equip tables
+/CoursePages/       MEF page-type components (HTML, YouTube, Vimeo, Quiz, Drag & Drop)
+/CoursePageComponent.cs, CoursePageContainer.cs   base component + MEF container for page types
+/Helpers/           CourseRequirementHelper (status sync), PersonCourseInfo (Lava DTO)
+/Jobs/              UpdateCourseRequirements — recompute requirement statuses
+/Lava/              CustomFilters.cs — the PersonCourseInfo Lava filter
+/Startup/           LoadCustomFilters — IRockOwinStartup hook that registers the filter
+/Reporting/DataFilter/   3 Person data filters (completion / requirement / expiring)
+/Controls/          CoursePicker — a course-selection control used by the data filters and the
+                    Course Requirement Detail block
+/org_secc/Equip/    12 admin/learner UI blocks (.ascx + .cs) and supporting .js
+/Migrations/        Rock plugin migrations (001 stands up all tables; 002–007 add columns)
+```
+
+## Components
+
+### Models
+
+EF entities (table prefix `_org_secc_Equip_`), each with a matching `*Service`. `Course` and
+`CourseRequirement` implement `ISecured`; `Course` is also `ICategorized` / `IHasActiveFlag`.
+
+| Model | Table | Purpose |
+|-------|-------|---------|
+| `Course` | `_org_secc_Equip_Course` | Top-level course: name, description, category, image, slug, icon, active flag, `AllowDocumentationMode` flag, optional external URL, and optional `AllowedGroup` / `AllowedDataView` viewer restriction. |
+| `Chapter` | `_org_secc_Equip_Chapter` | Ordered section within a course. |
+| `CoursePage` | `_org_secc_Equip_CoursePage` | A single lesson page; `EntityTypeId` points at the MEF page-type component, `Configuration` holds that type's serialized settings, `PassingScore` is its threshold. |
+| `CourseRecord` | `_org_secc_Equip_CourseRecord` | Per-person attempt/completion of a whole course (`Passed`, `CompletionDateTime`). |
+| `ChapterRecord` | `_org_secc_Equip_ChapterRecord` | Per-person completion of a chapter within a course record. |
+| `CoursePageRecord` | `_org_secc_Equip_CoursePageRecord` | Per-person result for a page (`Score`, `Passed`, completion details). |
+| `CourseRequirement` | `_org_secc_Equip_CourseRequirement` | Assigns a course to a `Group` or `DataView`, with optional `DaysValid` expiration window. |
+| `CourseRequirementStatus` | `_org_secc_Equip_CourseRequirementStatus` | Per-person row tracking whether a required course is complete and `ValidUntil`. |
+
+### Course Page Types (MEF components)
+
+Subclasses of `CoursePageComponent`, discovered via MEF (`[Export(typeof(CoursePageComponent))]`)
+and resolved through `CoursePageContainer`. Each renders its own author-time configuration and
+learner-time display, and scores the page into a `CoursePageRecord`.
+
+| Component (ComponentName) | Icon | Notes |
+|---------------------------|------|-------|
+| HTML Page | `fa-file-code` | Free-form lesson HTML authored in the Rock HtmlEditor. |
+| YouTube Video Page | `fa-youtube` | Embeds a YouTube iframe; "Watch Percent Required" (stored in `PassingScore`) gates completion via `YouTubeHelper.js`. |
+| Vimeo Video Page | `fa-vimeo` | Same as YouTube but for Vimeo (`VimeoHelper.js`, Vimeo player API). |
+| Quiz Page | `fa-question-circle` | Question/answer builder (`QuizEditor.js` / `QuizDisplay.js`); JSON config + a passing score. |
+| Drag & Drop Page | `fa-bars` | Builds the page with [org.secc.Widgities](../org.secc.Widgities/README.md)' `WidgityControl`. |
+
+### Blocks
+
+Category in Rock: **SECC > Equip**.
+
+| Block | Purpose |
+|-------|---------|
+| Course List | Grid of courses to manage (links to Course Detail). |
+| Course Detail | Create/edit a course (category, image, slug, icon, viewer restriction, external URL). |
+| Course Information | Read-only course summary with links to edit and to requirements. |
+| Course Outline | Shows all chapters and pages in a course. |
+| Chapter List | Grid of a course's chapters. |
+| Chapter Detail | Create/edit a chapter. |
+| Course Page List | Grid of a chapter's pages. |
+| Course Page Edit | Create/edit a page (picks the page type, renders its configuration). |
+| Course Entry | The learner experience — walks a person through chapters/pages and records results. |
+| Course Lava | Renders courses through a configurable Lava template (`CodeEditorField`). |
+| Course Requirement List | Grid of course requirements. |
+| Course Requirement Detail | Create/edit a requirement (course + group/data view + days-valid). |
+
+### Lava Filters
+
+Registered at startup via `LoadCustomFilters` (`IRockOwinStartup`).
+
+| Filter | Purpose |
+|--------|---------|
+| `PersonCourseInfo` | Given a `Person`, returns a list of `PersonCourseInfo` (course, category, complete/expired flags). Optional second arg is a space-delimited list of course Category Ids to scope to. Only returns courses the **current** person is authorized to VIEW. |
+
+### Jobs
+
+| Job (class) | Purpose |
+|-------------|---------|
+| `UpdateCourseRequirements` | `[DisallowConcurrentExecution]` Quartz `IJob`. Walks every `CourseRequirement` and calls `CourseRequirementHelper.UpdateCourseRequirementStatuses` to add/remove per-person status rows (from the group or data view, intersected with the course's allowed viewers) and recompute complete/`ValidUntil`. |
+
+### Report Data Filters
+
+`DataFilterComponent`s on `Rock.Model.Person`, section **Learning Tool**.
+
+| Filter (ComponentName) | Purpose |
+|------------------------|---------|
+| Course Completion Status | Filter people by completion of a chosen course — has completed / not completed / started-not-completed / not started. |
+| Course Requirement Status | Filter people by their status against a course requirement. |
+| Expiring Course Requirement | Filter people whose requirement completion is expiring. |
+
+## Dependencies & Integrations
+
+- **Rock:** EF (`Rock.Data.DbContext`, `Model<T>`, `IRockEntity`), the category/security framework
+  (`ICategorized`, `ISecured`, `IHasActiveFlag`), Quartz jobs, reporting data filters, the MEF
+  component framework (`Rock.Extension.Container`/`Component`), block/UI framework, DotLiquid (Lava),
+  Binary Files (course images), DataViews and Groups (requirement membership + viewer restriction).
+- **Cross-plugin:** [org.secc.Widgities](../org.secc.Widgities/README.md) — the Drag & Drop page type.
+- **Third-party:** Newtonsoft.Json (quiz/page config serialization). Video pages embed YouTube /
+  Vimeo players (client-side; no server-side API calls).
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/`:
+
+- `001_Init` — creates all eight `_org_secc_Equip_*` tables, keys, FKs, and indexes.
+- `002_ActiveFlag` — `Course.IsActive`.
+- `003_CourseImage` — `Course.ImageId`.
+- `004_CourseSlug` — `Course.Slug`.
+- `005_AllowedViewers` — `Course.AllowedGroupId` / `Course.AllowedDataViewId`.
+- `006_ExternalCourseUrl` — `Course.ExternalCourseUrl`.
+- `007_IconCssClass` — `Course.IconCssClass`.
+
+(`Migrations/Configuration.cs` is the EF migrations config; `LearningContext` itself uses a
+`NullDatabaseInitializer`, so schema changes flow only through these numbered plugin migrations.)
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** Course viewer-restriction logic is split. `Course.PersonCanView` checks
+  `AllowedGroup` / `AllowedDataView` membership, while `CustomFilters.PersonCourseInfo` instead
+  relies on `IsAuthorized(VIEW, currentPerson)` (Rock category-based security via `ParentAuthority`).
+  These are two different gates; confirm the Course Entry / Course Lava blocks consistently enforce
+  whichever one is intended so a course can't be viewed through one path but not the other.
+- **Improvement:** The `PersonCourseInfo` Lava filter constructs a fresh `RockContext` per call and
+  materializes all active courses in the scoped categories, then authorizes them in-memory — fine
+  for a single person page, wasteful if looped over many people.
+- **Improvement:** Several video/HTML page types disable request validation
+  (`ValidateRequestMode.Disabled`) and emit author-supplied HTML/embed markup directly into the page
+  (e.g. `YouTubePage`/`VimeoPage` wrap `coursePage.Configuration` in a container literal). That's
+  expected for an HTML-authoring tool, but it means page authoring should stay an
+  admin/trusted-staff capability — treat the Course Detail/Page Edit blocks' security accordingly.
+- **Improvement:** The `Data/LearingContext.cs` filename is misspelled (the class is
+  `LearningContext`); harmless but worth tidying. Its doc-comment also still references
+  `GroupManagerContext` from a copy/paste.
+
+## Making Changes
+
+- To add a new lesson type, drop a class in `/CoursePages/` that subclasses `CoursePageComponent`
+  and is decorated `[Export(typeof(CoursePageComponent))]` + `[ExportMetadata("ComponentName", "…")]`;
+  MEF discovers it and `CoursePageContainer` resolves it — no registration step. Follow `HTMLPage`
+  (simplest) or `QuizPage` (config + scoring) as templates.
+- To change what the `PersonCourseInfo` filter returns, edit `Lava/CustomFilters.cs`; it is
+  auto-registered because the whole `CustomFilters` type is passed to `Template.RegisterFilter` in
+  `Startup/LoadCustomFilters.cs`.
+- New columns/tables belong in a new numbered migration under `/Migrations/` and a matching property
+  on the `/Model/` entity — don't hand-edit migrations that have already run.
+- Requirement status recomputation lives in `Helpers/CourseRequirementHelper.cs`; the
+  `UpdateCourseRequirements` job is just a scheduled wrapper around it.
+- The Drag & Drop page type depends on [org.secc.Widgities](../org.secc.Widgities/README.md).
+</content>
+</invoke>

--- a/Plugins/org.secc.Event/README.md
+++ b/Plugins/org.secc.Event/README.md
@@ -1,0 +1,96 @@
+# org.secc.Event
+
+> Southeast's custom event/registration blocks — calendar Lava, a heavily-customized registration entry/detail pair, QR event passes, SignNow signing, camp-placement import, and the Community Gives Back program.
+
+## Overview
+
+This plugin is a collection of Rock **UI blocks** (`.ascx` user controls) covering Southeast's
+public events and registration flows. It includes Lava-driven calendar/event displays, SECC's own
+forks of Rock's stock `RegistrationEntry` / `RegistrationDetail` blocks, QR-based "Event Pass"
+generation and request, a SignNow digital-signature embed, a CSV camp-placement importer, and the
+self-contained "Community Gives Back" school-sponsorship sub-area. Blocks are configured through
+Rock block settings and used by ministry/communications staff and public registrants.
+
+## Project Info
+
+- **Project file:** none — **no `.csproj`; RockWeb-compiled.** The `.ascx` controls use
+  `CodeFile=` + `Inherits=`, so RockWeb compiles the code-behind at runtime; there is no built
+  assembly for this plugin.
+- **Root namespace:** `RockWeb.Plugins.org_secc.Event` (calendar blocks use `RockWeb.Blocks.Event`;
+  Community Gives Back uses `RockWeb.Plugins.org_secc.CommunityGivesBack`)
+- **Target framework:** n/a (compiled in-place by RockWeb, .NET Framework 4.7.2)
+- **Deploys to:** `RockWeb/Plugins/org_secc/Event/` (`.ascx` markup + `.ascx.cs` code-behind)
+
+## Project Layout
+
+```
+/org_secc/Event/                     Event & registration blocks (.ascx + .ascx.cs)
+/org_secc/Event/CommunityGivesBack/  Community Gives Back program blocks
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Event** (Community Gives Back blocks: **SECC > Community Gives Back**).
+
+| Block (DisplayName) | Purpose | Key settings |
+|---------------------|---------|--------------|
+| Yearly Calendar Lava (`CalendarLava`) | Renders an event calendar (Day/Week/Month/Year) via Lava, with campus/audience filters. | Event Calendar, Default View Option, Lava Template, campus/audience filter modes, Cache Duration, Cache Tags |
+| Calendar Event Item Lava (`EventItemLava`) | Renders a single calendar event item via Lava, optionally resolved by URL slug. | EventItem, Lava Template, URL Slug Attribute, Set Page Title, Event Not Found template |
+| Event Redirect (`EventRedirect`) | Interprets event slugs and forwards to the right page. | Base Route (default `upcomingevents`) |
+| Registration Entry (`RegistrationEntry`) | SECC fork of Rock's stock registration-entry block (register for an instance). | Connection Status, Record Status, plus the stock registration-entry settings |
+| Registration Detail (`RegistrationDetail`) | SECC fork of Rock's registration-detail block (view/manage a registration). | (stock registration-detail settings) |
+| Event Pass (`EventPass`) | Displays a QR "Event Pass" for registrants of an event. | Include Registrants on Waitlist, Pass Not Found Header/Message |
+| Generate Event Pass (`RequestEventPass`) | Public form that launches a workflow to request an Event Pass. | Block Title, Event Pass Workflow Type, Pass Person Attribute, Contact Fields Editable |
+| Family Registration List Lava (`FamilyRegistrationLava`) | Lava sidebar listing a family's children's registrations. | Lava Template, Max Results, Date Range, Limit To Owed |
+| SignNow (`SignNow`) | Embedded sub-control (a plain `System.Web.UI.UserControl`, **not** a registerable Rock block — no `[DisplayName]`/`[Category]`) that hosts the SignNow digital-signature flow inside registration; parses the returned `document_id` (falls back to the referer on iOS). | (none — driven by the registration's digital-signature component) |
+| Camp Placement Import (`CampPlacementImport`) | Imports a CSV to place camp registrants into placement groups; queues a background import run. | Default Group Member Status, Batch Size |
+| Community Gives Back Registration (`CommunityGivesBackRegistration`) | Public registration for the Community Gives Back program (launches a workflow on submit, with an acknowledgement step). | Community Gives Back Schools (defined type), Acknowledgement Text, Confirmation Text, Registration Complete Text, Registration Workflow Type, Auto Populate Registration Data, Campaign |
+| Community Gives Back Registrations List (`CommunityGivesBackRegistrations`) | Lists CGB registrations by school. | Community Gives Back Schools (defined type), Registration Workflow Type, School List Page |
+| Community Gives Back School List (`SchoolList`) | Lists CGB schools / sponsorship registrations. | Community Gives Back Schools (defined type), Registration Workflow Type, School Registration Page |
+
+`RegistrationEntry` (6,091 lines) and `RegistrationDetail` (2,799 lines) are large SECC-maintained
+copies of the corresponding stock Rock blocks; treat them as forks kept in sync with upstream.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockBlock` / `RockContext`, event-calendar & registration models
+  (`EventItem`, `RegistrationInstance`, `RegistrationRegistrant`, `PersonSearchKey`), Lava, the
+  workflow engine (Generate Event Pass), defined types (Community Gives Back schools).
+- **Cross-plugin:**
+  [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) — used by `SignNow` and
+  `RegistrationEntry`.
+  [org.secc.Jobs](../org.secc.Jobs/README.md) — `CampPlacementImport` queues and runs
+  `org.secc.Jobs.Event.CampPlacementImportRunner` and reads its `ImportRunStatus`.
+  [org.secc.QRManager](../org.secc.QRManager/README.md) — `EventPass` builds QR URLs against the
+  same `GetQRCode.ashx` handler / person search-key codes.
+- **Third-party:** SignNow (digital-signature provider, via Rock's `DigitalSignatureComponent`);
+  Newtonsoft.Json (registration serialization).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** `EventPass` builds a public QR URL of the form
+  `…/GetQRCode.ashx?data={alternateId}` using each registrant's **person search-key** (alternate id),
+  read-only. The pass surfaces registrant identity for an event instance — confirm the page hosting
+  this block is access-controlled and that "Include Registrants on Waitlist" is intentional where set.
+- **Improvement:** `SignNow` recovers a missing `document_id` by regex-parsing
+  `Request.UrlReferrer` (an iOS workaround, per the inline comment). Referer is client-supplied and
+  can be absent/spoofed; the block already returns early when it can't recover the id, but this path
+  is worth keeping an eye on as SignNow's behavior changes.
+- **Improvement:** `RegistrationEntry` / `RegistrationDetail` are large forks of stock Rock blocks.
+  When upgrading Rock, diff these against the upstream versions so SECC customizations aren't lost
+  and upstream fixes are picked up.
+
+## Making Changes
+
+- Block markup and behavior live together in `org_secc/Event/<Block>.ascx` + `.ascx.cs`; because
+  there is no `.csproj`, edits compile when RockWeb next loads the control — no separate build step.
+- Camp-placement import is split: this block (`CampPlacementImport`) handles upload/queueing, but the
+  actual placement work runs in [org.secc.Jobs](../org.secc.Jobs/README.md)
+  (`Event.CampPlacementImportRunner` / `CampPlacementImportBackgroundJob`); change the import logic there.
+- QR/pass URL conventions are shared with [org.secc.QRManager](../org.secc.QRManager/README.md);
+  person-matching for SignNow / Community Gives Back lives in
+  [org.secc.PersonMatch](../org.secc.PersonMatch/README.md).

--- a/Plugins/org.secc.FamilyCheckin/README.md
+++ b/Plugins/org.secc.FamilyCheckin/README.md
@@ -1,0 +1,183 @@
+# org.secc.FamilyCheckin
+
+> Southeast's custom check-in stack — kiosk/kiosk-type models, a library of check-in workflow actions, a cached check-in state layer, mobile/touchless check-in, and the consent and quick-check-in UI blocks.
+
+## Overview
+
+FamilyCheckin replaces and extends Rock's stock check-in for Southeast's children's and event
+ministries. It ships its own **Kiosk** and **KioskType** entities (so a physical device's
+configuration, theme, label printer, and grace window live in plugin tables), ~25 custom check-in
+**workflow actions** that override Rock's load/filter/save pipeline, a custom cache layer that
+keeps check-in state and mobile reservations hot, a **MobileCheckinRecord** entity for phone/SMS
+reservations, and the kiosk-facing UI blocks (quick check-in, quick search, medical consent,
+pre-registration, mobile start). Used by check-in staff and parents at kiosks and on phones.
+
+## Project Info
+
+- **Project file:** `org.secc.FamilyCheckin.csproj`
+- **Root namespace:** `org.secc.FamilyCheckin`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly), `RockWeb/Plugins/org_secc/` (block `.ascx` markup),
+  `RockWeb/Themes/` (check-in themes), and `RockWeb/Scripts/CheckinClient/` (`ZebraPrint.js`)
+- **Cross-plugin dependency:** [org.secc.DevLib](../org.secc.DevLib/README.md)
+
+## Project Layout
+
+```
+/Model/          Kiosk, CheckinKioskType, MobileCheckinRecord entities + services (EF, custom tables)
+/Data/           FamilyCheckinContext — plugin EF DbContext (NullDatabaseInitializer; uses RockContext db)
+/Cache/          CheckinCache<T> + KioskType/MobileCheckinRecord/Attendance/Occurrence caches
+/Workflows/      ~25 custom CheckInActionComponent actions (load, filter, save, reserve, labels)
+/Rest/           FamilyCheckinController + session-enabled route/controller handlers
+/Jobs/           Quartz IJob — expire mobile reservations, reset disabled group-location-schedules
+/FieldTypes/     CheckinGroupFieldType (single/multi check-in group picker)
+/Attribute/      CheckinGroupFieldAttribute (block-attribute helper for the above)
+/UI/ /Controls/  CheckinGroupPicker control, archiving-aware group row
+/Utilities/      CheckinLabelGen, LabelPrinter, KioskDeviceHelpers, Constants
+/Exceptions/     CheckInStateLost
+/org_secc/FamilyCheckin/   UI blocks (.ascx + .ascx.cs)
+/Themes/         SE Kids + SEKids2020 (+ Shine / Students) check-in themes
+/Scripts/        ZebraPrint.js (client-side label printing)
+/Migrations/     Rock plugin migrations (entities, defined types, pages, attributes)
+```
+
+## Components
+
+### Custom Models (EF entities in plugin tables)
+
+| Entity | Table | Purpose |
+|--------|-------|---------|
+| `Kiosk` | `_org_secc_FamilyCheckin_Kiosk` | A check-in device: name, KioskType, IP, printer device, print-from/to override. `ISecured`, `ICategorized`. |
+| `CheckinKioskType` | `_org_secc_FamilyCheckin_KioskType` | Reusable kiosk config: check-in template, campus, minutes-valid / grace minutes, theme. `ISecured`. |
+| `MobileCheckinRecord` | `_org_secc_FamilyCheckin_MobileCheckinRecord` | A mobile/SMS check-in reservation, keyed by a unique `AccessKey` and `UserName`, with an expiration. |
+
+### REST Endpoints
+
+Registered via `FamilyCheckinController` (`IHasCustomHttpRoutes`); routed through a
+session-enabled handler so check-in state persists in `HttpContext.Session`.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `api/org.secc/familycheckin/Family/{param}` | GET | Run the configured check-in workflow for a phone-number search and return matching families. |
+| `api/org.secc/familycheckin/ProcessMobileCheckin/{param}` | GET | Process a mobile (UserLogin-search) check-in; adds the user's primary family to check-in state. |
+| `api/org.secc/familycheckin/KioskStatus/{param}` | GET | Report whether a kiosk type is currently open / has available locations. |
+| `api/org.secc/familycheckin/Post` | POST | Echo endpoint (returns the posted phone). |
+
+### Workflow Actions
+
+Category in Rock: **SECC > Check-In**. All subclass Rock's `CheckInActionComponent`
+(except `Save SMS Attendance`, which subclasses `ActionComponent`) and are MEF-exported, so they
+drop into a check-in workflow with no code change.
+
+| Action (ComponentName) | Purpose |
+|------------------------|---------|
+| Load All Groups / Group Types / Locations / Cacheless / Override | Custom replacements for Rock's load steps (cache-backed and override variants). |
+| Custom Find Families | Family search step. |
+| Load Person By PIN / Load Person By Parent's phone number | Alternate person-lookup load steps. |
+| Search By PIN | PIN search step. |
+| Select All People | Auto-select everyone in the family. |
+| Filter Groups By Ability / Birthday / Grade (Custom) / Membership | Custom group-filter steps. |
+| Sideload Groups | Add additional groups into check-in state. |
+| Historical Preselect | Pre-select based on prior attendance. |
+| Reserve Attendance | Create a (mobile) attendance reservation. |
+| Save Attendance Custom | Save attendance. |
+| Save Attendance And Remove Session | Save, then clear the mobile reservation/session. |
+| Save SMS Attendance | Save attendance arriving via SMS. |
+| Remove Full GroupLocationSchedules | Drop locations that are at capacity. |
+| Aggregate Checkin Label / Create Event Labels / Create Medication Labels / Reprint Aggregate | Label generation and reprinting. |
+| Load All Override | Group-type load override. |
+| S&F Childcare Receipt / Deduct Sports Fitness Chidcare Credits | Sports & Fitness childcare receipt + credit deduction. |
+
+### Blocks
+
+Category in Rock: **SECC > Check-in** (medical-consent block: **SECC > Family Check In**).
+
+| Block | Purpose |
+|-------|---------|
+| QuickCheckin | Helps parents check in their whole family quickly. |
+| QuickSearch | Helps parents find their family quickly. |
+| Mobile Check-in Start | Start page for the mobile check-in process. |
+| Family Check-In Consent | Consent screen shown during check-in. |
+| My Account Medical Consent | Prompts a parent for medical consent for minors in their family. |
+| Childrens Pre-Registration | Pre-register families (children's-ministry oriented). |
+| AutoConfigure | Auto-configures a kiosk's check-in setup. |
+| Kiosk List / Kiosk Detail | Admin CRUD for `Kiosk` records. |
+| Kiosk Type List / Kiosk Type Detail | Admin CRUD for `CheckinKioskType` records. |
+
+### Jobs
+
+Quartz `IJob`s (both `[DisallowConcurrentExecution]`); scheduled in Rock, not self-registered.
+
+| Job | Purpose |
+|-----|---------|
+| `RemoveExpiredMobileReservations` | Cancels mobile check-in records that are expired or created before today. |
+| `ResetGroupLocationSchedules` | Re-enables group-location-schedules parked in the "disabled GLS" defined type. |
+
+### Field Type
+
+| Field type | Purpose |
+|------------|---------|
+| `CheckinGroupFieldType` | Picks a single or (configurably) multiple check-in groups; stores `Group.Guid`. Backed by `CheckinGroupPicker` and `CheckinGroupFieldAttribute`. |
+
+## Dependencies & Integrations
+
+- **Rock:** check-in engine (`CheckInState`, `CheckInActionComponent`), workflow engine,
+  `RockContext`, EF `DbContext`, `RockCache` / message bus, REST (`ApiController`,
+  `IHasCustomHttpRoutes`), defined types, Quartz scheduler, field-type framework.
+- **Cross-plugin:** [org.secc.DevLib](../org.secc.DevLib/README.md).
+- **Third-party:** EntityFramework, CacheManager.Core, Newtonsoft.Json, ASP.NET Web API; client-side
+  Zebra label printing via `ZebraPrint.js`.
+- **Related:** scannable check-in codes are produced by
+  [org.secc.QRManager](../org.secc.QRManager/README.md).
+
+## Migrations
+
+Ships Rock plugin migrations that install the plugin's entities, pages, defined types, and
+attributes (don't hand-edit ones that have already run):
+
+- `001_Init` — initial Kiosk / KioskType schema.
+- `002_Message`, `003_UpdateCacheTags` — messaging + cache-tag setup.
+- `004_Touchless`, `007_SearchType` — touchless / search-type config.
+- `005_KioskCategories`, `006_KioskNameIndex` — kiosk categorization + unique-name index.
+- `008_MobileCheckinRecord`, `009_ExpirationTime`, `014_AccessKey` — mobile-reservation table,
+  expiration, and access key.
+- `010_AttendanceQualifiers`, `013_GroupFilterAttributes` — attendance qualifiers + group-filter attributes.
+- `011_KioskTypeTheme` — kiosk-type theme.
+- `012_CheckinCampusFamilyDT`, `021_DisabledGLSsDT` — campus/family + disabled-GLS defined types.
+- `020_FamilyCheckinWorkflow`, `022_CheckinGroupTypes`, `027_MoveGroupTypes` — workflow + group-type data.
+- `023`–`026` — Kiosk-Type / Family / Super / Mobile check-in pages.
+- `030_LastMedicationCheckinAttribute`, `031_MedicalConsentKioskTypeAttributes`,
+  `032_KioskTypeEntityUpdates` — medication/medical-consent attributes and kiosk-type entity updates.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** Check-in handles minors' PII (names, birthdays, grade, medical/medication
+  consent, allergy data driving labels). Confirm the Rock **page/block security** on the consent and
+  pre-registration blocks, and that the kiosk-facing pages are restricted to the intended check-in
+  roles.
+- **Security (review):** Mobile check-in is gated by `MobileCheckinRecord.AccessKey` (a unique
+  string consumed by `GetByAccessKey`). Worth confirming the access key is generated from a
+  cryptographically strong, non-guessable source, since possessing it identifies a family's
+  reservation.
+- **Security (low):** `FamilyCheckinController.Family` decrypts the `LocalDeviceConfig` cookie and
+  trusts `CurrentKioskId` / `BlockGuid` from it and from session to pick the workflow; the broad
+  `catch` returns a generic `Forbidden`. Worth confirming the cookie's integrity protection is
+  sufficient for the device-config trust placed in it.
+- **Improvement:** The REST `Family` and `ProcessMobileCheckin` handlers are near-duplicates of the
+  same activate-workflow / process / save-state block — a shared private helper would cut the
+  copy-paste and keep the two paths from drifting.
+
+## Making Changes
+
+- To change a check-in step (load/filter/save/label), edit the matching action in `Workflows/`;
+  follow a sibling as a template and keep `[ActionCategory("SECC > Check-In")]` + the MEF export so
+  Rock discovers it. The aggregate label actions live in `CreateLabelsAggregate` / `ReprintAggregate`.
+- Kiosk/KioskType/MobileCheckinRecord shape changes go in `Model/` plus a new numbered migration
+  under `/Migrations/`; the cache wrappers in `Cache/` must be kept in sync (see the desync checks
+  in `MobileCheckinRecordCache`).
+- Kiosk-facing UI lives in `org_secc/FamilyCheckin/*.ascx[.cs]`; visual theming lives under
+  `/Themes/`.
+- Related: scannable codes come from [org.secc.QRManager](../org.secc.QRManager/README.md);
+  shared helpers from [org.secc.DevLib](../org.secc.DevLib/README.md).

--- a/Plugins/org.secc.FamilyOnMission/README.md
+++ b/Plugins/org.secc.FamilyOnMission/README.md
@@ -1,0 +1,82 @@
+# org.secc.FamilyOnMission
+
+> A single Rock block that lists the "Family on Mission" classes by time slot and lets a logged-in person sign up for an open one.
+
+## Overview
+
+FamilyOnMission ships one RockWeb block, **FoM Signup**, used for the Family on Mission
+registration page. It reads the child groups of a configured parent group, buckets them by their
+schedule's start time, and renders a card per class showing teacher, location, track, and remaining
+spots. Inside an optional open/close window it shows a **Sign Up** button (linking to a configured
+landing page); outside the window — or once the person is already a member — it shows the class(es)
+they're enrolled in instead.
+
+## Project Info
+
+- **Project file:** none — no `.csproj`; RockWeb-compiled (`.ascx` + `.ascx.cs` only).
+- **Root namespace:** `RockWeb.Plugins.org_secc.FamilyOnMission`
+- **Target framework:** n/a (compiled in-place by RockWeb)
+- **Deploys to:** `RockWeb/Plugins/org_secc/FamilyOnMission/` (block markup + code-behind)
+
+## Project Layout
+
+```
+/org_secc/FamilyOnMission/   FoMSignup.ascx (+ .ascx.cs) — the sign-up listing block
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Family On Misson** (spelling per source).
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| FoM Signup | Lists Family on Mission classes grouped by start time; shows a Sign Up button for open classes or the person's enrolled class outside the window. | Parent Group, Next Page, Open, Close |
+
+Block attributes (set in Rock block settings):
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Parent Group** | Group | The parent group whose child groups are the FoM classes. Child groups must have a `Schedule`. |
+| **Next Page** | Linked Page | Sign-up target; the `Sign Up` button links here with `?GroupId={id}`. |
+| **Open** | DateTime | Optional. Registration is closed before this time. |
+| **Close** | DateTime | Optional. Registration is closed after this time. |
+
+Per-group attributes the block reads (must exist on the child groups / their track):
+
+| Attribute | On | Notes |
+|-----------|----|-------|
+| **Track** | Group | Defined Value Guid; resolves a track whose **Image** / **About** values are shown on the card. |
+| **Teacher** | Group | Free-text teacher name shown on the card. |
+| **Image** / **About** | Track Defined Value | Track icon and (currently unused in output) description. |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockBlock`, `RockContext`, `GroupService`, `DefinedValueCache`, group schedules /
+  capacity / locations, the attribute framework, and `LinkedPageUrl`.
+- No third-party APIs.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** Card markup is built by `string.Format` against unencoded group/track/teacher
+  values (`Name`, `Description`, `Teacher`, location name) injected into HTML. These are
+  staff-entered fields, so exposure is limited, but HTML-encoding the values would be safer and is
+  cheap. The first card template also has a mismatched tag (`<h3>…</h2>`).
+- **Improvement:** `OnLoad` builds the whole list every postback (no `!IsPostBack` guard) and queries
+  group membership/capacity per render; fine for a short class list, worth noting if the parent group
+  grows. `trackAbout` is computed but never rendered.
+- **Improvement:** Capacity check uses `( GroupCapacity - Members.Count() ) < 1` to decide whether to
+  hide a full class. `GroupCapacity` is nullable, so when capacity is unset the subtraction is `null`
+  and `null < 1` is `false` — the class is **never** filtered out and shows with no "Spots remaining"
+  count. Set a capacity on every FoM class if you want the full-class hide behavior to work.
+
+## Making Changes
+
+- To change the card layout, what fields show, or the open/close behavior, edit
+  `org_secc/FamilyOnMission/FoMSignup.ascx.cs` (markup is assembled in `OnLoad`); inline CSS lives at
+  the top of `FoMSignup.ascx`.
+- Grouping is by each child group's `Schedule.StartTimeOfDay` — classes without a schedule are
+  skipped. The Sign Up flow hands off to the configured **Next Page** with `?GroupId=`.

--- a/Plugins/org.secc.Finance/README.md
+++ b/Plugins/org.secc.Finance/README.md
@@ -1,0 +1,125 @@
+# org.secc.Finance
+
+> Generates and serves annual giving (contribution) statements — a workflow action and merge-field builder that assemble the statement, blocks to launch/list/print them, a download handler, and a job to drive the generation workflows at scale; plus a bulk registration-refund block.
+
+## Overview
+
+Finance is Southeast's contribution-statement plugin. It builds a person/family giving statement
+(transactions, fund summary, pledges) as Lava-rendered HTML, then drives the at-scale generation of
+those statements through a Rock workflow that a job processes in batches. Staff use the blocks under
+**SECC > Finance** to kick off a statement run, review and list the resulting PDF/binary files, and
+print an on-screen Lava statement. The plugin also ships a download handler that access-checks
+statement files and a separate bulk-refund block for registrations.
+
+## Project Info
+
+- **Project file:** `org.secc.Finance.csproj`
+- **Root namespace:** `org.secc.Finance`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + iText7 / Newtonsoft), `RockWeb/Plugins/org_secc/`
+  (block `.ascx` markup + Lava), and `RockWeb/GetStatement.ashx` (download handler)
+
+## Project Layout
+
+```
+/Workflow/      GenerateStatement   — workflow action that renders one statement to an attribute
+/Utility/       Statement           — builds the statement merge fields (transactions, accounts, pledges)
+/Jobs/          ProcessGivingStatements — batch-processes pending statement-generator workflows
+/Rest/Controllers/ FinancialStatementsController — DELETE endpoint for a statement binary file
+/Handlers/      GetStatement.ashx   — access-checked download handler for statement files
+/org_secc/Finance/  UI blocks (.ascx + .ascx.cs) and the ContributionStatement.lava template
+/Migrations/    Rock plugin migrations (giving-analytics stored proc update)
+```
+
+## Components
+
+### Workflow Actions
+
+Discovered by Rock via MEF (`[Export(typeof(ActionComponent))]`). Category: **SECC > Finance**.
+
+| Action | Purpose | Key config attributes |
+|--------|---------|-----------------------|
+| Generate Giving Statement | Builds one person's/family's statement and stores the rendered HTML to a target workflow attribute. | Person, Start Date, End Date, Lava Template, Excluded Currency Types, Accounts, Statement HTML (target) |
+
+Statement content is assembled by `Utility/Statement.AddMergeFields`, which pulls all transactions
+for the person's `GivingId` (whole giving family), groups them into account/fund summaries, and adds
+pledge progress. With no Accounts selected it defaults to tax-deductible accounts.
+
+### Jobs
+
+| Job | Purpose | Key config attributes |
+|-----|---------|-----------------------|
+| ProcessGivingStatements | Finds active, **Pending** workflows of the configured statement-generator type and activates the named PDF-generation activity on each (new `RockContext` per workflow). | Statement Generator Workflow, Workflow Activity Name |
+
+### Blocks
+
+Category in Rock: **SECC > Finance**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Contribution Statement Generator | Kicks off the statement-generation run (launches the generator workflow over a dataview). | Statement Generator Workflow, Default Review DataView, Suppress Statement Dataview, Command Timeout, Concurrent Workers |
+| Contribution Statement List | Lists generated statement files; supports merge/print and delete. | Detail Page, Binary File Type, Document Type, Print & Mail Dataviews, Page Load Timeout |
+| Contribution Statement Lava | Renders an on-screen, printable Lava statement for a person. | Accounts, Display Pledges, Lava Template (ships a default template) |
+| Bulk Refund | Issues bulk refunds for registrations (SignalR progress). | (none declared) |
+
+### REST Endpoints
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `api/FinancialStatements/{binaryFileId}` | DELETE (`[Authenticate, Secured]`) | Deletes a contribution-statement binary file and its `Document` row. |
+
+### HTTP Handlers
+
+| Handler | Purpose |
+|---------|---------|
+| `GetStatement.ashx` (`?id=` or `?guid=`) | Streams a binary file (resumable/range support). When the file type requires view security, authorizes the caller via Rock authorization *or* by matching the file's `GivingId` / `PersonIds` attributes against the current person. |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, `FinancialTransactionDetailService`, `PersonAliasService`,
+  `WorkflowService` / workflow engine, `BinaryFileService`, Rock REST (`ApiControllerBase`),
+  the Rock block/UI framework, SignalR (`RockMessageHub`).
+- **Third-party:** iText7 (PDF merge in the statement list), DotLiquid / Lava, Quartz (job),
+  Newtonsoft.Json.
+- **Cross-plugin:** none in code; relies on the configured Rock workflow type for statement
+  generation.
+
+## Migrations
+
+Ships Rock plugin migrations (SQL only — `Down()` is intentionally empty):
+
+- `001_v12_AddFamilyIdToGivingAnalytics` — adds `PrimaryFamilyId` to
+  `spFinance_GivingAnalyticsQuery_PersonSummary` (Rock 1.12).
+- `002_v13_AddFamilyIdToGivingAnalytics` — re-applies the same change for the Rock 1.13 stored proc.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** Giving statements are sensitive financial PII. `GetStatement.ashx` only
+  enforces authorization when the binary file's *type* has `RequiresViewSecurity` set — otherwise
+  any file id/guid streams without a person check. The custom fallback (matching `GivingId` or
+  `PersonIds` file attributes) is reasonable, but worth confirming the statement binary-file type is
+  actually flagged `RequiresViewSecurity` and that those attributes are populated on every generated
+  file; otherwise statements could be retrieved by guessing/iterating ids.
+- **Improvement:** The DELETE endpoint runs a raw `DELETE FROM dbo.[Document]` via
+  `ExecuteSqlCommand` (parameterized, so not injection-prone) alongside the EF `Delete` of the
+  binary file. Review that this leaves no orphaned references and consider doing the cleanup through
+  the service layer for consistency.
+- **Improvement:** `Statement.AddMergeFields` constructs its own `RockContext` independent of the
+  caller's, so the workflow action effectively uses two contexts per statement. Fine for one-off
+  generation, but the per-person job loop plus per-statement context allocation is worth watching at
+  full-membership scale.
+
+## Making Changes
+
+- To change what a statement contains (transactions, fund summary, pledges), edit
+  `Utility/Statement.cs`; to change the action's inputs/output, edit `Workflow/GenerateStatement.cs`.
+- The default on-screen statement markup lives in the **Lava Template** block setting of
+  Contribution Statement Lava (and in `org_secc/Finance/Lava/ContributionStatement.lava`); the
+  generation run is configured on the Contribution Statement Generator block.
+- The batch driver is `Jobs/ProcessGivingStatements.cs` — it keys off the configured generator
+  workflow type and activity name, so adding a new generation step is a workflow change, not a code
+  change.
+- File access/serving rules live in `Handlers/GetStatement.ashx.cs`; deletion in
+  `Rest/Controllers/FinancialStatementsController.cs`.

--- a/Plugins/org.secc.GroupManager/README.md
+++ b/Plugins/org.secc.GroupManager/README.md
@@ -1,0 +1,145 @@
+# org.secc.GroupManager
+
+> A suite of Rock blocks for self-service group management — leader rosters, attendance, group finder, and a "Publish Group" model that lets ministries advertise and register groups.
+
+## Overview
+
+GroupManager is Southeast's catch-all groups plugin. The bulk of it is 21 Rock UI **blocks**
+that group leaders and members use directly: roster views, mark-attendance screens, a map-based
+group finder, group creation/recommit flows, and camp-specific leader tools. It also ships its
+own EF entity — `PublishGroup` — that wraps a Rock `Group` with publishing metadata (schedule,
+audience, registration/childcare options, contact info) so ministries can list groups publicly
+and take registrations. A single REST endpoint backs the group finder's distance search.
+
+## Project Info
+
+- **Project file:** `org.secc.GroupManager.csproj`
+- **Root namespace:** `org.secc.GroupManager`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup), via the PostBuildEvent `xcopy`
+- **Cross-plugin dependency:** [org.secc.Mapping](../org.secc.Mapping/README.md)
+
+## Project Layout
+
+```
+/org_secc/GroupManager/   UI blocks (.ascx + .ascx.cs) — rosters, attendance, finder, registration
+/Model/                   PublishGroup entity + service (the publishable-group data model)
+/Data/                    GroupManagerContext (EF DbContext) + generic GroupManagerService<T>
+/Rest/Controllers/        GroupManagerController — distance-based home-group lookup
+/UI/                      GroupManagerBlock — shared base block (current group/member, filters)
+/Exceptions/              NonExistantFilter exception
+/Migrations/              Rock plugin migrations (PublishGroup table evolution + allergy proc)
+```
+
+## Components
+
+### REST Endpoints
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `api/groupmanager/homegroups/{groupTypeId}/{zipcode}` | GET (authenticated) | Returns a map of `groupId -> travel distance` for active/public groups of a type, ranked by distance from a 5-digit ZIP (uses [org.secc.Mapping](../org.secc.Mapping/README.md)). |
+
+### Base Block
+
+`UI/GroupManagerBlock` (subclass of Rock `RockBlock`) is the shared base for several member-facing
+blocks. It resolves the current group (from `GroupId` page param or the `CurrentGroupManagerGroup`
+user preference), the current group member, and an optional member-attribute filter, then enforces
+access. Block settings: **Home Page** (redirect target), **GroupType** (restrict to one type),
+**Leaders Only** (leaders-only access).
+
+### Blocks
+
+Categories in Rock: **SECC > Groups**, **SECC > Camp**, and **Groups**.
+
+| Block (DisplayName) | Base | Purpose |
+|---------------------|------|---------|
+| Group List | GroupManagerBlock | Members of a group in roster format. |
+| Group Roster | GroupManagerBlock | Members of a group in roster format. |
+| LWYA Roster | GroupManagerBlock | Roster variant (Live Where You Are). |
+| Group Detail Lava | GroupManagerBlock | Group info rendered via Lava. |
+| Group Manager Attendance | GroupManagerBlock | List members for an occurrence and mark attendance. |
+| Group Member Tracker | GroupManagerBlock | Let a leader confirm a member attended after check-in. |
+| Group Registration Modal | GroupManagerBlock | Register a person for a group (modal). |
+| Group Creator | RockBlock | Create new groups. |
+| Group Recommit | RockBlock | Sign up to lead a new group or copy an existing one. |
+| Group Finder Map | RockBlockCustomSettings | Map-based group search by parameters/location. |
+| Group Lava | RockBlock | Output groups via Lava. |
+| Group Detail Button Inject | ContextEntityBlock | Add custom buttons to the core Group Detail block. |
+| Small Group Content | RockBlockCustomSettings | Dynamic, paginated small-group content for a group. |
+| Personal Group Information Panel | RockBlockCustomSettings | Edit a person's sports/fitness status. |
+| Breakout Group Migration | RockBlock | Tool to migrate kids into groups. |
+| Camp Group | RockBlock | Camp leaders view their group. |
+| Camp Allergies | RockBlock | Campers in a group who have allergies (backed by a stored proc). |
+| Publish Groups Lava | RockBlock | Output PublishGroups via Lava. |
+| Publish Group List | RockBlock | List of PublishGroups. |
+| Publish Group Registration | RockBlock | Register a person for a published group. |
+| Publish Group Request | RockBlock | Display a publish-group request. |
+
+### Models
+
+| Model | Table | Notes |
+|-------|-------|-------|
+| `PublishGroup` | `_org_secc_GroupManager_PublishGroup` | Wraps a Rock `Group` with publishing metadata: title/description/image, start/end window, weekly or custom schedule, audience (`DefinedValue` many-to-many via `_org_secc_GroupManager_PublishGroupAudienceValue`), requestor/contact aliases, registration + childcare options/links, confirmation email fields, status, slug. Implements `ISecured`/`IRockEntity`; exposes Lava-visible helpers (`Title`, `ScheduleText`, `IsActive`, `IsFull`). |
+
+Enums on the model: `PublishGroupStatus` (PendingApproval/Approved/Denied/Draft/PendingIT),
+`RegistrationRequirement`, `ChildcareOptions`.
+
+`PublishGroupService` (and the generic `GroupManagerService<T>`) provide standard Rock service
+access; `GroupManagerContext` is a `Rock.Data.DbContext` with a null initializer (no EF-managed
+schema — see Migrations).
+
+## Dependencies & Integrations
+
+- **Rock:** Rock block/UI framework (`RockBlock`, `RockBlockCustomSettings`, `ContextEntityBlock`),
+  `RockContext` + Rock services (`GroupService`, `GroupTypeService`), attribute framework, Lava
+  (DotLiquid), `ApiControllerBase` for REST, plugin migrations (`Rock.Plugin`).
+- **Cross-plugin:** [org.secc.Mapping](../org.secc.Mapping/README.md) — `GroupUtilities.GetGroupsDestinations`
+  powers the distance search in the REST endpoint and Group Finder Map.
+- **Third-party:** EntityFramework 6, Newtonsoft.Json.
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/` that build up the `PublishGroup` table over time
+(all `MigrationNumber` 1–11):
+
+- `001_Init` — create the `_org_secc_GroupManager_PublishGroup` table.
+- `002_SpouseRegistration` — add spouse-registration support.
+- `003_MeetingDetails` — meeting schedule/time/location columns.
+- `004_RegistrationOptions` — `RegistrationRequirement` (migrated from the old `RequiresRegistration` flag).
+- `005_ChildcareOptions` / `006_ChildcareDescription` — childcare options + description columns.
+- `007_RegistrationDescription` — registration description column.
+- `008_AddKeys` — foreign key to `[Group]`.
+- `009_RequestedChanges` — `IsHidden`/`Slug` columns + indexes.
+- `010_DropRequiresRegistration` — drop the obsolete `RequiresRegistration` column.
+- `011_AddCampAllergyReportProc` — create the `_org_secc_CampManager_GetGroupMemberAllergies`
+  stored procedure (backs the Camp Allergies block).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** The Camp Allergies block surfaces camper medical/allergy PII, and roster
+  blocks expose member contact details. Confirm the Rock **page/block security** on these is
+  scoped to the appropriate leader/staff roles. The `Leaders Only` block setting on
+  `GroupManagerBlock` gates member-facing pages — worth verifying it's set on every page that
+  should be leader-restricted, since it defaults off.
+- **Improvement:** `GetFilteredMembers` / `GetCurrentGroupFilterValues` call `member.LoadAttributes()`
+  inside a loop over `CurrentGroup.Members`, so attribute loading is per-member (N round-trips) on
+  every render of the filtered roster blocks. Fine for small groups, costly for large ones.
+- **Improvement:** Several blocks live under different Rock categories (`SECC > Groups`,
+  `SECC > Camp`, plain `Groups`); consolidating naming would make them easier to find in the block
+  picker. Three roster blocks (Group List / Group Roster / LWYA Roster) share the identical
+  description "Presents members of group in roster format."
+
+## Making Changes
+
+- To change a roster/attendance/finder block, edit the matching `*.ascx` / `*.ascx.cs` in
+  `org_secc/GroupManager/`; member-facing blocks inherit shared current-group/filter logic from
+  `UI/GroupManagerBlock.cs`.
+- Distance/location search behavior lives in [org.secc.Mapping](../org.secc.Mapping/README.md), not
+  here — the REST endpoint and Group Finder Map just call into it.
+- Schema changes to `PublishGroup` belong in a new numbered migration under `/Migrations/` (the
+  `GroupManagerContext` uses a null initializer, so EF won't manage the schema) — don't hand-edit
+  migrations that have already run.
+- The Camp Allergies stored procedure is defined inline in `011_AddCampAllergyReportProc`; change
+  it with a new migration rather than editing the proc in the database directly.

--- a/Plugins/org.secc.GroupTrackerDemo/README.md
+++ b/Plugins/org.secc.GroupTrackerDemo/README.md
@@ -1,0 +1,79 @@
+# org.secc.GroupTrackerDemo
+
+> REST endpoints that list a leader's groups and let a client view and toggle today's attendance for a group's members.
+
+## Overview
+
+GroupTrackerDemo is a small, REST-only plugin: no UI blocks, no Lava, no migrations. It exposes
+three JSON endpoints intended to back a "group tracker" client (the `Demo` name suggests a
+prototype) — list the active groups a person leads, pull today's attendance occurrence and roster
+for one group, and mark a member present/absent. All read queries use `AsNoTracking`.
+
+## Project Info
+
+- **Project file:** `org.secc.GroupTrackerDemo.csproj`
+- **Root namespace:** `org.secc.GroupTrackerDemo`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly)
+
+## Project Layout
+
+```
+/Controllers/   GroupTrackerController — the three REST endpoints
+/Models/        Plain DTOs returned as JSON (GroupSummary, GroupWithOccurrence,
+                GroupMemberWithAttendance)
+/Properties/    AssemblyInfo
+```
+
+## Components
+
+### REST Endpoints
+
+`GroupTrackerController : ApiControllerBase` — routes registered via `[Route]` attributes.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `api/GroupTracker/GroupSummaryByLeader/{personAliasId}` | GET | Active, non-archived groups where the person (resolved from `personAliasId`) is a leader. Optional `includedGroupTypeIds` query string (comma-separated) filters by group type. Returns `GroupSummary[]`. |
+| `api/GroupTracker/GroupOccurrenceAttendance/{groupGuid}` | GET | For one group (by Guid), the non-leader active members joined to today's attendance occurrence, including mobile phone and per-member attendance state. Returns a single `GroupWithOccurrence`, or `404` if the group has no matching roster. |
+| `api/GroupTracker/UpdateAttendedStatus/{attendanceId}/{isPresent}` | POST | Sets `DidAttend`/`PresentDateTime` on an existing `Attendance` record. `404` if the attendance Id is unknown; otherwise `202 Accepted`. |
+
+### Models (JSON DTOs)
+
+| Model | Shape |
+|-------|-------|
+| `GroupSummary` | `Id`, `Name`, `GroupTypeId`, `GroupTypeName`, `Guid`, `IsActive`. |
+| `GroupWithOccurrence` | Group + today's occurrence (`OccurrenceId`, `Location*`, `Schedule*`, `OccurrenceDate`) + `List<GroupMemberWithAttendance>`. |
+| `GroupMemberWithAttendance` | `GroupMemberId`, `PersonId`, `NickName`, `LastName`, `BirthDate`, `PhotoId`, `MobilePhone`, `AttendanceId`, `StartDateTime`, `EndDateTime`, `DidAttend`, `PresentDateTime`. |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, `PersonAliasService`, `GroupMemberService`, `AttendanceService`,
+  `PhoneNumberService`, `DefinedValueCache`, Rock REST (`ApiControllerBase`).
+- **Third-party:** `Newtonsoft.Json`, ASP.NET Web API.
+- No cross-plugin dependencies.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** All three endpoints inherit only `ApiControllerBase`'s default auth and
+  carry no per-method authorization or ownership check. `UpdateAttendedStatus` mutates any
+  `Attendance` row by Id with no verification that the caller leads that group, and
+  `GroupOccurrenceAttendance` returns member PII (name, birth date, mobile phone, photo) for any
+  group Guid. Worth confirming the intended access model before this leaves "demo" status.
+- **Improvement:** `GetGroupSummaryByLeader` does not guard against an unknown `personAliasId` —
+  `PersonAliasService.GetPerson` can return null and the following `m.PersonId == person.Id` then
+  throws a `NullReferenceException`. (Omitting `includedGroupTypeIds` is safe: it defaults to null
+  and `IsNotNullOrWhiteSpace()` is a null-safe Rock string extension.) Review the null handling.
+- **Improvement:** `GroupOccurrenceAttendance` keys "today's" occurrence off `RockDateTime.Today`
+  and the attendance `GroupJoin` takes `FirstOrDefault()` per member, so behavior is ambiguous when
+  a group has more than one occurrence on the same day.
+
+## Making Changes
+
+- All behavior lives in `Controllers/GroupTrackerController.cs`; add or change endpoints there and
+  adjust the matching DTO under `/Models/`.
+- The roster query in `GetGroupOccurrenceAttendance` is the non-trivial part — note the
+  leader-exclusion filter (`!gm.GroupRole.IsLeader`) and the mobile-phone defined-value lookup
+  (`PERSON_PHONE_TYPE_MOBILE`) if you extend the returned fields.
+- This plugin is independent of other org.secc plugins; there are no migrations to add.

--- a/Plugins/org.secc.Imaging/README.md
+++ b/Plugins/org.secc.Imaging/README.md
@@ -1,0 +1,122 @@
+# org.secc.Imaging
+
+> Renders HTML/Lava into PNG images over REST, and bulk-updates person photos by AI face-cropping existing binary files via Azure Cognitive Services Face.
+
+## Overview
+
+Imaging bundles two unrelated image features. The first is a REST endpoint that converts an
+HTML string to a PNG (via the wkhtmltoimage-backed `NReco.ImageGenerator`), used to produce
+images from Lava/HTML templates. The second is a pair of admin blocks that batch-crop person
+profile photos: they pull existing binary files, send each to Azure Face to detect and
+straighten the face, crop to a 500x500 square, and save the result (as a quality-95 JPEG) back
+as the person's photo.
+
+## Project Info
+
+- **Project file:** `org.secc.Imaging.csproj`
+- **Root namespace:** `org.secc.Imaging`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `NReco.ImageGenerator.dll`; the Microsoft Azure
+  Face/Rest client DLLs (`Microsoft.Azure.CognitiveServices.Vision.Face`,
+  `Microsoft.IdentityModel.Clients.ActiveDirectory`, `Microsoft.Rest.ClientRuntime[.Azure]`);
+  and `ImageResizer.dll` + `ImageResizer.Plugins.SimpleFilters.dll`) and
+  `RockWeb/Plugins/org_secc/` (block `.ascx` markup)
+
+## Project Layout
+
+```
+/Rest/         ImagingController  — REST endpoints (test, generateimage)
+/AI/           FaceCrop           — Azure Face detect + rotate + crop person photos
+/Components/   MicrosoftFaceSettings — DevLib SettingsComponent holding Face endpoint + key
+/org_secc/Imaging/  UpdatePersonImage(.ascx), UpdatePersonImageFromRegistration(.ascx) — bulk crop blocks
+/Migrations/   Rock plugin migrations (Html To Image defined type)
+HtmlToImage.cs Constants.cs       — NReco HTML->image wrapper; defined-type Guid constant
+```
+
+## Components
+
+### REST Endpoints
+
+`ImagingController` derives from `ApiControllerBase`.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `api/imaging/test` | GET | Returns the literal string `"test"`. |
+| `api/imaging/generateimage` | POST | Renders posted `Content` (HTML/Lava string) to a PNG and returns it as a `image.png` attachment. Optional `Width` (default 1920). Non-ASCII chars are HTML-entity encoded before rendering. |
+
+### Blocks
+
+Category in Rock: **SECC > Imaging**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Update Person Image | Runs an admin-supplied SQL query returning `PersonId`/`BinaryFileId` pairs, then face-crops each binary file into the person's photo. | Execution Delay |
+| Update Person Image From Registration | Picks one or more registration templates, finds registrant attribute values with key containing "photo", and face-crops those binary files into the registrant's photo. | Execution Delay |
+
+Both blocks share the `ExecutionDelay` (`IntegerField`) attribute — milliseconds to `Thread.Sleep`
+between calls to stay under the Azure Face transactions-per-second limit. The registration block
+adds an "Overwrite photos?" checkbox: when checked it updates non-`secc.org` profiles even if they
+already have a photo; otherwise only registrants with no existing `PhotoId`.
+
+### Settings Component
+
+| Component | Type | Settings |
+|-----------|------|----------|
+| Microsoft Face | DevLib `SettingsComponent` (MEF `Export`) | **Endpoint** (`TextField`), **Subscription Key** (`TextField`, key `SubscriptionKey`) — Azure Cognitive Services Face credentials read by `FaceCrop`. |
+
+### Defined Type
+
+`001` installs the **Html To Image** defined type (Guid `8CC5A105-…`, mirrored in `Constants.cs`)
+with entry attributes for Template (Lava/HTML), Enabled Lava Commands, Canvas Width, Canvas Height,
+and Response Headers — intended as reusable templates for the image generator.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, `PersonService`, `BinaryFileService`, `RegistrationRegistrantService`,
+  `AttributeValueService`, `GlobalAttributesCache`, Rock REST (`ApiControllerBase`), the block/UI
+  framework, defined types, `BinaryFiletype.PERSON_IMAGE`.
+- **Third-party:** `NReco.ImageGenerator` (wkhtmltoimage HTML->image), `Microsoft.Azure.CognitiveServices.Vision.Face`
+  (face detection), `System.Drawing` (rotate/crop/encode), `ImageResizer`.
+- **Cross-plugin:** [org.secc.DevLib](../org.secc.DevLib/README.md) (`SettingsComponent` base for `MicrosoftFaceSettings`).
+
+## Migrations
+
+- `001_ImageGeneratorDefinedType` — adds the **Html To Image** defined type and its entry attributes
+  (Template, Enabled Lava Commands, Image Type, Width, Height).
+- `002_ImageGeneratorDefinedTypeResponseHeaders` — adds a Response Headers key-value attribute.
+- `003_ImageGeneratorCleanup` — drops the Image Type attribute; renames Width/Height to Canvas Width /
+  Canvas Height with help text.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** The "Update Person Image" block executes **arbitrary admin-entered SQL**
+  (`rockContext.Database.SqlQuery<ResponseData>(sql)`) with no validation. Powerful by design, but
+  ensure the page/block is locked to trusted admins.
+- **Security (low):** The Azure Face **Subscription Key** is stored in a plain `TextField` settings
+  attribute (not an encrypted/`EncryptedTextField`), so it is readable in cleartext by anyone with
+  access to the settings component. Treat it as a secret and restrict access accordingly.
+- **Security (low):** The Azure Face `DetectWithUrlAsync` call builds the image URL from
+  `PublicApplicationRoot` + `GetImage.ashx?Guid=…`, so the binary file must be publicly fetchable by
+  Azure for detection to work. Worth confirming those `GetImage` URLs aren't otherwise sensitive.
+- **Improvement:** Both blocks fire `Task.Run(async () => await face.UpdatePhoto(...))` in a
+  fire-and-forget loop on a web request — the task is never awaited and exceptions are swallowed, so
+  the page returns before/independent of the crops finishing and failures are invisible. A scheduled
+  job or transaction queue would be more robust for a multi-thousand-record batch.
+- **Improvement:** Both `.ascx.cs` files declare the same class `UpdatePersonImage` in the same
+  `RockWeb.Plugins.org_secc.Imaging` namespace (the registration file's class name was not renamed).
+  Worth confirming this doesn't cause a type collision at compile/load.
+- **Improvement:** The `generateimage` endpoint takes raw `Content` and never reads the **Html To Image**
+  defined type that the migrations install, so the template/canvas-size attributes appear unused by the
+  current controller. Confirm whether a consumer applies them or whether they're vestigial.
+
+## Making Changes
+
+- To change HTML->image rendering, edit `HtmlToImage.cs` (NReco options) or the `GenerateImage`
+  action in `Rest/ImagingController.Partial.cs`.
+- To change face-crop logic (detection model, crop padding, output size/quality), edit `AI/FaceCrop.cs`.
+- Azure Face credentials are stored in the **Microsoft Face** settings component
+  (`Components/MicrosoftFaceSettings.cs`), edited through Rock, not in code.
+- To change which photos a batch targets, edit the matching `*.ascx.cs` in `org_secc/Imaging/`.
+- New defined-type attributes belong in a new numbered migration under `/Migrations/`.

--- a/Plugins/org.secc.Jobs/README.md
+++ b/Plugins/org.secc.Jobs/README.md
@@ -1,0 +1,113 @@
+# org.secc.Jobs
+
+> A grab-bag of Southeast's custom Rock scheduled jobs (Quartz `IJob`s) for data maintenance, attendance, communications, and one-off migrations.
+
+## Overview
+
+This plugin is Southeast's collection of custom Rock **scheduled jobs**. Each class implements
+Quartz's `IJob` and is wired up as a Rock Job (Admin > System Settings > Jobs), configured entirely
+through Rock job attributes — no code change is needed to schedule or re-point one. The jobs span
+ongoing maintenance (closing workflows, syncing attendance, cleaning phone numbers) and targeted
+one-time data fixes (pickleball-credit migration, facilities-team relocation). It also ships two EF
+plugin migrations that stand up supporting data and a tracking table.
+
+## Project Info
+
+- **Project file:** `org.secc.Jobs.csproj`
+- **Root namespace:** `org.secc.Jobs`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`, via the PostBuildEvent `xcopy`)
+- **Cross-plugin dependency:** [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md)
+
+## Project Layout
+
+```
+/ (root)        Most jobs — workflow, communication, attendance, person/device maintenance
+/Event/         Event-area jobs: camp-placement import, event check-in relationships, GivesBack
+/Rock13/        Jobs targeting Rock v13 behavior (phone-number type cleanup)
+/Migrations/    Rock plugin migrations (group-type roles, camp-import tracking table)
+```
+
+## Components
+
+### Jobs
+
+Each is a Quartz `IJob`; most carry `[DisallowConcurrentExecution]`. Configuration is per-job via
+Rock job attributes (read from the `JobDataMap`).
+
+| Job (class) | Purpose | Key settings |
+|-------------|---------|--------------|
+| `CloseDeseasedPastoralWorkflows` | Close pastoral-care workflows for people now marked deceased. | Hospital Admission / Nursing Home Resident / Homebound Person workflow types |
+| `CompleteWorkflows` | Bulk-close workflows of the selected type(s) past an expiration age. | Workflow Types, Close Status, Expiration Age, Expiration Calc Last Used |
+| `DisableCommunicationsForInactivePeople` | Turn off email/SMS for inactive people; snapshot original prefs to a DefinedType. | Inactive Person Communication Overrides Defined Type, Lookback Days, Dry Run |
+| `RestoreCommunicationsForReactivatedPeople` | Restore email/SMS prefs for re-activated people from the stored snapshots. | Inactive Person Communication Overrides Defined Type, Dry Run |
+| `EasterChildrensAttendance` | Pull Easter SEKids vs. worship-service attendance analytics. | Easter Sunday Date, SE!Kids / Worship Schedule Categories, Command Timeout |
+| `SetFirstAttendanceDate` | Backfill each person's first-attendance date (batched SQL). | Command Timeout, Take |
+| `StoreAttendanceFromInteraction` | Convert WiFi-presence interactions into attendance records. | Interaction Channel, Component Campus Mapping, Operation, Group Type, Date Range |
+| `GroupLeaderMedicationNotifications` | Notify small-group leaders of campers with medications. | Parent Group, Communication List, Medication Checkin Days, Communication Template |
+| `RemoveDevicesFromPersons` | Remove personal devices for people in a DataView. | DataView (Person) |
+| `FrontPorchDeviceRemoval` | Delete stale personal devices via the Front Porch external API. | Date Range |
+| `PushPayDownloadCheckNumbers` | Backfill check numbers on PushPay check transactions via the PushPay API. | Transaction Source, Currency Type, Check Number Attribute, Date Range |
+| `MigratePickleballCredits` | One-off: migrate pickleball session credits to a Group Fitness group. | Pickleball / Group Fitness groups + attribute keys, Note Type |
+| `UpdateFacilitiesTeamLocation` | One-off: migrate facilities staff & requisitions to a central support location. | Central Support Location, Facilities Ministry Area, Location / Ministry Area attribute keys |
+| `Event.AddEventCanCheckinRelationships` | Create "Event Can/Allow Checkin" known-relationships for a registration template. | Registration Template, Expiration Date Time |
+| `RemoveEventCanCheckinRelationships` | Remove the "Event Can/Allow Checkin" relationships. | (none) |
+| `Event.CopyCommunityGivesBackSchools` | Copy Community Gives Back school records into a new campaign. | Destination Campaign Name, Source Campaign, Copy Inactive Schools |
+| `Event.CampPlacementImportBackgroundJob` | Background runner for a camp-placement CSV import (driven by a `RunId`). | RunId (passed via JobDataMap, not a job attribute) |
+| `Rock13.PhoneNumberCleanup` | Clean up duplicate phone-number types (Rock v13). **Note: not in the `.csproj` `<Compile>` list, so it is not currently built.** | (none) |
+
+### Migrations-driven data
+
+| Migration | Installs |
+|-----------|----------|
+| `001_EventRelationshipRoles` | "Event Can Checkin" / "Event Allow Checkin By" roles on the Known Relationships group type. |
+| `002_CampPlacementImportRun` | `_org_secc_CampPlacementImportRun` table tracking camp-import run status/progress. |
+
+## Dependencies & Integrations
+
+- **Rock:** Quartz job framework (`IJob`, `JobDataMap`), `RockContext` and Rock services, workflow
+  engine, defined types/values, attribute framework, plugin migrations (`Rock.Plugin`).
+- **Cross-plugin:** [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md) — `StoreAttendanceFromInteraction`
+  uses `org.secc.FamilyCheckin.Utilities`.
+- **Third-party APIs:** PushPay (`api.pushpay.com`, OAuth token obtained reflectively from
+  `com.pushpay.RockRMS.dll`), Front Porch device API (host + token from Global Attributes).
+- **Other:** Newtonsoft.Json (snapshot serialization), Ical.Net / NodaTime (transitive).
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/`:
+
+- `001_EventRelationshipRoles` — adds the event check-in known-relationship roles (`MigrationNumber 1`).
+- `002_CampPlacementImportRun` — creates the camp-placement import tracking table (`MigrationNumber 2`).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** Two files are present on disk but **not referenced in the `.csproj`** `<Compile>`
+  list, so they never compile or run: `Migrations/AddOtherPhoneTypes.cs` and `Rock13/PhoneNumberCleanup.cs`.
+  `AddOtherPhoneTypes` also declares `[MigrationNumber(1, "1.13.0")]`, which would collide with
+  `001_EventRelationshipRoles` (also number 1) if it were ever included. Worth wiring up, removing, or
+  renumbering as appropriate.
+- **Improvement:** `PushPayDownloadCheckNumbers` loads `com.pushpay.RockRMS.dll` via reflection at
+  runtime (`Assembly.LoadFrom` + `GetMethod("GetAccessToken")`). This is a brittle, hard-to-detect
+  coupling — a rename in that plugin breaks this job only at runtime. The job's `errors` counter is
+  also never incremented, so the result string always reports `0 Error(s)`.
+- **Security (low):** `FrontPorchDeviceRemoval` and `PushPayDownloadCheckNumbers` reach external HTTP
+  APIs using credentials from Global Attributes / merchant rows. Confirm those tokens are stored
+  encrypted and that the Front Porch `Host`/token global attributes are not broadly readable.
+- **Improvement:** `AssemblyInfo.cs` still carries the default scaffolded company/copyright
+  (`"Microsoft"`, `"Copyright © Microsoft 2017"`) rather than Southeast Christian Church.
+
+## Making Changes
+
+- To add a job, drop a new `IJob` class in the matching folder (root, `Event/`, or `Rock13/`),
+  decorate it with `[DisplayName]`/`[Description]` and its Rock `*Field` attributes, then register
+  it as a Rock Job in the admin UI; follow an existing sibling as a template.
+- Most jobs read their config from `context.JobDetail.JobDataMap` — keep the attribute `Key` and the
+  `GetString(...)` lookup in sync.
+- New supporting data (roles, tables, defined values) belongs in a new numbered migration under
+  `/Migrations/` — don't hand-edit migrations that have already run.
+- Related: the pastoral workflows closed by `CloseDeseasedPastoralWorkflows` are installed by
+  [org.secc.PastoralCare](../org.secc.PastoralCare/README.md); attendance utilities live in
+  [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md).

--- a/Plugins/org.secc.LeagueApps/README.md
+++ b/Plugins/org.secc.LeagueApps/README.md
@@ -1,0 +1,143 @@
+# org.secc.LeagueApps
+
+> Imports sports-league programs and members from the LeagueApps API into Rock as a year/category/league group hierarchy with matched people.
+
+## Overview
+
+LeagueApps integrates Southeast's [LeagueApps](https://leagueapps.com/) sports-registration platform
+with Rock. Two scheduled jobs call the LeagueApps REST API: one syncs current programs (leagues) into
+a three-level Rock group tree and enrolls each registrant as a group member, the other backfills a
+LeagueApps user-id person attribute (and family id) onto matched Rock people. People are matched (or
+created) through Rock's standard person matching plus suffix and previous-name fallbacks, and the
+LeagueApps user id is stored so future imports are idempotent. There are no blocks, REST endpoints, or
+Lava filters — it is entirely job-driven.
+
+## Project Info
+
+- **Project file:** `org.secc.LeagueApps.csproj`
+- **Root namespace:** `org.secc.LeagueApps`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `jose-jwt.dll`, `Security.Cryptography.dll`, via the PostBuildEvent `xcopy`)
+- **Cross-plugin dependencies:** [org.secc.DevLib](../org.secc.DevLib/README.md) (settings component), [org.secc.PersonMatch](../org.secc.PersonMatch/README.md)
+
+## Project Layout
+
+```
+/Jobs/         ImportData (programs + registrants), ImportMembers (member/family backfill)
+/Utilities/    APIClient (JWT/OAuth REST client), LeagueAppsHelper (person match/create),
+               HTMLConvertor (strip HTML from descriptions), Constants (attribute/Guid keys)
+/Components/   LeagueAppsSettings — DevLib SettingsComponent holding all config attributes
+/Contracts/    POCOs deserialized from the API: Member, Programs, Registrations
+/Migrations/   Rock plugin migrations (defined types/values + person & family attributes)
+```
+
+## Components
+
+### Jobs
+
+Each is a Quartz `IJob` with `[DisallowConcurrentExecution]`, registered as a Rock Job in the admin UI.
+Most configuration lives on the shared `LeagueAppsSettings` component (see below), not on the job itself.
+
+| Job (class) | Purpose | Key settings |
+|-------------|---------|--------------|
+| `ImportData` | Pull current programs, build/refresh the `Year > Category > League` group tree (league keyed by `ForeignId = programId`), set league group attributes, then enroll each registrant as a `GroupMember` with a mapped role; deactivates leagues no longer returned. | All `LeagueAppsSettings` attributes; no per-job attributes |
+| `Jobs.ImportMembers` | Page through all members and backfill the `LeagueAppsUserId` person attribute and `LeagueAppsFamilyId` family attribute. | **CreateNew** (`BooleanField`) — create a new person if no Rock match |
+
+### Settings (`LeagueAppsSettings`)
+
+DevLib `SettingsComponent` (`[Export(typeof(SettingsComponent))]`), configured under Rock's component
+settings. Attribute keys in **bold**.
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **LeagueAppsSiteId** | EncryptedText | LeagueApps site id (decrypted at call time). |
+| **LeagueAppsClientId** | EncryptedText | API key / OAuth client id. |
+| **LeagueAppsServiceAccountFile** | File | PKCS#12 (`.p12`) private key used to sign the JWT bearer assertion. |
+| **ParentGroup** | Group | Grandparent group the year/category/league tree is built under. |
+| **YearGroupType** | GroupType | Group type for the year level. |
+| **CategoryGroupType** | GroupType | Group type for the category (mode) level. |
+| **LeagueGroupType** | GroupType | Group type for the league itself; its roles map LeagueApps roles. |
+| **LeagueGroupTeam** | Attribute (GroupMember) | Group-member attribute populated with the registrant's team. |
+| **DefaultConnectionStatus** | DefinedValue (Connection Status) | Connection status for newly created people (default Prospect). |
+
+### Contracts
+
+POCOs deserialized from LeagueApps JSON; epoch-millisecond dates use a custom `MillisecondEpochConverter`.
+
+| Class | Maps to |
+|-------|---------|
+| `Programs` | A program/league (id, name, sport, season, gender, mode, dates, URLs, logo). |
+| `Registrations` | A registrant within a program (`userId`, `team`, `role`). |
+| `Member` | A LeagueApps member (id, name, email, birth date, gender, address, phone, `groupId`). |
+
+### Migration-installed data
+
+| Defined Type / Attribute | Guid |
+|--------------------------|------|
+| Sport (Group defined type) | `3fc2b68b-9a24-46e9-b6d9-6c77b98abfb3` |
+| Season (Group defined type) | `cb85b2aa-46e6-4655-802c-4fe33379018d` |
+| Gender (Group defined type) + values | `4FACC42E-8783-4805-859F-AAC6D8951CE6` |
+| `LeagueAppsUserId` person attribute | `FA679B84-53A4-4DE9-84B5-D4EAFCC52E75` |
+| `League Apps Family Id` family-group attribute | `D9A8CBFB-4F9B-41B8-837F-24772A00FCAE` |
+
+## Dependencies & Integrations
+
+- **Rock:** Quartz job framework (`IJob`, `JobDataMap`), `RockContext` and Rock services
+  (`GroupService`, `PersonService`, `GroupMemberService`, `LocationService`, attribute/defined-value
+  services), `RockMigrationHelper` plugin migrations, `Rock.Security.Encryption`, the attribute and
+  caching frameworks.
+- **Cross-plugin:** [org.secc.DevLib](../org.secc.DevLib/README.md) — `SettingsComponent` base for
+  `LeagueAppsSettings`; [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) — types used by the
+  match helpers.
+- **Third-party APIs:** LeagueApps (`public.leagueapps.io`, `auth.leagueapps.io`,
+  `admin.leagueapps.io`) — public calls use an `la-api-key` header; private calls sign an RS256 JWT
+  with the PKCS#12 key and exchange it for an OAuth bearer token.
+- **Other:** RestSharp (public client), `System.Net.Http.HttpClient` (private client), `jose-jwt`
+  (JWT signing), `Security.Cryptography` (RSACng for CNG keys), Newtonsoft.Json.
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/`:
+
+- `001_CreateDefinedTypes` — Sport and Season defined types (`MigrationNumber 1`).
+- `002_CreateDefinedValues` — seed Sport/Season defined values (`MigrationNumber 2`).
+- `003_CreateGenderType` — Gender defined type (`MigrationNumber 3`).
+- `004_CreateGenderDefinedValues` — seed Gender defined values (`MigrationNumber 4`).
+- `005_CreateAttribute` — `LeagueAppsUserId` person attribute (`MigrationNumber 5`).
+- `006_FamilyAttribute` — `League Apps Family Id` family-group attribute (`MigrationNumber 6`).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** `ImportData` runs most of its work on a single long-lived `RockContext` (`dbContext`)
+  with repeated `SaveChanges()` inside loops, and re-queries groups/defined values per program. The
+  inner registrant loop does open a fresh `RockContext` per person, but the outer job can hold a large
+  tracked graph for the full run; worth reviewing for large program counts.
+- **Improvement:** `006_FamilyAttribute.Down()` is empty, so rolling that migration back leaves the
+  family attribute in place. The other migrations implement `Down()` — worth aligning for consistency.
+- **Improvement:** The two API base URLs and `"notasecret"` PKCS#12 password are hard-coded in
+  `APIClient` (the password matches Google service-account `.p12` convention). The auth flow also runs
+  async work via `.GetAwaiter().GetResult()`, which can deadlock under some sync contexts — acceptable
+  inside a Quartz job thread, but worth noting if this code is ever reused on a request thread.
+- **Improvement:** `LeagueAppsHelper.GetPersonByApiId` matches with a substring `Value.Contains(userId + "|")`,
+  while `ImportData` uses a stricter three-pattern match (`== id`, `Contains("|" + id + "|")`,
+  `StartsWith(id + "|")`). The substring `Contains` is the looser of the two — a query for `12|` also
+  matches a stored value like `512|` — so the two paths can disagree on which person an id maps to;
+  worth aligning `GetPersonByApiId` with the stricter `ImportData` patterns.
+- **Improvement:** `CreatePersonFromMember` calls `CampusCache.All().FirstOrDefault()` for new
+  families' campus, which is order-dependent rather than an explicit/configured campus.
+
+## Making Changes
+
+- To change which groups/group types/attributes the import targets, edit the attributes on the
+  **League Apps Settings** component in Rock — no code change needed. Their keys are defined in
+  `Utilities/Constants.cs`.
+- Person matching, creation, suffix parsing, and family resolution all live in
+  `Utilities/LeagueAppsHelper.cs`; the match overloads accept injected lists for unit testing.
+- To consume a new LeagueApps API field, add it to the matching `Contracts/*` POCO and reference it in
+  the job; API auth and request plumbing is in `Utilities/APIClient.cs`.
+- New seed data (defined types/values, attributes) belongs in a new numbered migration under
+  `/Migrations/` — don't hand-edit migrations that have already run.
+- Related: people created here flow through the same matching concerns as
+  [org.secc.PersonMatch](../org.secc.PersonMatch/README.md).

--- a/Plugins/org.secc.LessInclude/README.md
+++ b/Plugins/org.secc.LessInclude/README.md
@@ -1,0 +1,97 @@
+# org.secc.LessInclude
+
+> A CMS block that lets admins edit LESS variables/theme per page and compiles them to CSS on save, swapping the page's stylesheet for the result.
+
+## Overview
+
+LessInclude is a single Rock block (category **CMS**) that overrides a page's default theme CSS with
+a compiled-on-demand variant. An admin edits four LESS sources (variable overrides, full variables,
+theme, and print) in the block's custom-settings modal; on save the block compiles `bootstrap.less`
+and `theme.less` to CSS via the dotless engine and links the resulting files into the page header.
+Each block instance keeps its own copy of the LESS files under the active theme's `Styles/<blockId>/`
+folder, so per-page styling can diverge from the site theme. The plugin also ships the **StarkLess**
+theme as a starting point.
+
+## Project Info
+
+- **Project file:** `org.secc.LessInclude.csproj` (compiles only `Properties/AssemblyInfo.cs` to an
+  assembly; the `.ascx`/`.ascx.cs` block and `Themes/` are xcopied to RockWeb by a post-build step).
+- **Root namespace:** `org.secc.LessInclude` (block class namespace is `RockWeb.Plugins.org_secc.LessInclude`).
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/Plugins/org_secc/LessInclude/` (block markup), `RockWeb/Themes/` (StarkLess
+  theme), and `RockWeb/bin/` (`dotless.*`).
+
+## Project Layout
+
+```
+/org_secc/LessInclude/   LessInclude.ascx (+ .ascx.cs) — the CMS block + custom-settings modal
+/Themes/StarkLess/       Sample theme: Layouts/, Styles/ (LESS + base CSS), Assets/Lava/
+/Properties/             AssemblyInfo.cs (only compiled file)
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **CMS**.
+
+| Block | Purpose | Custom settings (LESS editors) |
+|-------|---------|--------------------------------|
+| Less Include | Includes custom CSS via LESS into the current page; compiles LESS to CSS on save and replaces the page's default stylesheet links. | **Variables**, **Overrides**, **Theme**, **Print** |
+
+The four settings are declared as `CodeEditorField` attributes scoped to `"CustomSetting"` (so they
+appear only in the block's settings modal, not standard block properties). They map to files written
+under the theme's `Styles/<blockId>/` folder:
+
+| Setting (key) | Type | File written | Notes |
+|---------------|------|--------------|-------|
+| **Variables** | LESS code editor | `_variables.less` | Full variable list. |
+| **Overrides** | LESS code editor | `_variable-overrides.less` | Variable overrides. |
+| **Theme** | LESS code editor | `theme.less` | Template/theme LESS. |
+| **Print** | LESS code editor | `_print.less` | Print stylesheet LESS. |
+
+Runtime behavior (`LessInclude.ascx.cs`):
+
+- `OnLoad` hides the page's `CSSDefault` placeholder, then links the block-specific `bootstrap.css`
+  and `theme.css` (falling back to the theme-level files if no per-block copy exists). Resolved paths
+  are cached per `BlockId + fileName`.
+- On first save the block creates `Styles/<blockId>/` and seeds it from `themeCustom.less` /
+  `bootstrapCustom.less`.
+- `mdEdit_SaveClick` writes the four LESS files, then `ProcessLess` compiles `bootstrap.less` and
+  `theme.less` with `dotless.Core` (`Less.Parse`), saves the CSS, and clears the cached paths.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockBlockCustomSettings`, `RockBlock`/`RockPage`, `CodeEditorField`, `Rock:ModalDialog`,
+  `Rock:CodeEditor`, the block caching API (`GetCacheItem`/`AddCacheItem`/`RemoveCacheItem`).
+- **Third-party:** `dotless` 1.5.2 (`dotless.Core` — LESS-to-CSS compilation).
+- No REST, jobs, Lava filters, field types, or migrations.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** The block writes files into the live theme's `Styles/<blockId>/` directory
+  at runtime based on admin-entered LESS, and links them into the page header. Since the settings
+  modal is admin-only this is expected, but the block has effective write access to the theme
+  directory and compiles attacker-controllable LESS — worth confirming the settings modal is gated to
+  trusted CMS-admin roles and that the theme folder isn't writable by lower-privilege paths.
+- **Improvement:** Every file-touching method (`GetFileLocation` on `OnLoad`, plus `GetPageFile`,
+  `ProcessLess`, and `SavePageFile` on the settings/save path) sets `Environment.CurrentDirectory`
+  on a shared web process. Setting process-global CWD from a request is not thread-safe and can race
+  with concurrent requests; consider passing absolute mapped paths to the file APIs instead of
+  relying on CWD.
+- **Improvement:** Compiled CSS is written directly into `RockWeb/Themes/...`, which is typically
+  redeployed/overwritten on plugin or theme updates. Per-block compiled output living under the theme
+  folder may be lost on deploy — worth confirming the `Styles/<blockId>/` artifacts are
+  backed up or regenerated.
+
+## Making Changes
+
+- Block logic (CSS swap, LESS compilation, per-block file storage) lives in
+  `org_secc/LessInclude/LessInclude.ascx.cs`; the settings modal markup is in the matching `.ascx`.
+- To change which LESS files compile or where output lands, edit `ProcessLess` / `SavePageFile` /
+  `GetFileLocation` in the `.ascx.cs`.
+- The sample theme (layouts, base LESS/CSS, seed `themeCustom.less` / `bootstrapCustom.less`) is under
+  `Themes/StarkLess/`; new LESS settings would add a `CodeEditorField` attribute plus a save call in
+  `mdEdit_SaveClick`.

--- a/Plugins/org.secc.Mapping/README.md
+++ b/Plugins/org.secc.Mapping/README.md
@@ -1,0 +1,128 @@
+# org.secc.Mapping
+
+> Computes and caches driving distance/time from an address to a set of Rock entities (campuses, groups) via the Azure Maps Route Matrix API, exposed as a REST endpoint and a workflow action.
+
+## Overview
+
+Mapping answers "which of these is closest to me?" for a supplied address. A REST endpoint takes
+an address plus a defined-value that names a mappable entity set (a campus list, a group type, a
+parent group's children, or a location-valued attribute), resolves each entity's address, asks
+Azure Maps for driving distance and time, and returns them ordered by **shortest travel time**
+(`OrderBy(TravelDuration)`), nearest-first. Results are cached
+(in-memory + a backing table) so repeat lookups don't re-hit the paid API. It also ships a
+"Closest Campus" workflow action for use inside Rock workflows.
+
+## Project Info
+
+- **Project file:** `org.secc.Mapping.csproj`
+- **Root namespace:** `org.secc.Mapping`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`, via the PostBuildEvent `xcopy`). The
+  PostBuildEvent also xcopies an `org_secc` folder, but none ships in source (no `.ascx` markup).
+
+## Project Layout
+
+```
+/Azure/        AzureDistanceMatrix — calls the Azure Maps Route Matrix API, merges cached results
+/Data/         MappingContext (EF DbContext on RockContext) + base MappingService<T>
+/Model/        Destination (transient DTO) + LocationDistanceStore entity & service (distance cache)
+/Rest/Controllers/  DistanceController — api/mapping/distance endpoint, per-entity-type resolvers
+/Utilities/    CampusUtilities, GroupUtilities (build destination lists), Constants (defined-type Guid)
+/Workflow/     ClosestCampusAction — "Closest Campus" workflow action
+/Migrations/   Rock plugin migrations (distance table, "Distance Mappable Entities" defined type)
+```
+
+## Components
+
+### REST Endpoints
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `api/mapping/distance/{definedValueId}/{address}` | GET (authenticated) | Order the entities described by `{definedValueId}` by travel **time** from `{address}` (results are sorted by `TravelDuration`). Returns a `{ entityId: distanceInMiles }` dictionary — the *values* are the travel distance in miles, but the *ordering* is by duration. |
+
+`{definedValueId}` must be a value in the **Distance Mappable Entities** defined type
+(`Constants.UniversalDefinedTypeGuid` = `7F70ABE9-1705-4DED-BABE-6D720EC52914`); otherwise the
+endpoint returns `BadRequest`. The defined value's **EntityType** attribute selects the resolver:
+
+| EntityType | EntityId means | Resolver |
+|------------|----------------|----------|
+| `Campus` | (ignored) | All campuses with a `Location.Street1` (`CampusUtilities.OrderCampusesByDistance`). Returns an ordered `List<CampusCache>`, nearest-first — **not** a dictionary like the other resolvers. |
+| `ParentGroup` | parent group Id | Active, non-archived, public child groups of that group that also have a group-location whose `PostalCode` is non-empty (`GroupUtilities.GetGroupsDestinations`). Groups with no usable location are dropped. |
+| `GroupType` | group type Id | Active, non-archived, public groups of that type, same group-location/`PostalCode` filter as `ParentGroup`. |
+| `Attribute` | attribute Id | Locations referenced by that attribute's values (each value is parsed as a `Location` Guid; non-Guid/empty values are skipped). |
+
+### Workflow Actions
+
+| Action (ComponentName) | Category | Purpose | Key settings |
+|------------------------|----------|---------|--------------|
+| `ClosestCampusAction` ("Closest Campus") | SECC > Mapping | Resolve the campus closest to an address and write its Guid to a Campus attribute. | **Origin** (text-or-attribute, Lava), **Campus** (Campus attribute, output) |
+
+The action runs the async lookup synchronously (`Task.Run(...).Wait()`); exceptions are logged to
+the workflow action and execution still returns `true`.
+
+### Models
+
+| Type | Table | Notes |
+|------|-------|-------|
+| `LocationDistanceStore` | `_org_secc_Mapping_LocationDistanceStore` | Persistent distance cache: `Origin`, `Destination` (both formatted-address strings, indexed), `TravelDistance` (miles), `TravelDuration` (minutes), `CalculatedBy`. `Model<T>`, `ISecured`, `IRockEntity`. |
+| `Destination` | — | Transient DTO (not persisted). Holds `EntityId`, `LocationId`, `Address` (lazily resolved from `LocationId` via `LocationService`), and the computed distance/duration. `LavaVisible` on `EntityId`. |
+
+`LocationDistanceStoreService.LoadDurations` checks an in-memory `RockCache` region
+(`org.secc.Mapping.LocationDistance`) first, then the `LocationDistanceStore` table, before
+`AzureDistanceMatrix` calls the API for anything still uncalculated; new results are written back to
+both.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, `DefinedValueCache` / `CampusCache` / `GlobalAttributesCache`, `RockCache`,
+  `LocationService` / `GroupService` / `GroupLocationService` / `AttributeValueService`, workflow
+  engine (`ActionComponent`), Rock REST (`ApiControllerBase`, `[Authenticate]`), plugin migrations,
+  EntityFramework 6.
+- **Third-party:** Azure Maps **Route Matrix API** (`atlas.microsoft.com/route/matrix`, key from the
+  `AzureMapsKey` global attribute), Newtonsoft.Json.
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/`:
+
+- `001_Init` — creates `_org_secc_Mapping_LocationDistanceStore` (the distance cache table).
+- `002_AddDefinedType` — creates the **Distance Mappable Entities** defined type (under Tools) with
+  two attributes: `EntityType` (DDL field; `values` qualifier
+  `GroupType^Group Type,ParentGroup^Child Groups of Group,Campus^Campus,Attribute^Address Attribute`)
+  and `EntityId` (text field). It seeds four defined values: **Campus** (`EntityType=Campus`),
+  **Home Groups** (`GroupType`, EntityId `60`), **Blankenbaker Home Groups** (`ParentGroup`, EntityId
+  `820057`), and **Content Channel Attributes** (`Attribute`, EntityId `89281`).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** `{address}` is passed straight through to the Azure Maps payload and is also
+  stored as the `Origin` column (the in-memory cache key is `origin + destinationAddress`). The
+  endpoint is `[Authenticate]`-gated, so callers must be
+  logged-in Rock users, but the address travels in the URL path (logged in IIS/proxy logs). Worth
+  confirming that's acceptable for the addresses being queried.
+- **Improvement:** The Azure Maps key is read from the `AzureMapsKey` global attribute on every call;
+  confirm that attribute is stored encrypted and not broadly readable, since it bills against a paid
+  Azure subscription. If `AzureMapsKey` is empty the request still fires and simply fails (logged),
+  rather than short-circuiting.
+- **Improvement:** `AzureDistanceMatrix.OrderDestinations` returns **only** destinations where
+  `IsCalculated == true`, sorted by `TravelDuration`. Any address Azure can't route (bad/foreign
+  address, API failure) is silently dropped from the results rather than reported, so the caller can't
+  distinguish "far away" from "couldn't be calculated." Note the sort key is travel *time*, while the
+  REST response values are travel *distance* in miles — the two can disagree on ordering.
+- **Improvement:** `Destination.Address`'s getter constructs a new `RockContext` and runs a
+  `LocationService.Get` on first access — a side effect hidden in a property getter, and one context
+  per uncached destination when building large lists.
+
+## Making Changes
+
+- To add a new mappable entity kind, add a `case` in `DistanceController.GetDistance` (and a matching
+  resolver) and extend the `EntityType` attribute's DDL `values` qualifier in a new migration; the
+  endpoint dispatches purely on the defined value's `EntityType`.
+- The Azure Maps request shape (travel mode, route type, units) lives in
+  `Azure/AzureDistanceMatrix.cs`; distance is converted to miles and duration to minutes there.
+- Caching behavior (in-memory region + `LocationDistanceStore` table) is in
+  `Model/LocationDistanceStoreService.cs`.
+- The "Closest Campus" workflow action is MEF-discovered (`[Export(typeof(ActionComponent))]`); see
+  [org.secc.Workflow](../org.secc.Workflow/README.md) for the broader library of SECC workflow actions.

--- a/Plugins/org.secc.MetricsDigest/README.md
+++ b/Plugins/org.secc.MetricsDigest/README.md
@@ -1,0 +1,110 @@
+# org.secc.MetricsDigest
+
+> A single scheduled job that emails a per-campus "metric entry progress" digest, showing how many of the selected metrics have values entered for a date range.
+
+## Overview
+
+MetricsDigest is a one-class Rock plugin: a Quartz scheduled job that audits **metric data entry**.
+For each configured metric category it counts, per campus (and per service schedule, when the metric
+is partitioned by schedule), how many metrics should have values for the chosen date range versus how
+many actually do. It rolls those counts into Lava merge fields and emails them via a System
+Communication to a notification group — so staff can see which campuses are behind on entering their
+weekly metrics.
+
+> **Scope note:** only metrics whose partitions include a **Campus** partition are counted. A selected
+> metric with no campus partition is added to the `Metrics` merge field but contributes nothing to the
+> per-campus tallies. Schedule sub-counts are only computed when the metric *also* has a Schedule
+> partition.
+
+## Project Info
+
+- **Project file:** `org.secc.MetricsDigest.csproj`
+- **Root namespace:** `org.secc.MetricsDigest` (note: the job's actual C# namespace is `org.secc.Jobs`)
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`, via the PostBuildEvent `xcopy`)
+
+## Project Layout
+
+```
+MetricsDigest.cs        The job (IJob) + the MetricCount Lava Drop
+/Properties/            AssemblyInfo
+```
+
+## Components
+
+### Jobs
+
+A single Quartz `IJob` (`[DisallowConcurrentExecution]`), wired up as a Rock Job and configured
+entirely through job attributes (read from the `JobDataMap`).
+
+| Job (class) | Purpose |
+|-------------|---------|
+| `MetricsDigest` | Counts entered vs. expected metric values per campus/schedule for a date range and emails the digest to a notification group. |
+
+### Job Settings
+
+Rock attributes declared on the class; values are read from the `JobDataMap` by key. The **key** is the
+display name with spaces removed (Rock's default), which is what `dataMap.GetString(...)` uses.
+
+| Attribute (display name) | JobDataMap key | Type | Required | Notes |
+|--------------------------|----------------|------|----------|-------|
+| **Metrics** | `Metrics` | `MetricCategoriesField` | Yes | Metric categories to include; expanded to metric/category Guid pairs. |
+| **Date Range** | `DateRange` | `SlidingDateRangeField` | Yes | Date range over which metric entries are reviewed. |
+| **Schedule Categories** | `ScheduleCategories` | `CategoryField` (`Rock.Model.Schedule`) | Yes | Schedule categories used to build the per-service list (needs Campus Attribute to filter by campus). |
+| **Campus Attribute** | `CampusAttribute` | `AttributeField` (Schedule entity) | No | Schedule attribute used to filter schedules by campus. |
+| **Notification Group** | `NotificationGroup` | `GroupField` | Yes | Group whose members receive the digest email. |
+| **Email** | `Email` | `SystemCommunicationField` | Yes | System Communication template sent to each member. The job throws if unset. |
+
+### Models / Lava Drops
+
+| Type | Purpose |
+|------|---------|
+| `MetricCount` (`DotLiquid.Drop`) | Per-campus tally exposed to Lava: `Campus`, `TotalEntered`, `TotalMetrics`. |
+
+Merge fields passed to the email template: `MetricCounts` (list of `MetricCount`), `Metrics`
+(the resolved `Metric` list), `DateRange` (string), and `LastRunDate` (the job's last successful run).
+
+## Dependencies & Integrations
+
+- **Rock:** Quartz job framework (`IJob`, `JobDataMap`), `RockContext` and Rock services
+  (`MetricService`, `CategoryService`, `GroupService`, `ScheduleService`, `AttributeValueService`,
+  `ServiceJobService`), `CampusCache` / `CategoryCache`, the metric partition model, `RockEmailMessage`
+  + System Communications, and Lava (`LavaHelper`, `SlidingDateRangePicker`, `InetCalendarHelper`).
+- **Third-party:** DotLiquid (`Drop`), Ical.Net / DDay.iCal / NodaTime (transitive, via schedule
+  occurrence calculation), Entity Framework.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** The job class lives in namespace `org.secc.Jobs` while the assembly/root namespace
+  is `org.secc.MetricsDigest`. Functionally harmless (the [org.secc.Jobs](../org.secc.Jobs/README.md)
+  plugin uses the same namespace but has no `MetricsDigest` type, so the two coexist), but the mismatch
+  is surprising and makes the class harder to locate from its assembly name.
+- **Improvement:** `AssemblyInfo.cs` is mis-scaffolded — title/product read `org.secc.ConnectionsDigest`
+  and the company/copyright are the default `"Microsoft"` / `"Copyright © Microsoft 2017"` rather than
+  Southeast Christian Church. Cosmetic, but the title is plainly wrong for this assembly.
+- **Improvement:** `metric.MetricValues` and `metric.MetricPartitions` are walked in memory rather than
+  queried, and `metricCounts.Where(...).FirstOrDefault()` is re-evaluated repeatedly inside nested
+  loops over campuses/services. For a large metric history this loads and scans a lot of rows; a
+  filtered query (or a dictionary keyed by campus) would scale better.
+- **Improvement:** `int jobId = Convert.ToInt16(context.JobDetail.Description)` parses the job Id out of
+  the job *Description* field — fragile if that field is ever edited to hold real description text. The
+  Id is normally available more directly from the execution context.
+- **Improvement:** The whole compute-and-send block is gated on `notificationGroup != null &&
+  metricCategories.Count > 0 && dateRange.Start.HasValue && dateRange.End.HasValue`. If any of those
+  fail (no group, no categories, open-ended date range) the job sends **nothing** and silently returns
+  `"Sent 0 metric entry digest emails."` with no warning — a misconfiguration looks like a successful
+  run. `GroupMember.Person.Email` is also used without a null/blank check, so members with no email
+  address can produce empty recipients.
+
+## Making Changes
+
+- All behavior lives in `MetricsDigest.cs`. To change *what* is counted, edit the per-metric/partition
+  loop in `Execute`; to change the per-service schedule resolution, edit the private `GetServices`
+  helper.
+- To add a configuration option, add a Rock `*Field` attribute on the class and read it from
+  `dataMap.GetString("<Key>")` — keep the attribute key and the lookup string in sync.
+- Email content/layout is driven by the configured System Communication template and the merge fields
+  above (`MetricCounts`, `Metrics`, `DateRange`, `LastRunDate`); edit the template in Rock, not here.
+- Related scheduled jobs live in [org.secc.Jobs](../org.secc.Jobs/README.md).

--- a/Plugins/org.secc.Microframe/README.md
+++ b/Plugins/org.secc.Microframe/README.md
@@ -1,0 +1,113 @@
+# org.secc.Microframe
+
+> Drives physical Microframe LED paging signs over TCP — pushing child-pickup codes from Rock so they display (and clear) on the boards.
+
+## Overview
+
+Microframe lets check-in staff manage the codes shown on Southeast's physical Microframe LED
+"pager" boards. Codes are grouped into **Sign Categories**; each **Sign** (a network-addressable
+board with an IP/port/PIN) subscribes to one or more categories. When a code is added or removed —
+either through the Sign Code Manager block or the scheduled job — the plugin opens a TCP socket to
+each affected sign and synchronizes its displayed tags. Two custom entities (`Sign`, `SignCategory`)
+and a set of admin blocks/pages make up the UI.
+
+## Project Info
+
+- **Project file:** `org.secc.Microframe.csproj`
+- **Root namespace:** `org.secc.Microframe`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup)
+
+## Project Layout
+
+```
+/Model/        Sign, SignCategory entities + their services
+/Data/         MicroframeContext / MicroframeService (EF DbContext)
+/Utilities/    SignUtilities (sync orchestration) + MicroframeConnection (async TCP client)
+/Jobs/         UpdateSigns — Quartz job that re-syncs all signs
+/Migrations/   Rock plugin migrations (tables, pages/blocks, indexes)
+/org_secc/Microframe/   UI blocks (.ascx + .ascx.cs)
+```
+
+## Components
+
+### Models
+
+| Entity | Table | Notes |
+|--------|-------|-------|
+| `Sign` | `_org_secc_Microframe_Sign` | A physical board: `Name`, `Description`, `IPAddress`, `Port`, 4-char `PIN`. Many-to-many to `SignCategory` via `_org_secc_Microframe_SignSignCategory`. |
+| `SignCategory` | `_org_secc_Microframe_SignCategory` | A named group of codes. `Codes` is a single comma-delimited string column. |
+
+Both implement `Rock.Data.Model<T>`, `ISecured`, and `IRockEntity`.
+
+### Blocks
+
+Category in Rock: **SECC > Microframe**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Sign List | Lists all signs; links to detail. | **DetailPage** |
+| Sign Detail | Edit a sign (name, IP, port, PIN) and its category memberships. | — |
+| Sign Category List | Lists all sign categories; links to detail. | **DetailPage** |
+| Sign Category Detail | Edit a category (name, description). | — |
+| Sign Code Manager | Add/remove codes within a category; pushes the change to subscribed signs immediately. | **Max Length** (`IntegerField`, key `MaxLength`, default 4). A `DetailPage` `LinkedPage` attribute is also registered by the migration but is unused by the block. |
+
+`Sign Code Manager` validates each code against `^\w+$` and the `MaxLength` attribute, writes the
+updated comma-delimited `Codes` string, then calls `SignUtilities.UpdateSignCategorySigns`.
+
+### Jobs
+
+| Job | Purpose |
+|-----|---------|
+| `UpdateSigns` | `[DisallowConcurrentExecution]` Quartz job; calls `SignUtilities.UpdateAllSigns()` to re-push every sign's codes. Returns immediately — the socket work is asynchronous, so completion of the job does not mean every sign has finished updating. |
+
+### Sign sync / device protocol
+
+`SignUtilities` gathers a sign's codes (union of its categories' comma-split `Codes`) and hands them
+to `MicroframeConnection`, which speaks the board's TCP protocol via async `Socket` callbacks:
+
+- Connects to `IPAddress:Port` (`SignUtilities` falls back to port **9107** when the `Port` string is
+  unparsable) and prefixes each message with the 2-byte PIN. The PIN is derived by splitting the 4-char
+  `PIN` into two 2-digit halves and converting each to a byte (`ConvertPIN`); a PIN that isn't exactly
+  4 chars silently becomes `{0x00, 0x00}`.
+- Sends `GLA` to read the sign's current tags, then diffs: emits `S+ <code>` to add missing codes
+  (truncated to 4 chars) and `S- <tag>` to remove tags no longer present.
+- A `resets` watchdog retries the connection up to 10 times before giving up.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, Rock entity/service framework, the block/UI framework, Quartz job engine, plugin migrations.
+- **Third-party:** Physical Microframe LED sign hardware (raw TCP socket protocol); Quartz.NET; Entity Framework 6.
+- **Cross-plugin:** `org.secc.DevLib` (migration extension helpers used in `003_Indexes`). Codes mirror the child-pickup codes used by check-in — see [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md).
+
+## Migrations
+
+- `001_Init` — creates the `Sign`, `SignCategory`, and `SignSignCategory` join tables.
+- `002_PagesMigration` — Microframe admin pages, the five block types, and block instances.
+- `003_Indexes` — primary keys, PersonAlias foreign keys, and Guid/Foreign* indexes (each block wrapped in `try/catch`).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** The sign `PIN` is stored as plaintext in `_org_secc_Microframe_Sign.PIN` and
+  transmitted over an unencrypted TCP socket. This appears to match the device's native protocol
+  (the boards only support a 4-digit numeric PIN), so it's likely a hardware constraint rather than a
+  fixable defect — worth confirming these signs sit on a trusted internal VLAN.
+- **Improvement:** `MicroframeConnection`'s socket callbacks swallow exceptions into empty `catch {}`
+  blocks and `Console.WriteLine`, with no Rock logging. A sign that is offline or misconfigured fails
+  silently — there's no surfaced error for an operator. Worth routing failures to `ExceptionLogService`.
+- **Improvement:** `UpdateAllSigns` opens a fresh socket per sign with no batching or backoff; fine for
+  a handful of boards but worth noting if the sign count grows.
+
+## Making Changes
+
+- To change code validation or the immediate-push behavior, edit
+  `org_secc/Microframe/SignCodeManager.ascx.cs` (`btnAdd_Click` / `RemoveCode`).
+- The device protocol (connect, `GLA` diff, `S+`/`S-` framing, PIN encoding) lives entirely in
+  `Utilities/MicroframeConnection.cs`; the orchestration that gathers codes per sign is in
+  `Utilities/SignUtilities.cs`.
+- New entity columns or tables belong in a new numbered migration under `/Migrations/` (don't edit
+  migrations that have already run).
+- To re-sync signs on a schedule, configure the `UpdateSigns` job in Rock; see
+  [org.secc.Jobs](../org.secc.Jobs/README.md) for the other SECC scheduled jobs.

--- a/Plugins/org.secc.Migrations/README.md
+++ b/Plugins/org.secc.Migrations/README.md
@@ -1,0 +1,104 @@
+# org.secc.Migrations
+
+> A library of Rock plugin migrations that install SECC's pages, workflows, defined types, attributes, stored procedures, and DB triggers at startup.
+
+## Overview
+
+This assembly contains nothing but Rock plugin migrations — C# classes implementing `Rock.Plugin.Migration`,
+each tagged with a `[MigrationNumber(n, "rockVersion")]` attribute. Rock discovers and runs them in
+number order the first time the plugin assembly loads, then records each as applied so it never re-runs.
+The migrations stand up the foundational data for several SECC ministries (check-in, finance, groups,
+pastoral care, MOC, volunteer application, etc.) by calling `RockMigrationHelper` and raw `Sql(...)`.
+
+## Project Info
+
+- **Project file:** `org.secc.Migrations.csproj`
+- **Root namespace:** `org.secc.Migrations`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly only; post-build `xcopy` of `org.secc.Migrations.*`)
+- **References:** `Rock.csproj` (project ref) and EntityFramework 6.1.3
+
+## Project Layout
+
+```
+/                    Root-level migrations (Finance stored procs, Events campaign attribute)
+/Connection/         Connection-opportunity attribute migration (Safety & Security)
+/GroupApp/           Defined-type migrations backing the Group App
+/Metric/             SQL trigger that logs worship-attendance MetricValue changes to history
+/Pages/              Migrations that create Rock pages/blocks for SECC features
+/WorkflowsTypes/     Migrations that install SECC workflow types
+/Properties/         AssemblyInfo
+```
+
+## Components
+
+All components are migrations. Each runs once, in `MigrationNumber` order, and most provide a `Down()`
+that removes what `Up()` created (the stored-proc/trigger migrations re-create on `Up()` and largely
+no-op on `Down()`).
+
+### Migrations
+
+| # | Class | Folder | Installs |
+|---|-------|--------|----------|
+| 2 | `MOC_WorkflowData` | WorkflowsTypes | MOC (Ministry Opportunity / Connection) workflow type |
+| 3 | `FamilyCheckin_PageData` | Pages | Family Check-in pages/blocks |
+| 4 | `GroupFinderMap_PageData` | Pages | Group Finder Map page/blocks *(not in .csproj — see Observations)* |
+| 5 | `GroupManager_PageData` | Pages | Group Manager pages/blocks |
+| 6 | `MOC_PageData` | Pages | MOC pages/blocks |
+| 7 | `Purchasing_PageData` | Pages | Purchasing pages/blocks |
+| 9 | `SuperyCheckin_PageData` | Pages | Super Check-in pages/blocks |
+| 10 | `SuperCheckin_WorkflowData` | WorkflowsTypes | Super Check-in workflow type |
+| 11 | `FamilyCheckin_WorkflowData` | WorkflowsTypes | Family Check-in workflow type |
+| 12 | `SportsAndFitness_WorkflowData` | WorkflowsTypes | Sports & Fitness workflow type |
+| 13 | `Pastoral_WorkflowData` | WorkflowsTypes | Pastoral Care workflow types |
+| 14 | `GroupTreasurerReport_WorkflowData` | WorkflowsTypes | Group Treasurer Report workflow type |
+| 15 | `VolunteerApplication_WorkflowData` | WorkflowsTypes | Volunteer Application workflow type (largest migration, ~1.4k lines) |
+| 16 | `SafetyAndSecurity_ConnectionVerification` | Connection | Connection-opportunity attributes `SecurityToConnect`, `ConnectableStatuses` |
+| 17 | `GroupAppGroupTypeMigration` | GroupApp | "Group App Group Types" defined type |
+| 18 | `GroupAppTableBasedGroupsMigration` | GroupApp | "Group App Table-Based Group Types" defined type |
+| 19 | `WorshipAttendanceTrigger` | Metric | SQL triggers `_org_secc_trgMetricValueWorshipAttendanceInsertLogToHistory` and `_org_secc_trgMetricValueWorshipAttendanceUpdateLogToHistory` on `MetricValue` |
+| 19 | `GroupAppStudentGroupsMigration` | GroupApp | "Group App Student Group Types" defined type *(not in .csproj; duplicate # — see Observations)* |
+| 30 | `Finance_MoveContributionSummaryStoredProcedure` | / | Recreates proc `_org_secc_Commitment_GetTotalsByPersonId` |
+| 31 | `Finance_MoveContributionSummaryStoredProcedure_002` | / | Updates the same contribution-summary proc |
+| 32 | `Finance_MoveContributionSummaryStoredProcedure_003` | / | Updates the same contribution-summary proc |
+| 33 | `Events_CommunityGivesBackCampaignAttribute` | / | Adds `Year` defined-type attribute; backfills existing values to "2024" |
+
+## Dependencies & Integrations
+
+- **Rock:** `Rock.Plugin.Migration`, `RockMigrationHelper`, `DefinedTypeCache`, and the Rock plugin-migration
+  runner (numbered, version-gated, run-once). Raw `Sql(...)` for stored procedures and triggers.
+- **Third-party:** EntityFramework 6.1.3 (migration base infrastructure).
+- **Cross-plugin:** Installs the data backing many SECC plugins — e.g. check-in
+  ([org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md)), pastoral care
+  ([org.secc.PastoralCare](../org.secc.PastoralCare/README.md)), finance
+  ([org.secc.Finance](../org.secc.Finance/README.md)), and connections
+  ([org.secc.Connection](../org.secc.Connection/README.md)).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** Two `.cs` files are present in the folder but **not included in `org.secc.Migrations.csproj`**
+  (`Pages/GroupFinderMap_PageData.cs`, migration #4; `GroupApp/GroupAppStudentGroups.cs`, migration #19), so
+  they are not compiled or run. Worth confirming whether they were intentionally dropped or accidentally
+  excluded.
+- **Improvement:** Migration number **19 is used twice** — by `WorshipAttendanceTrigger` (compiled) and
+  `GroupAppStudentGroupsMigration` (not compiled). Even though only one is built today, re-adding the second
+  to the project without renumbering would collide. Migration numbers should be unique within an assembly.
+- **Improvement:** Migration #33 (`Events_CommunityGivesBackCampaignAttribute`) **hard-codes the year "2024"**
+  when backfilling defined values. That's expected for a one-shot data migration, but the value won't update
+  for later campaigns — new years need their own migration or a config-driven approach.
+- **Improvement:** Most workflow/stored-proc/trigger migrations have an empty or no-op `Down()`, so rolling
+  back is effectively one-way. Acceptable for run-once installs, but note it before relying on `Down()`.
+
+## Making Changes
+
+- To add new data, create a **new** migration class with the next unused `[MigrationNumber]` and add it to
+  `org.secc.Migrations.csproj`; never edit a migration that has already run in production (Rock won't re-run
+  it). Verify the number isn't already taken (see the duplicate-19 note above).
+- Page/block installs go under `/Pages/`, workflow types under `/WorkflowsTypes/`, defined types under the
+  feature folder (e.g. `/GroupApp/`); follow the existing `RockMigrationHelper` patterns.
+- Stored procedures and triggers are created via raw `Sql(...)` (see `/Metric/` and the root `Finance_*`
+  files) — guard with `IF EXISTS ... DROP` so the migration is idempotent on re-create.
+</content>
+</invoke>

--- a/Plugins/org.secc.OAuth/README.md
+++ b/Plugins/org.secc.OAuth/README.md
@@ -1,0 +1,193 @@
+# org.secc.OAuth
+
+> A self-hosted **OAuth 2.0 authorization server** for Rock — issues tokens against Rock `UserLogin` credentials, with admin-managed clients/scopes and a small set of profile REST endpoints.
+
+> **Doc tier: deep.** This plugin is externally-facing security infrastructure (it stands up an OWIN OAuth authorization server inside Rock and brokers credentials), so it's documented at the deeper technical tier — token flow, the OWIN provider contract, config attributes, and edge cases. Most SECC plugins use the lighter standard tier.
+
+## Overview
+
+OAuth turns Rock into its own OAuth 2.0 provider. It wires an OWIN authorization server into the Rock pipeline at startup, hosts a login/authorize/logout portal on a dedicated Rock site, and lets staff register **clients** (API key/secret + callback URL) and **scopes** through an admin block. Third-party apps send users to the Authorize page, the user signs in with their Rock credentials and consents to scopes, and the app exchanges the resulting code for a bearer token it can use against the `api/oauth/*` endpoints (or any Rock REST endpoint). It also ships "service provider" blocks so one Rock instance can act as an OAuth *client* of another (auth chaining / SSO between Rock sites).
+
+## Project Info
+
+- **Project file:** `org.secc.OAuth.csproj`
+- **Root namespace:** `org.secc.OAuth`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `Microsoft.Owin.Security.OAuth/Cookies`, `System.Web.Http.Owin`, `Microsoft.AspNet.Identity.Core`, `DotNetOpenAuth*`) and `RockWeb/Plugins/org_secc/` (block markup)
+
+## Project Layout
+
+```
+/                       Startup.cs — IRockOwinStartup hook that builds the OAuth server; OAuthClient.cs — client-side helper
+/Data/                  OAuthContext (EF DbContext on RockContext) + base OAuthService<T>
+/Model/                 Client, Scope, ClientScope, Authorization entities + services; AuthToken + AuthTokenService (sproc-backed code storage)
+/Rest/Controllers/      OAuthController — api/oauth/* profile + family endpoints (bearer-gated)
+/Utilities/             TokenResponse — DTO for deserializing a token endpoint response
+/Migrations/            Rock plugin migrations (tables, OAuth site/pages, admin page, seed client/scopes, token storage)
+/org_secc/OAuth/        UI blocks (.ascx + .ascx.cs): Authorize, Login, Logout, Configuration, OAuthServiceProvider, OAuthRestorer, AuthLogout
+```
+
+## How the OAuth Server Works
+
+`Startup` implements `Rock.Utility.IRockOwinStartup`; Rock calls `OnStartup(IAppBuilder)` and the plugin registers cookie auth, an OAuth authorization server, and bearer authentication onto the OWIN pipeline. Endpoint paths and lifespans come from the `OAuthSettings` global attribute (a key/value list).
+
+```mermaid
+flowchart TD
+    A[Client app redirects user to /OAuth/Authorize] --> B[Authorize block]
+    B --> C{User logged in?<br/>OAuth identity?}
+    C -->|no| D[/OAuth/Login block<br/>validates Rock UserLogin/]
+    D --> B
+    C -->|yes, scopes not yet granted| E[Show scope consent<br/>rptScopes; user clicks Grant]
+    E --> F[Persist Authorization rows<br/>per client+scope]
+    F --> B
+    C -->|yes, scopes approved| G[OWIN issues authorization code<br/>CreateAuthenticationCode]
+    G --> H[(AuthToken sproc storage<br/>_org_secc_OAuth_Token)]
+    G --> I[Redirect to client CallbackUrl with code]
+    I --> J[Client POSTs code to /OAuth/Token<br/>Basic auth = ApiKey:ApiSecret]
+    J --> K[ValidateClientAuthentication<br/>+ ReceiveAuthenticationCode]
+    K --> L[Bearer access token returned]
+    L --> M[Client calls api/oauth/profile etc.<br/>HostAuthenticationFilter Bearer]
+```
+
+**Conventions / contracts:**
+- **Startup ordering** is `0` (does not matter). The hook runs `app.UseCookieAuthentication`, `app.UseOAuthAuthorizationServer`, and `app.UseOAuthBearerAuthentication`.
+- The OWIN `OAuthAuthorizationServerProvider` delegates drive the server lifecycle: `OnValidateClientRedirectUri`, `OnValidateClientAuthentication`, `OnGrantResourceOwnerCredentials`, `OnGrantClientCredentials` (all in `Startup`).
+- **Authorization codes** are generated as two concatenated GUIDs and persisted via `AuthTokenService` (stored procedures `_org_secc_OAuth_spAddToken/spGetTicket/spDeleteToken`); a code is single-use — `ReceiveAuthenticationCode` deletes it on consumption.
+- **Refresh tokens** are serialized OWIN tickets with an optional lifespan from `OAuthRefreshTokenLifespan` (hours).
+- **Scopes** are carried as `urn:oauth:scope` claims. A request only gets the intersection of requested scopes and the client's active `ClientScope` rows. If a client has *no* active client-scopes, all requested scopes are auto-approved (see Edge Cases).
+- **Credential validation** reuses Rock's `AuthenticationContainer` components — the same providers Rock uses for normal login (password, SMS, etc.), respecting `IsConfirmed` / `IsLockedOut`.
+- Entities are EF models on a dedicated `OAuthContext` that shares the `RockContext` connection but has its EF initializer set to `null` (no auto-migration).
+
+## Components
+
+### REST Endpoints
+
+Routes registered via `IHasCustomHttpRoutes`. The controller suppresses default host auth and applies a `HostAuthenticationFilter` for `OAuthDefaults.AuthenticationType` (bearer).
+
+| Route | Method | Scope required | Purpose |
+|-------|--------|----------------|---------|
+| `api/oauth/userlogin` | GET (bearer) | — | Returns `{ "Value": <username> }` for the token's current user. |
+| `api/oauth/profile` | GET (bearer) | `profile` | Returns a `Profile` (name, gender, birthdate, email, previous person ids). |
+| `api/oauth/family` | GET (bearer) | `family` | Returns the user's family members, each with role + `Profile`. |
+
+The token (`/OAuth/Token`) and authorize (`/OAuth/Authorize`) endpoints are **OWIN** endpoints registered in `Startup`, not MVC/WebApi routes — their paths are configured by `OAuthSettings`.
+
+### Blocks
+
+Categories in Rock: **SECC > Security** and **SECC > OAuth**.
+
+| Block | Category | Purpose |
+|-------|----------|---------|
+| OAuth Configuration | SECC > Security | Admin page: edit `OAuthSettings`, manage clients (key/secret/callback/scopes) and scopes. |
+| OAuth Authorize | SECC > Security | The authorization endpoint UI — consent/scope grant, restricted-group auth enforcement. |
+| OAuth Login | SECC > Security | Username/password login during the OAuth flow (issues the OWIN application cookie). |
+| OAuth Logout | SECC > Security | Signs the user out of the OAuth (OWIN) session. |
+| OAuth Service Provider | SECC > OAuth | Makes *this* Rock an OAuth **client** of another provider (kicks off the code flow, exchanges the code, logs the user in). |
+| OAuth Session Restorer | SECC > OAuth | Replays a stored `OAuthQueryString` cookie back into the Authorize page (auth chaining). |
+| Auth Logout | SECC > OAuth | Chained logout: signs out locally then forwards to an upstream provider's logout URL. |
+
+#### OAuth Configuration  *(SECC > Security)*
+Keys in **bold** are the block attribute keys.
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **OAuthConfigAttributeKey** | text (default `OAuthSettings`) | Which global attribute holds the server settings. |
+| **OAuthSite** | site (default `1`) | The OAuth portal site whose page routes populate the path dropdowns. |
+
+Saving writes the route/SSL/lifespan choices back into the `OAuthSettings` global attribute and flushes the attribute + global caches.
+
+#### OAuth Authorize  *(SECC > Security)*
+| Setting | Type | Notes |
+|---------|------|-------|
+| **OAuthConfigAttributeKey** | text, required (default `OAuthSettings`) | Server settings source. |
+| **RestrictedSecurityGroups** | enhanced-list (groups) | Members of these groups are limited to specific auth providers. |
+| **ApprovedAuthenticationProviders** | components (`AuthenticationContainer`) | Auth providers permitted for restricted-group members. |
+| **RejectedAuthenticationPage** | linked page | Where to send a restricted user who used a disallowed method. |
+| **AcceptableDomain** | text | If set and the request host differs, redirects to `https://<domain>` (fixes legacy bad URLs). |
+
+#### OAuth Login  *(SECC > Security)*
+Mirrors Rock's stock login block: **NewAccountPage**, **HelpPage**, **ConfirmCaption**, **ConfirmationPage**, **ConfirmAccountTemplate**, **LockedOutCaption**, **HideNewAccount**, **NewAccountButtonText**, **PromptMessage**. On success it sets the Rock auth cookie and creates the OWIN OAuth identity (name + first/nick/last name claims).
+
+#### OAuth Service Provider  *(SECC > OAuth)*
+| Setting | Type | Notes |
+|---------|------|-------|
+| **OAuthClient** | dropdown (from `_org_secc_OAuth_Client`) | The client record (key/secret/callback) used against the upstream provider. |
+| **AuthorizationURI** | text | Upstream authorize endpoint. |
+| **TokenURI** | text | Upstream token endpoint. |
+| **UserLoginEndpoint** | text | Upstream `api/oauth/userlogin`-style endpoint used to resolve the username. |
+
+### Data Model
+
+The four EF entities below are `DbSet`s on `OAuthContext` and each is a `Rock.Data.Model<T>` implementing `Rock.Security.ISecured`. `AuthToken` is **not** on the context and is **not** `ISecured` — it's a plain `internal` POCO accessed only via stored procedures:
+
+| Entity | Table | On `OAuthContext`? | Notes |
+|--------|-------|--------------------|-------|
+| `Client` | `_org_secc_OAuth_Client` | yes | ClientName, ApiKey (Guid), ApiSecret (Guid), CallbackUrl, Active. |
+| `Scope` | `_org_secc_OAuth_Scope` | yes | Identifier, Description, Active. |
+| `ClientScope` | `_org_secc_OAuth_ClientScope` | yes | Which scopes a client may request (Active). |
+| `Authorization` | `_org_secc_OAuth_Authorization` | yes | A user's per-client, per-scope consent (Active). |
+| `AuthToken` | `_org_secc_OAuth_Token` | no (sproc-backed) | Authorization-code storage; `internal` POCO, not `ISecured`, accessed only via `AuthTokenService` sprocs. |
+
+## Dependencies & Integrations
+
+- **Rock:** `IRockOwinStartup`, `RockContext`, `UserLoginService` / `AuthenticationContainer`, `Rock.Security.Authorization`, `GlobalAttributesCache`, `RockBlock`, Rock REST (`IHasCustomHttpRoutes`), plugin migrations.
+- **Third-party:** OWIN / Katana (`Microsoft.Owin.Security.OAuth`, `.Cookies`), `Microsoft.AspNet.Identity.Core`, `DotNetOpenAuth.OAuth2` (the client-side `WebServerClient` in `OAuthClient`), `Newtonsoft.Json`, EntityFramework 6.
+- **Cross-plugin:** none required at build time.
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/`:
+
+- `201605171249414_InitialCreate` — the four OAuth tables (Client, Scope, ClientScope, Authorization).
+- `201605201037000_CreatePlugin` — `OAuthSettings` global attribute, the OAuth **site**, portal/login/authorize/logout pages + routes, and the portal blocks.
+- `201605271634000_CreateAdminPage` — the **OAuth Configuration** admin page/block under Rock RMS.
+- `201605311211000_CreateClientScopes` — seeds an initial client and its client-scope rows.
+- `202507111500_CreateTokenStorage` — `_org_secc_OAuth_Token` table + `spAddToken`/`spGetTicket`/`spDeleteToken` stored procedures for authorization-code storage.
+
+## Edge Cases & Constraints
+
+- **Empty client-scope list = open consent.** In both `GrantResourceOwnerCredentials` (Startup) and the Authorize block, if a client has *no* active `ClientScope` rows, the scope check short-circuits to approved. A client registered without scopes effectively bypasses scope filtering — confirm that's intended for every registered client.
+- **SSL is enforced two ways.** `Startup` passes `AllowInsecureHttp = !OAuthRequireSsl`, and the Authorize block throws `"OAuth requires SSL."` on non-HTTPS when `OAuthRequireSsl` is true. Turning SSL off is a deliberate, global toggle in `OAuthSettings`.
+- **Authorization codes are single-use and server-stored.** `ReceiveAuthenticationCode` deletes the row on use; there is no built-in expiry/cleanup of unconsumed `_org_secc_OAuth_Token` rows (worth a janitor job if codes are abandoned often).
+- **Default `OAuthSettings` seed has a duplicate key.** The migration default string contains `OAuthTokenPath` twice (`/OAuth/Logout` then `/OAuth/Token`) and no `OAuthRefreshTokenLifespan`; values are normally corrected through the Configuration block on first save.
+- **SMS auth is special-cased.** The resource-owner grant allows `Rock.Security.ExternalAuthentication.SMSAuthentication` even though it normally requires remote authentication.
+- **Service-provider block needs a session.** `OAuthServiceProvider.OnInit` sets a dummy `Session["MockData"]` to guarantee a session exists before DotNetOpenAuth prepares the user-authorization request.
+
+## Observations
+
+*Noticed while documenting — not a full audit; security-sensitive areas flagged for confirmation.*
+
+- **Security (review):** Client credentials are matched with a LINQ-to-SQL string compare on `ApiKey`/`ApiSecret` GUIDs (`ValidateClientAuthentication`), and the `ApiSecret` is a plain GUID stored in the clear in `_org_secc_OAuth_Client` and shown in the admin UI. These act as a client password; confirm the admin page/block security is locked to trusted staff and consider whether secrets should be hashed. Comparison is not constant-time, though GUID secrets make timing attacks impractical.
+- **Security (review):** `OAuthController` endpoints catch all exceptions and return a generic 500, but `GetProfile`/`GetFamily` gate only on the presence of a `profile`/`family` scope claim — there is no per-field consent beyond that. Worth confirming the `profile` scope's data set (name, birthdate, email, previous person ids) matches what consenting users expect to share.
+- **Security (low):** The Authorize block's restricted-group check (`IsAuthenticationNotPermitted`) only restricts members of the configured groups; everyone else is unrestricted by design. Verify the restricted groups + approved providers are configured for any staff/admin roles you intend to constrain.
+- **Improvement:** `OAuthContext`, `RockContext`, and the various services are newed up per request/method (and several per call inside `GrantResourceOwnerCredentials`). Fine for an auth path, but the repeated `clientScopeService.Queryable()...` calls in the grant/authorize loops re-query the same client scopes multiple times.
+- **Improvement:** `AuthToken`/`AuthTokenService` bypass EF and call raw sprocs; the rest of the model uses `OAuthContext`. Two storage idioms in one plugin — intentional (the token table was added much later, in the 2025 migration) but worth a note for maintainers.
+
+## Extending
+
+To register a new bearer-protected endpoint, add an action to the partial `OAuthController` and gate it on a scope claim:
+
+```csharp
+// Rest/Controllers/OAuthController.Partial.cs
+[System.Web.Http.Route( "api/oauth/giving" )]
+public HttpResponseMessage GetGiving()
+{
+    var id = ( ClaimsIdentity ) User.Identity;
+    if ( id == null || !id.Claims.Any( c => c.Type == "urn:oauth:scope" && c.Value.ToLower() == "giving" ) )
+    {
+        return ControllerContext.Request.CreateResponse( HttpStatusCode.Forbidden, "Forbidden" );
+    }
+    var currentUser = UserLoginService.GetCurrentUser();
+    // … build and return the payload …
+    return ControllerContext.Request.CreateResponse( HttpStatusCode.OK, /* dto */ null );
+}
+```
+
+Then create a matching **Scope** (Identifier `giving`) in the OAuth Configuration block and add it to each client that should be allowed to request it. No code change is needed to wire scopes to clients — that's all admin data.
+
+## Making Changes
+
+- Server behavior (token lifespans, grant logic, scope claim handling) lives in `Startup.cs`; endpoint paths and SSL are data in the `OAuthSettings` global attribute, edited via the **OAuth Configuration** block (`org_secc/OAuth/Configuration.ascx.cs`).
+- Consent UI and scope-grant persistence are in `org_secc/OAuth/Authorize.ascx.cs`; the login screen is `Login.ascx.cs`.
+- New tables, pages, or seed clients/scopes belong in a new numbered migration under `/Migrations/` — don't hand-edit migrations that have already run.
+- For Rock-acting-as-client (SSO between sites), configure the **OAuth Service Provider** block and `OAuthClient.cs`; pair with **OAuth Session Restorer** / **Auth Logout** for chained login/logout.

--- a/Plugins/org.secc.PDF/README.md
+++ b/Plugins/org.secc.PDF/README.md
@@ -1,0 +1,127 @@
+# org.secc.PDF
+
+> Workflow actions that generate PDFs — render Lava/HTML to PDF, fill a PDF form template, and combine two PDFs — outputting the result to a binary-file workflow attribute.
+
+## Overview
+
+PDF adds a set of Rock workflow action components (category **PDF**) for producing documents inside
+a workflow. It can render an HTML/Lava template to a PDF (with header/footer), merge workflow data
+into a fillable PDF form template, and concatenate two existing PDFs into one. Each action writes its
+output to a Rock binary file and stores the file Guid on a workflow/activity attribute. Two example
+RockWeb blocks demonstrate driving these actions from a page.
+
+## Project Info
+
+- **Project file:** `org.secc.PDF.csproj`
+- **Root namespace:** `org.secc.PDF`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` only — the post-build `xcopy` copies `org.secc.PDF.dll`,
+  `NReco.PdfGenerator.*`, and `iText*.*`. The example blocks under `org_secc/PDFExamples/` are **not**
+  referenced by the `.csproj` (neither compiled nor deployed); they exist as standalone source only.
+
+## Project Layout
+
+```
+/Workflows/    Workflow action components — LavaPDF, PDFFormMerge, PDFCombine, InsertXHTMLLava
+/Helpers/      PDFWorkflowObject  — entity passed to a workflow carrying Lava input + merge objects
+/Utilities/    Utility            — HtmlToPdf (NReco) and workflow-attribute helpers
+/org_secc/PDFExamples/   Two example RockWeb blocks (PDF Lava Example, PDF Form Example)
+```
+
+## Components
+
+### Workflow Actions
+
+Category in Rock: **PDF**. All write output to a `FileFieldType` workflow attribute.
+
+| Action (ComponentName) | Class | Purpose |
+|------------------------|-------|---------|
+| Lava PDF | `LavaPDF` | Resolves a Lava/HTML template (plus optional header/footer) and renders it to a PDF via NReco. |
+| PDF Form Merge | `PDFFormMerge` | Fills the form fields of a PDF template (iText AcroForm); supports Lava in unmatched field values and optional flattening. |
+| PDF Combine | `PDFCombine` | Merges two PDF binary files into one (iText `PdfMerger`); validates both are `application/pdf`. |
+| Insert XHTML and Lava | `InsertXTMLLava` | Stores the configured XHTML/Lava into the workflow `XHTML` attribute (ensures helper attributes exist first). |
+
+#### Lava PDF — settings
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Lava** | CodeEditor (Lava) | The Lava/HTML body to render. |
+| **Header** | CodeEditor (Lava) | Optional page-header HTML/Lava. |
+| **Footer** | CodeEditor (Lava) | Optional page-footer HTML/Lava. |
+| **PDF** | Workflow attribute (`FileFieldType`) | Destination binary-file attribute. |
+| **DocumentName** | Text (Lava) | Output filename; defaults to `LavaDocument.pdf`. |
+
+#### PDF Form Merge — settings
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **PDFTemplate** | BinaryFile | The fillable PDF template to merge into. |
+| **PDFOutput** | Workflow attribute | Destination for the rendered PDF (skipped when run with a `PDFWorkflowObject` entity). |
+| **Flatten** | Boolean | If true, flattens the form fields (locks them) after merge. |
+
+Merge keys come from `PDFWorkflowObject.MergeObjects`; when an entity isn't supplied, the action
+builds merge objects from the workflow/activity attribute values (`new PDFWorkflowObject(action, rockContext)`).
+
+#### PDF Combine — settings
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **PDFFirstFile** | Workflow attribute (`FileFieldType`) | First PDF to combine. |
+| **PDFSecondFile** | Workflow attribute (`FileFieldType`) | Second PDF, appended after the first. |
+| **PDFOutputFile** | Workflow attribute (`FileFieldType`) | Destination for the combined PDF. |
+
+### Blocks (examples)
+
+Category in Rock: **CMS**. Demonstration `RockBlock`s under `org_secc/PDFExamples/`. Note these are
+**not included in the `.csproj`**, so they are not compiled into the shipped assembly — treat them as
+reference source for how to drive the actions, not as deployed blocks.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| PDF Lava Example | Edits a Lava/HTML body, activates a workflow to render it, redirects to the generated PDF. | Workflow Type, Workflow Activity |
+| PDF Form Example | Uploads/selects a merge-template PDF, supplies key/value merge fields, runs a workflow to fill it. | Workflow Type, Workflow Activity |
+
+### Helpers / Models
+
+| Type | Purpose |
+|------|---------|
+| `PDFWorkflowObject` | Plain object passed as the workflow entity: carries `PDF` (BinaryFile), `LavaInput`, and `MergeObjects`. Resolves attribute values to entities when the field type is an `IEntityFieldType`. |
+| `Utility.HtmlToPdf` | Wraps NReco `HtmlToPdfConverter` (Letter size, optional header/footer/margins/orientation) and returns a `BinaryFile`. |
+| `Utility.EnsureAttributes` | Creates the `PersonId`, `RegistrationRegistrantId`, `GroupMemberId`, `PDFGuid`, and `XHTML` workflow attributes if absent. |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, `BinaryFileService` / `BinaryFileTypeService`, the workflow engine
+  (`ActionComponent`), `AttributeCache`, Lava (`ResolveMergeFields`), `RockBlock` (examples).
+- **Third-party:** `NReco.PdfGenerator` 1.1.15 (HTML-to-PDF, wkhtmltopdf-based), `itext7` 7.0.1
+  (form merge + PDF combine), EntityFramework 6.1.3.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** `Utility.EnsureAttributes` / `CreateAttribute` create workflow attributes at
+  **runtime** via `SaveChanges()` and `AttributeCache.Clear()` during action execution. Mutating the
+  attribute schema and clearing the cache on every run is a side effect worth confirming, and is only
+  invoked by `InsertXTMLLava`.
+- **Improvement:** The `InsertXHTMLLava` class is named `InsertXTMLLava` (typo) and its
+  `ComponentName` is "Insert XHTML and Lava" — the action stores XHTML to a workflow attribute but
+  does no PDF rendering itself, so it must be paired with another action. Worth confirming it's still
+  used.
+- **Improvement:** NReco's `HtmlToPdfConverter` shells out to a bundled wkhtmltopdf binary; the
+  `Lava PDF` action renders user/admin-authored Lava+HTML. Since templates are authored by trusted
+  staff this is low-risk, but be aware external HTML/remote resources in a template are fetched by the
+  renderer. Review template sources if untrusted input ever reaches them.
+- **Improvement:** `LavaPDF` does not null-check the result of `BinaryFileTypeService.Get(...)` when a
+  `binaryFileType` qualifier is present, so a misconfigured destination attribute could throw.
+
+## Making Changes
+
+- To change PDF generation behavior, edit the matching action under `/Workflows/`; HTML-to-PDF
+  conversion settings (page size, margins, orientation) live in `Utility.HtmlToPdf`.
+- New actions are discovered via MEF — add a class deriving from `ActionComponent` with
+  `[ActionCategory("PDF")]` / `[Export(typeof(Rock.Workflow.ActionComponent))]` /
+  `[ExportMetadata("ComponentName", ...)]` and configure settings with Rock attribute decorators.
+- The example blocks show two driving patterns: passing a `PDFWorkflowObject` entity into
+  `WorkflowService.Process` vs. letting an action read/write workflow attributes directly.
+- Related: [org.secc.Workflow](../org.secc.Workflow/README.md) for other SECC workflow actions.

--- a/Plugins/org.secc.PastoralCare/README.md
+++ b/Plugins/org.secc.PastoralCare/README.md
@@ -1,0 +1,75 @@
+# org.secc.PastoralCare
+
+> Block-based lists that let Pastoral Care staff track hospital, homebound, nursing-home, and communion visits.
+
+## Overview
+
+PastoralCare provides the Rock UI for Southeast's Pastoral Care ministry. Each block summarizes a
+category of people who have been reported to Pastoral Care — hospital admissions, homebound
+residents, nursing-home residents, and communion requests — driven by workflows and defined types
+that the plugin's migrations install. Staff use these lists to see who needs a visit and to launch
+the associated visit workflow.
+
+## Project Info
+
+- **Project file:** `org.secc.PastoralCare.csproj`
+- **Root namespace:** `org.secc.PastoralCare`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup)
+
+## Project Layout
+
+```
+/org_secc/PastoralCare/   UI blocks (.ascx + .ascx.cs)
+/Migrations/              Rock plugin migrations (pages, defined types, workflows)
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Pastoral Care**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Hospital List | Summary of current hospitalizations reported to Pastoral Care. | Hospital Admission Workflow, Hospital List defined type, Volunteer Group, Display Pastoral Minister |
+| Homebound List | Summary of current homebound residents. | Homebound Person Workflow |
+| Nursing Home List | Summary of current nursing-home residents. | Nursing Home Resident Workflow, Nursing Home List defined type |
+| Communion List | List of pastoral-care patients/residents who have requested communion. | (driven by the lists above) |
+
+Blocks are configured via Rock block settings — chiefly `WorkflowTypeField` (which workflow a
+list launches/closes), `DefinedTypeField` (the list of hospitals / nursing homes), a `GroupField`
+for the volunteer group, and a `BooleanField` to show the assigned pastoral minister.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, Rock workflow engine, defined types, the Rock block/UI framework.
+- No third-party APIs.
+
+## Migrations
+
+Ships Rock plugin migrations that stand up the plugin's data and pages:
+
+- `001_Pastoral_DefinedTypes` — hospital / nursing-home defined types.
+- `002_Pastoral_WorkflowData` — the pastoral visit workflows.
+- `003_Pastoral_Pages` — Rock pages/blocks for the lists.
+- `004`–`006` — fixes and additions (nursing-home fix, visit-cancel, legacy-Lava fix,
+  show-name-in-visit).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** These blocks surface sensitive health/PII — hospitalizations, homebound
+  status, nursing-home residency. Make sure the Rock **page/block security** for these is locked to
+  Pastoral Care staff roles and not inadvertently viewable by broader admin/staff groups.
+
+## Making Changes
+
+- To change what a list shows, edit the matching `*.ascx.cs` in `org_secc/PastoralCare/`; the
+  block's behavior keys off its configured workflow/defined-type settings.
+- New pages, workflows, or defined-type values belong in a new numbered migration under
+  `/Migrations/` (don't hand-edit existing migrations that have already run).
+- Related: [org.secc.Workflow](../org.secc.Workflow/README.md) (the `DeleteVisitActivity` action and
+  pastoral workflow helpers) and the `CloseDeseasedPastoralWorkflows` job in
+  [org.secc.Jobs](../org.secc.Jobs/README.md).

--- a/Plugins/org.secc.PayFlowPro/README.md
+++ b/Plugins/org.secc.PayFlowPro/README.md
@@ -1,0 +1,154 @@
+# org.secc.PayFlowPro
+
+> A single custom Rock **financial gateway component** that subclasses Rock's stock PayFlow Pro gateway to add an "Every 4 Weeks" giving frequency, friendlier handling of invalid saved accounts, and a custom recurring-billing reconciliation report.
+
+> **Doc tier: deep.** This plugin moves money — it processes charges and reconciles recurring giving against PayPal's PayFlow Pro reporting API — so it's documented at the deeper technical tier (gateway contract, payment-download flow, config attributes, edge cases). The plugin itself is small (one class + one migration); see the tier note in *Observations*.
+
+## Overview
+
+PayFlowPro is Southeast's customized PayPal/PayFlow Pro payment gateway for Rock giving. It does **not** reimplement a gateway from scratch — it inherits from Rock's built-in `Rock.PayFlowPro.Gateway` and overrides only the few behaviors SECC needs to change: it advertises a reduced set of supported recurring schedules (plus a custom **Every 4 Weeks** / `FRWK` period), on the PayFlow "Original transaction ID not found" charge error, deletes the now-invalid saved account and (when one was found) swaps in a user-readable message, and replaces the payment-download logic with a multi-report query against PayFlow Pro's reporting API to reconcile recurring transactions. It is discovered by Rock via MEF as a `GatewayComponent` and configured through Rock financial-gateway attributes — no code change is needed to wire it to a gateway.
+
+## Project Info
+
+- **Project file:** `org.secc.PayFlowPro.csproj`
+- **Root namespace:** `org.secc.PayFlowPro`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly only; `PostBuildEvent` xcopies `org.secc.PayFlowPro.dll`)
+- **Key references (project refs):** `Rock`, `Rock.PayFlowPro` (the stock base gateway + `Reporting.Api`), `Rock.Common`, `Rock.Lava.Shared`, `DotLiquid`. **Binary refs:** `Payflow_dotNET.dll` (PayPal SDK, from `libs/PayFlow`) and EntityFramework 6 (6.1.3).
+
+## Project Layout
+
+```
+/                       Gateway.cs — the GatewayComponent subclass (the entire plugin)
+/Migrations/            001_Create4WeekFrequency.cs — adds the "Every 4 Weeks" financial-frequency defined value
+/Properties/            AssemblyInfo.cs
+app.config / packages.config   EF6 config + NuGet manifest
+Packages.dgml                   NuGet dependency graph (tooling artifact)
+```
+
+## How the Gateway Works
+
+`Gateway` is exported via MEF (`[Export(typeof(GatewayComponent))]`, `ComponentName` = "SECC PayFlowPro") and subclasses `Rock.PayFlowPro.Gateway`. Rock discovers it at startup, renders its attributes on the financial-gateway admin screen, and calls the overridden methods through the normal giving pipeline. Only the methods below are overridden; everything else (tokenization, scheduling, profile creation) falls through to the base gateway.
+
+```mermaid
+flowchart TD
+    A[Rock financial pipeline] --> B{which operation?}
+    B -->|one-time / reference charge| C["Charge(gateway, paymentInfo, out err)"]
+    C --> C1["base.Charge(...)"]
+    C1 --> C2{ReferencePaymentInfo<br/>AND err == '[19] Original<br/>transaction ID not found'?}
+    C2 -->|yes, AND a matching<br/>FinancialPersonSavedAccount exists| C3[Delete the saved account<br/>+ replace err with friendly text]
+    C2 -->|no| C4[return transaction]
+    B -->|recurring schedule setup| D["SetPayPeriod(recurringInfo, freq)"]
+    D --> D1[Map frequency Guid -> PayFlow<br/>PayPeriod code WEEK/BIWK/MONT/FRWK/...]
+    B -->|download payments job| E["GetPayments(gateway, start, end, out err)"]
+    E --> E1[Force TLS 1.0/1.1/1.2]
+    E1 --> E2[RecurringBillingReport<br/>via Rock.PayFlowPro.Reporting.Api]
+    E2 --> E3[CustomReport for amount/<br/>tender/email by transaction id]
+    E3 --> E4{txn found<br/>in custom report?}
+    E4 -->|no| E5[TransactionIDSearch fallback<br/>per transaction]
+    E4 -->|yes| E6[Build Payment]
+    E5 --> E6
+    E6 --> E7[Return List&lt;Payment&gt;]
+```
+
+**Conventions / contracts:**
+- The class implements the Rock `GatewayComponent` contract by inheriting `Rock.PayFlowPro.Gateway`; SECC only overrides `SupportedPaymentSchedules`, `Charge`, and `GetPayments`, plus a private `SetPayPeriod` helper.
+- Credentials/mode are read at runtime from the `FinancialGateway` via `GetAttributeValue(financialGateway, key)` (keys `User`, `Vendor`, `Partner`, `Password`, `Mode`).
+- `GetPayments` returns `null` (with `errorMessage` set) on a hard failure and a populated `List<Payment>` on success — the Rock download-payments job treats a `null` return as an error.
+- The custom **Every 4 Weeks** frequency is identified by the constant `TRANSACTION_FREQUENCY_FOUR_WEEKS` (`B603E480-42C3-41D9-923B-17779C5909A8`), seeded as a defined value by the migration and mapped to PayFlow's `FRWK` pay period.
+
+## Components
+
+### Gateway Component
+
+`SECC PayFlowPro` — appears in the **Component** dropdown when configuring a Financial Gateway in Rock. Configuration attribute keys (in **bold**) are read by the base and overridden methods:
+
+| Setting (label) | Key | Type | Notes |
+|-----------------|-----|------|-------|
+| PayPal Partner | **Partner** | text (required) | PayFlow partner id. |
+| PayPal Merchant Login | **Vendor** | text (required) | PayFlow merchant/vendor login. |
+| PayPal User | **User** | text (optional) | PayFlow API user; passed to the reporting API. |
+| PayPal Password | **Password** | text (required, password-masked) | PayFlow API password. |
+| Mode | *(label "Mode")* | radio `Live,Test` (default `Live`) | `Test` routes the reporting API to the PayFlow test host (case-insensitive compare). |
+
+### Overridden Behavior
+
+| Override | What it changes vs. the base gateway |
+|----------|--------------------------------------|
+| `SupportedPaymentSchedules` | Advertises only One-Time, Weekly, Bi-Weekly, Monthly (Twice-Monthly is commented out). The base set is replaced. |
+| `SetPayPeriod` (private) | Maps each Rock frequency Guid to a PayFlow `PayPeriod` code, including the SECC-specific `FRWK` (Every 4 Weeks); One-Time becomes a 1-term yearly profile. |
+| `Charge` | After `base.Charge`, if a `ReferencePaymentInfo` charge fails with `"[19] Original transaction ID not found"` **and** a matching `FinancialPersonSavedAccount` is found (by `TransactionCode` + gateway id), deletes that saved account and replaces the error with a user-readable message. If no matching saved account is found, the original `[19]` error is left untouched. |
+| `GetPayments` | Replaces payment download: forces TLS, then queries `RecurringBillingReport` + `CustomReport` (+ a `TransactionIDSearch` fallback) via `Rock.PayFlowPro.Reporting.Api` to build `Payment` rows with amount, tender, schedule, and billing email (as a `CCEmail` attribute). |
+
+## Dependencies & Integrations
+
+- **Rock:** `GatewayComponent` / `Rock.PayFlowPro.Gateway` (base), `RockContext`, `FinancialPersonSavedAccountService`, `FinancialTransaction` / `Payment` / `PaymentInfo` / `ReferencePaymentInfo`, `DefinedValueCache` / `DefinedTypeCache`, financial system Guids, plugin migrations.
+- **Third-party:** PayPal **PayFlow Pro** (`Payflow_dotNET.dll` SDK; `PayPal.Payments.DataObjects.RecurringInfo`) and its **reporting API** (via `Rock.PayFlowPro.Reporting.Api`). EntityFramework 6.
+- **Other project refs:** `Rock.Common`, `Rock.Lava.Shared`, `DotLiquid` (transitive build dependencies of Rock).
+- **Cross-plugin:** none.
+
+## Migrations
+
+Ships one Rock plugin migration under `/Migrations/`:
+
+- `001_Create4WeekFrequency` (`MigrationNumber(1)`) — adds an **"Every 4 Weeks"** defined value to the Financial Frequency defined type, using the `TRANSACTION_FREQUENCY_FOUR_WEEKS` Guid. `Down()` deletes it. (Note: the file's namespace/class are `org.secc.PayFloPro.Migrations.CreateCurrencyType` — name typos that don't affect behavior.)
+
+## Edge Cases & Constraints
+
+- **`Mode` only switches the *reporting* host.** In `GetPayments`, `Mode == "Test"` selects the PayFlow test reporting endpoint. The base gateway is responsible for honoring `Mode` on the charge path — confirm both sides agree before testing against production credentials.
+- **TLS is forced inside `GetPayments`.** It sets `ServicePointManager.SecurityProtocol` to `Tls | Tls11 | Tls12` for the *whole process*, which re-enables TLS 1.0/1.1 globally (see Observations).
+- **`Charge` deletes saved accounts on a specific error string.** The cleanup only triggers on the exact message `"[19] Original transaction ID not found"`; if PayFlow changes that string the saved account won't be removed and the cryptic error surfaces to the donor. Also note the friendly message is only substituted **inside** the "saved account found" branch — if the `[19]` error fires but no matching saved account row exists, the donor still sees the raw `[19]` text.
+- **`GetPayments` short-circuits on the first un-resolvable transaction.** If even one recurring-billing row can't be matched by `CustomReport` or `TransactionIDSearch`, the method sets `errorMessage` and returns `null` — discarding any payments already collected for that run.
+- **Amounts are divided by 100.** Report amounts are treated as cents (`amount / 100`); a report that returns dollars would be off by 100×.
+- **`SetPayPeriod` maps more frequencies than `SupportedPaymentSchedules` advertises.** The switch also handles Twice-Monthly (`SMMO`, commented out of the schedule list), Quarterly (`QTER`), Twice-Yearly (`SMYR`), and Yearly (`YEAR`) — so a schedule created through another path with one of those frequencies would still map to a valid PayFlow pay period even though donors can't select it in this gateway's UI. One-Time maps to a 1-term `YEAR` profile.
+
+## Observations
+
+*Noticed while documenting — not a full audit; this plugin handles payments, so flagged for confirmation.*
+
+- **Tier mismatch (process):** This is effectively a **standard-tier** plugin by size — one gateway class and one defined-value migration, no blocks/REST/jobs/Lava. It was assigned the deep tier (and written as such) on the reasonable grounds that it processes money and brokers PayPal credentials, but a human may prefer to downgrade it to standard to match siblings like [org.secc.QRManager](../org.secc.QRManager/README.md).
+- **Security (review):** `GetPayments` sets `ServicePointManager.SecurityProtocol = Tls | Tls11 | Tls12`, which **re-enables TLS 1.0 and 1.1** process-wide (not just for this call) and clobbers any stricter policy Rock or the host set. Worth confirming PayPal still requires anything below TLS 1.2; if not, narrow this to `Tls12` (or `Tls12 | Tls13`).
+- **Security (low):** The PayFlow `Password` attribute is declared password-masked (`isPassword: true`), but `User`/`Vendor`/`Partner` are plain text fields and the billing email is copied into a `CCEmail` payment attribute. Standard for a gateway, but confirm gateway-admin access is restricted to trusted finance staff.
+- **Improvement:** `GetPayments` is a long single method that builds a ~50-key `customParams` dictionary inline and does per-transaction fallback API calls in a loop (N extra round-trips when `CustomReport` misses rows). For large date ranges this is chatty; the parameter block could be extracted and the fallback batched.
+- **Improvement:** The migration's namespace (`org.secc.PayFloPro`) and class name (`CreateCurrencyType`) don't match what it does or where it lives. Harmless, but confusing for future maintainers grepping for the frequency seed.
+
+## Extending
+
+There is no plugin-specific extension surface beyond the gateway itself — to change giving behavior, override more of the base `Rock.PayFlowPro.Gateway` contract in `Gateway.cs`. To add another custom frequency, follow the existing pattern: define the Guid constant, seed it in a new numbered migration, and map it in `SetPayPeriod`.
+
+```csharp
+// Gateway.cs
+public const string TRANSACTION_FREQUENCY_MY_PERIOD = "<new-guid>";
+
+private void SetPayPeriod( RecurringInfo recurringInfo, DefinedValueCache transactionFrequencyValue )
+{
+    // ... existing cases ...
+    case TRANSACTION_FREQUENCY_MY_PERIOD:
+        recurringInfo.PayPeriod = "MYCODE"; // a valid PayFlow PayPeriod code
+        break;
+}
+```
+
+```csharp
+// Migrations/002_CreateMyFrequency.cs
+[MigrationNumber( 2, "1.0.0" )]
+class CreateMyFrequency : Rock.Plugin.Migration
+{
+    public override void Up() =>
+        RockMigrationHelper.AddDefinedValue(
+            Rock.SystemGuid.DefinedType.FINANCIAL_FREQUENCY,
+            "My Period", "My Period", Gateway.TRANSACTION_FREQUENCY_MY_PERIOD );
+
+    public override void Down() =>
+        RockMigrationHelper.DeleteDefinedValue( Gateway.TRANSACTION_FREQUENCY_MY_PERIOD );
+}
+```
+
+MEF discovers the gateway automatically; new migrations run in number order on app start.
+
+## Making Changes
+
+- All gateway behavior lives in `Gateway.cs`. Edit `SupportedPaymentSchedules` to change which schedules donors can pick, `SetPayPeriod` to change frequency→PayFlow mappings, and `Charge`/`GetPayments` for charge error handling and payment reconciliation.
+- New giving frequencies require both a `SetPayPeriod` case and a numbered migration under `/Migrations/` (don't edit a migration that has already run).
+- Reporting-API behavior (report names, host selection) comes from the shared `Rock.PayFlowPro` project's `Reporting.Api` — changes there affect this gateway too.
+- Credentials and Live/Test mode are admin data on the Financial Gateway record, not code.

--- a/Plugins/org.secc.PayPalExpress/README.md
+++ b/Plugins/org.secc.PayPalExpress/README.md
@@ -1,0 +1,166 @@
+# org.secc.PayPalExpress
+
+> A Rock financial **gateway component** for PayPal Express Checkout (Classic Merchant API), plus a drop-in Transaction Entry block that adds a PayPal tab to Rock's giving flow.
+
+> **Doc tier: deep.** This plugin handles money and credentials — it brokers a redirect-based payment flow against PayPal's API, decrypts API credentials, and creates `FinancialTransaction` records — so it's documented at the deeper technical tier (payment flow, gateway contract, config attributes, edge cases). Most SECC plugins use the lighter standard tier.
+
+## Overview
+
+PayPalExpress lets Southeast accept one-time gifts through PayPal Express Checkout alongside Rock's built-in credit-card/ACH gateways. It supplies a `GatewayComponent` (`Gateway`) that talks to PayPal's **Classic** Merchant API (`SetExpressCheckout` / `GetExpressCheckoutDetails` / `DoExpressCheckoutPayment` / `RefundTransaction`) via the legacy `PayPalMerchantSDK`, and a `TransactionEntry` block that subclasses Rock's stock giving block to inject a "PayPal" payment tab. Because PayPal Express is redirect-based, the block hands off to PayPal, then resumes on the configured Return page (carrying `token` + `PayerID`) to confirm and capture the gift. Only **one-time** gifts are supported — all scheduled-payment methods are stubs.
+
+## Project Info
+
+- **Project file:** `org.secc.PayPalExpress.csproj`
+- **Root namespace:** `org.secc.PayPalExpress`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (the `org.secc.PayPalExpress.dll` assembly only), `RockWeb/Plugins/org_secc/` (block markup), and `RockWeb/Assets/` (PayPal/SECC logos) — see the three `PostBuildEvent` xcopy steps. The PayPal SDK and `Newtonsoft.Json` DLLs are *not* xcopied by this project; they reach `RockWeb/bin` via NuGet/the main solution build.
+- **Third-party SDK:** `PayPalCoreSDK` 1.7.1 + `PayPalMerchantSDK` 2.16.117 (PayPal's *Classic* NVP/SOAP Merchant API — deprecated upstream).
+
+## Project Layout
+
+```
+/                       Gateway.cs — the PayPal Express GatewayComponent; RedirectGatewayComponent.cs — abstract base adding PreRedirect/RedirectUrl; PayPalPaymentInfo.cs — PaymentInfo subclass carrying Token/PayerId
+/Migrations/            001_CreateCurrencyType.cs — seeds the "PayPal Express" currency-type defined value
+/org_secc/PayPalExpress/ TransactionEntry.ascx(.cs) — giving block subclassing Rock's stock TransactionEntry, adds the PayPal tab + redirect/confirm flow
+/Assets/PayPalExpress/  PayPal + SECC logo images used in the giving UI
+```
+
+## How the Payment Flow Works
+
+PayPal Express is a **redirect** gateway: the user is sent to PayPal to authorize, then bounced back to Rock to confirm and capture. `RedirectGatewayComponent` exists to model this — it adds `PreRedirect(...)` (call PayPal, compute the redirect URL) and a `RedirectUrl` property on top of Rock's `GatewayComponent`.
+
+```mermaid
+flowchart TD
+    A[User picks PayPal tab in TransactionEntry block] --> B[btnPaymentInfoNext_Click<br/>validates amounts > 0]
+    B --> C["Gateway.PreRedirect()<br/>SetExpressCheckout API call"]
+    C --> D[PayPal returns a Token]
+    D --> E[Block redirects browser to<br/>PayPalURL + _express-checkout&token=...]
+    E --> F[User authorizes on PayPal]
+    F --> G[PayPal redirects to Return Page<br/>with ?token=...&PayerID=...]
+    G --> H[Block OnInit sees token+PayerID<br/>shows confirmation panel]
+    H --> I["Gateway.GetPaymentInfo()/GetSelectedAccounts()<br/>GetExpressCheckoutDetails API call"]
+    I --> J[User clicks Finish<br/>btnPayPalConfirmationNext_Click]
+    J --> K["Gateway.Charge()<br/>DoExpressCheckoutPayment (SALE)"]
+    K --> L[SaveTransaction:<br/>find/create Person, build FinancialTransaction,<br/>add to batch, queue receipt]
+```
+
+**Conventions / contracts:**
+- The component is discovered by Rock via **MEF** (`[Export(typeof(GatewayComponent))]`, `[ExportMetadata("ComponentName", "PayPal Express Gateway")]`) — no registration step. Configure it by creating a Financial Gateway in Rock that uses this component.
+- **Credentials** (API username/password/signature) are stored as **encrypted** gateway attributes and decrypted at call time via `Encryption.DecryptString` in `GetCredentials`, which builds the `account1.*` config dictionary the SDK's `PayPalAPIInterfaceServiceService` expects. `mode` comes from the **PayPal Environment** attribute (`Live`/`Sandbox`).
+- **Two-phase capture:** `SetExpressCheckout` is sent with `PaymentAction = AUTHORIZATION`; the actual `DoExpressCheckoutPayment` in `Charge` uses `PaymentAction = SALE`.
+- **Return/Cancel URLs** are built from the configured linked pages, prefixed with `GlobalAttributesCache.Value("PublicApplicationRoot")` (with a trailing path segment trimmed).
+- Per-account line items are passed to PayPal as `PaymentDetailsItem`s (name, amount, account id as `Number`); on return, `GetSelectedAccounts` reconstructs the Rock account allocation from those line items.
+- The redirect URL is `PayPalURL + "_express-checkout&token=" + token` — i.e. the **PayPal URL** attribute is expected to end with `...webscr?cmd=`.
+
+## Components
+
+### Gateway Component: PayPal Express Gateway
+
+`Gateway : RedirectGatewayComponent : Rock.Financial.GatewayComponent`. Currency type defined value GUID `2D6FC5FA-A49F-4D20-BCDF-2F0D7E67AD86` (seeded by migration 1).
+
+Implemented operations:
+
+| Operation | Behavior |
+|-----------|----------|
+| `PreRedirect` | `SetExpressCheckout` — sets line items, return/cancel URLs, brand/logo; stores the redirect URL. |
+| `GetPaymentInfo` / `GetSelectedAccounts` | `GetExpressCheckoutDetails` — pulls payer info + account line items back from PayPal using the token. |
+| `Charge` | `DoExpressCheckoutPayment` (SALE) — captures the payment; returns a `FinancialTransaction` with `TransactionCode` set. Requires a `PayPalPaymentInfo`. |
+| `Credit` | `RefundTransaction` (FULL) — refunds by original `TransactionCode`. |
+| `SupportedPaymentSchedules` | One-time only (`TRANSACTION_FREQUENCY_ONE_TIME`). |
+| `PromptForNameOnCard` / `PromptForBankAccountName` / `PromptForBillingAddress` | All `false` (collected by PayPal). |
+| `AddScheduledPayment` / `UpdateScheduledPayment` / `CancelScheduledPayment` / `ReactivateScheduledPayment` / `GetScheduledPaymentStatus` / `GetPayments` / `GetReferenceNumber` | **Not supported** — stubs returning null/false/empty. |
+
+Gateway attributes (configured per Financial Gateway in Rock). Keys in **bold** are the attribute keys read in code.
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **PayPalAPIUsername** | encrypted text (required) | Classic API username; also sent as `SellerDetails.PayPalAccountID`. |
+| **PayPalAPIPassword** | encrypted text (required) | Classic API password. |
+| **PayPalAPISignature** | encrypted text (required) | Classic API signature. |
+| **PayPalEnvironment** | dropdown `Live`/`Sandbox` (default `Sandbox`) | Passed straight to the SDK `mode`. |
+| **PayPalURL** | text (required) | Base redirect URL; default points at `sandbox.paypal.com/...webscr?cmd=`. Code appends `_express-checkout&token=`. |
+| **ReturnPage** | linked page (required) | Where PayPal returns with `token` + `PayerID`. |
+| **CancelPage** | linked page (required) | Where PayPal sends a cancelled checkout. |
+| **PayPalBrandName** | text (optional) | Overrides the business name on PayPal's hosted pages. |
+| **PayPalLogoImage** | text (optional) | URL of a logo shown on PayPal's checkout (sent as `cppHeaderImage`). |
+
+### Block: Transaction Entry with PayPal Express
+
+Category in Rock: **SECC > Finance**. `TransactionEntry : RockWeb.Blocks.Finance.TransactionEntry` — it **subclasses Rock's stock giving block**, dynamically loads the stock block as a child control (`~/Blocks/Finance/TransactionEntry.ascx`), and injects a PayPal pill/tab into the existing payment-method UI. It therefore **inherits all of Rock's stock TransactionEntry block attributes** (Accounts, AllowScheduled, batch/source/receipt config, Impersonation, etc.) and adds one:
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **PayPalExpressGateway** | financial-gateway (optional) | The Financial Gateway using the PayPal Express component. If unset/unsupported for the chosen frequency, the PayPal tab is hidden. |
+
+Behavioral notes:
+- The PayPal tab is hidden unless a one-time gift is selected — scheduled/future-dated gifts disable PayPal (it only supports one-time).
+- On the PayPal-return request (`token` + `PayerID` present), the block renders its **own** confirmation/success panels (in `TransactionEntry.ascx`) rather than the stock block.
+- Person resolution on capture mirrors Rock's `CreatePledge` logic: a single exact match on first/last/email is reused, otherwise a new Person + family is created.
+
+## Dependencies & Integrations
+
+- **Rock:** `Rock.Financial.GatewayComponent`, `FinancialTransaction` / `FinancialBatch` / `FinancialAccount`, `RockContext`, `Encryption`, `GlobalAttributesCache`, `PageReference`, `RockWeb.Blocks.Finance.TransactionEntry` (stock block subclassed), plugin migrations, `SendPaymentReceipts` queued transaction.
+- **Third-party:** PayPal **Classic** Merchant API via `PayPalMerchantSDK` 2.16.117 + `PayPalCoreSDK` 1.7.1; `Newtonsoft.Json`.
+- **Cross-plugin:** none.
+
+## Migrations
+
+Ships a single Rock plugin migration under `/Migrations/`:
+
+- `001_CreateCurrencyType` (`[MigrationNumber(1, "1.0.1")]`) — adds a **"PayPal Express"** value to the Financial Currency Type defined type (`2D6FC5FA-A49F-4D20-BCDF-2F0D7E67AD86`). `Down()` removes it.
+
+## Edge Cases & Constraints
+
+- **One-time gifts only.** Every scheduled-payment method is a stub; `SupportedPaymentSchedules` returns only the one-time frequency, and the block hides the PayPal tab for any scheduled/future-dated gift.
+- **`PayPalURL` must end with `...webscr?cmd=`.** The redirect is built by string-concatenating `"_express-checkout&token=" + token`; a mis-set base URL silently produces a broken redirect.
+- **`Charge` returns `null` on no/failed payment.** A `SUCCESS` ack with no `PaymentInfo` rows falls through to `return null` with an empty error message; the block treats a null transaction as "Invalid Transaction".
+- **Errors are surfaced as raw PayPal `LongMessage` text** (and, on exceptions, `ex.Message`) directly into the giving UI's notification box.
+- **Refund is always FULL.** `Credit` ignores the requested `amount` for `RefundType` (sends `RefundType.FULL`) while still passing the amount as `Amount` — partial refunds aren't really supported.
+- **Classic API is legacy.** The underlying PayPal Merchant SDK / Classic Express Checkout API is deprecated by PayPal; this is a maintenance/long-term-viability constraint, not a code bug.
+
+## Observations
+
+*Noticed while documenting — not a full audit; payment + credential paths flagged for confirmation.*
+
+- **Security (review):** The return flow trusts the `token`/`PayerID` query-string parameters and re-fetches details from PayPal with them, but the captured amount comes from `GetExpressCheckoutDetails`/the selected accounts rather than being re-validated against the original `SetExpressCheckout` request server-side. Worth confirming that a tampered token can't be used to capture against a different/short amount, and that the confirm→capture step is tied to the current user/session.
+- **Security (review):** `Charge` swallows all exceptions into the `errorMessage` string and returns `null`, and `Credit` likewise returns raw PayPal/exception messages to the UI. Confirm no sensitive API detail leaks to end users, and that failed/partial captures can't leave an orphaned Rock-side record.
+- **Improvement:** `GetPaymentInfo` / `GetSelectedAccounts` each make a **separate** `GetExpressCheckoutDetails` round-trip, and the block calls them repeatedly across the page lifecycle — the same PayPal call is made multiple times per confirmation render. Caching the response once per token would cut API calls (the block already memoizes accounts via `TokenSelectedAccounts`, but not payment info across both methods).
+- **Improvement:** `populateRequestObject` mixes `double` arithmetic for `OrderTotal`/`ItemTotal` (`Convert.ToDouble(paymentInfo.Amount)`) while `Charge` uses `decimal` — floating-point money math is fragile; prefer `decimal` throughout.
+- **Improvement:** `Credit` sends `RefundType.FULL` regardless of the `amount` argument, so a partial refund requested from Rock would still attempt a full refund — verify that's intended or guard it.
+
+## Extending
+
+This plugin models a redirect gateway via the abstract `RedirectGatewayComponent`. To add another redirect-style provider, subclass it and implement `PreRedirect` + `RedirectUrl` plus the standard `GatewayComponent` overrides:
+
+```csharp
+[Description( "My Redirect Gateway" )]
+[Export( typeof( GatewayComponent ) )]
+[ExportMetadata( "ComponentName", "My Redirect Gateway" )]
+[EncryptedTextField( "API Key", "...", true, "", "Settings", 1 )]
+public class MyGateway : RedirectGatewayComponent
+{
+    private string _redirectUrl = "";
+    public override string RedirectUrl => _redirectUrl;
+
+    public override void PreRedirect( FinancialGateway gateway, PaymentInfo info,
+        List<GatewayAccountItem> selectedAccounts, out string errorMessage )
+    {
+        errorMessage = string.Empty;
+        // call provider, set _redirectUrl
+    }
+
+    public override FinancialTransaction Charge( FinancialGateway gateway,
+        PaymentInfo paymentInfo, out string errorMessage ) { /* capture */ }
+
+    // ...the remaining GatewayComponent overrides
+}
+```
+
+MEF discovers `[Export(typeof(GatewayComponent))]` at startup; create a Financial Gateway in Rock to use it. To surface it in the giving UI, the `TransactionEntry` block's redirect handling (the `RedirectGatewayComponent` branch in `btnPaymentInfoNext_Click`) already works for any `RedirectGatewayComponent`. Capture itself (`btnPayPalConfirmationNext_Click`) calls the base `GatewayComponent.Charge`, so it is generic — but the **confirm/detail** path is PayPal-specific: `GetPaymentInfo`/`GetSelectedAccounts` aren't on the base class, so the block hard-casts the component to `org.secc.PayPalExpress.Gateway` to call them.
+
+## Making Changes
+
+- Gateway / PayPal API behavior lives in `Gateway.cs`; credentials and environment are gateway attributes declared at the top of that file (decrypted in `GetCredentials`).
+- The redirect/confirm/capture UI flow is in `org_secc/PayPalExpress/TransactionEntry.ascx.cs`; the confirmation/success markup is in the matching `.ascx`. Most giving-flow settings come from Rock's stock TransactionEntry block (subclassed), not from this plugin.
+- The "PayPal Express" currency type is seeded by `Migrations/001_CreateCurrencyType.cs` — any new tables/defined values belong in a new numbered migration, not an edit to that file.
+- Related: this block is a PayPal-specific sibling of Rock's stock Finance giving block; for other SECC finance work see [org.secc.Finance](../org.secc.Finance/README.md).

--- a/Plugins/org.secc.PayPalReporting/README.md
+++ b/Plugins/org.secc.PayPalReporting/README.md
@@ -1,0 +1,152 @@
+# org.secc.PayPalReporting
+
+> A scheduled job that pulls PayFlow Pro transaction reports out of PayPal and stores them in a custom Rock table, with a block to view/edit individual rows.
+
+> **Doc tier: deep.** This plugin talks to two external PayPal APIs (the PayFlow Pro Reporting XML engine and the classic NVP/SOAP Merchant API), handles encrypted credentials, and has a non-obvious two-pass import + fee-lookup flow — so it's documented at the deeper technical tier (data flow, the report XML contract, edge cases, extending). Most SECC plugins use the lighter standard tier.
+
+## Overview
+
+PayPalReporting backfills a local copy of PayPal/PayFlow Pro giving transactions so they can be reconciled against Rock financial batches. A scheduled `IJob` (`ImportData`) finds every active PayFlow Pro `FinancialGateway`, runs a named report against PayPal's PayFlow Pro **Reporting Engine** (XML over HTTPS), and upserts each row into the custom `_org_secc_PayPalReporting_Transaction` table. A second pass optionally calls the classic PayPal **Merchant API** (`TransactionSearch`) to fill in the per-transaction fee that the report doesn't return. Finance staff view/edit a single transaction through the **PayPal Reporting Transaction** block.
+
+## Project Info
+
+- **Project file:** `org.secc.PayPalReporting.csproj`
+- **Root namespace:** `org.secc.PayPalReporting`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `PayPal*` SDK DLLs) and `RockWeb/Plugins/org_secc/` (block markup)
+
+## Project Layout
+
+```
+/                       ImportData.cs — the scheduled IJob (report import + fee lookup)
+/Data/                  PayPalReportingContext (EF DbContext on RockContext) + base PayPalReportingService<T>
+/Model/                 Transaction entity + TransactionService
+/Engine/                XMLReport — drives the PayFlow Pro Reporting Engine; API — classic Merchant API fee lookup
+/Services/              PayFlowProReportSvc.cs (auto-generated XSD proxy types) + PayFlowProRequest (HTTP/XML transport)
+/Migrations/            Rock plugin migrations (table + FinancialGateway FK)
+/org_secc/PayPalReporting/  Transaction.ascx (+ .cs) — view/edit a single stored transaction
+```
+
+## How the Import Works
+
+`ImportData` is a Rock `IJob`. Its block/job attributes (declared on the class) populate the Quartz `JobDataMap`; `Execute` reads them, queries the PayFlow Pro gateways, and runs the report per gateway. Authentication for the *report* comes from the gateway's own Rock attributes (`Partner`/`User`/`Vendor`/`Password`); authentication for the *fee lookup* comes from the job's encrypted API attributes.
+
+```mermaid
+flowchart TD
+    A[Quartz triggers ImportData job] --> B[Force TLS 1.0/1.1/1.2 on ServicePointManager]
+    B --> C[Query active FinancialGateways<br/>where EntityType name contains 'PayFlowPro']
+    C --> D{for each gateway}
+    D --> E["XMLReport.RunReport(start,end)<br/>POST XML to Reporting Engine"]
+    E --> F[Poll statusCode every<br/>PollingTimeout seconds until success]
+    F --> G[Fetch metadata + each page<br/>build a DataTable]
+    G --> H[ProcessTransaction per row<br/>upsert by Gateway Transaction ID]
+    H --> I[(_org_secc_PayPalReporting_Transaction)]
+    D --> J{Fetch Fees enabled?}
+    J -->|yes| K[Decrypt API user/pass/signature]
+    K --> L[Load tx where Fees=0 and not IsZeroFee<br/>and MerchantTransactionId set]
+    L --> M["API.GetTransactionFee — Merchant API<br/>TransactionSearch per tx"]
+    M --> N[Write fee back, SaveChanges]
+    J -->|no| O[Done — set context.Result message]
+    N --> O
+```
+
+**Conventions / contracts:**
+- **Two PayPal integrations, two credential sources.** The Reporting Engine report is authenticated with the *gateway's* `Partner`/`User`/`Vendor`/`Password` attributes (read live via `Gateway.LoadAttributes()` in `XMLReport.GetAuthRequest`). The fee lookup uses the *job's* encrypted `PayPal API Username/Password/Signature` attributes.
+- **Reporting Engine is request/poll/page.** `XMLReport.RunReport` submits a `RunReport` request, then `Thread.Sleep(PollingTimeout)`-polls `statusCode` until `3` (created successfully), reads metadata to size the `DataTable`, and pulls every page (`pageSize = 50`).
+- **Upsert key is the report's `Transaction ID`.** `ProcessTransaction` calls `TransactionService.Get(gatewayTransactionId)`; if found it updates in place, otherwise inserts. The SQL PK is on `GatewayTransactionId`, not `Id`.
+- **Report column names are string-keyed.** `ProcessTransaction` indexes `DataRow` by literal column names from the PayPal report (`"Transaction ID"`, `"Amount"`, `"PayPal Transaction ID"`, `"Batch ID"`, etc.). `Amount` is divided by 100 (report is in cents) and stored as a `double`.
+- **Fee pass is opt-in and second-stage.** Fees are not part of the report; only rows with `Fees == 0 && !IsZeroFee && MerchantTransactionId != ""` are looked up. A returned fee of `0` is counted as a failure (the `IsZeroFee` flag is the manual escape hatch to stop re-querying genuinely fee-free rows).
+- The custom `PayPalReportingContext` shares the `RockContext` connection with its EF initializer nulled out (`NullDatabaseInitializer`) — no auto-migration.
+
+## Components
+
+### Scheduled Job
+
+`ImportData : IJob`, marked `[DisallowConcurrentExecution]`. Configured through Rock's Jobs admin (Settings > Jobs); the attribute display names (in **bold**) become `JobDataMap` entries under their space-stripped keys — `Execute` reads them as `ReportName`, `PayPalReportURL`, `FetchFees`, `PayPalAPIUsername`/`Password`/`Signature`, and `DateRange`.
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Report Name** | text (default `GivingReport`) | Name of the PayFlow Pro report/template to run. |
+| **PayPal Report URL** | text (default `https://payments-reports.paypal.com/reportingengine`) | Reporting Engine endpoint; switch to the sandbox host for test mode. |
+| **Fetch Fees** | bool (default true) | Whether the second pass calls the Merchant API to fill per-transaction fees. |
+| **PayPal API Username** | encrypted text | Merchant API (NVP) username — required only when *Fetch Fees* is on. |
+| **PayPal API Password** | encrypted text | Merchant API password. |
+| **PayPal API Signature** | encrypted text | Merchant API signature. |
+| **Date Range** | sliding date range (default `Previous|24|Hour`) | Window of transactions to import. |
+
+If *Fetch Fees* is enabled but any of the three API credentials is blank, the job throws.
+
+### Block
+
+Category in Rock: **SECC > Finance**.
+
+| Block | Purpose |
+|-------|---------|
+| PayPal Reporting Transaction | View one stored transaction by `TransactionId` page parameter; **Edit** reveals an inline edit panel that writes all fields (including `IsZeroFee`) back to the table. |
+
+The block has no block attributes; it keys entirely off the `TransactionId` query-string parameter.
+
+### Data Model
+
+| Entity | Table | Notes |
+|--------|-------|-------|
+| `Transaction` | `_org_secc_PayPalReporting_Transaction` | `Rock.Data.Model<Transaction>` + `ISecured`. Holds the report row (gateway + merchant transaction ids, billing name, amount, fees, tender/type, comments, batch id, `IsZeroFee`, `FinancialGatewayId`). **SQL primary key is `GatewayTransactionId`**, not `Id`. |
+
+## Dependencies & Integrations
+
+- **Rock:** `IJob` / Quartz, `RockContext`, `FinancialGatewayService` + `FinancialGateway` attributes, `Rock.Security.Encryption` (credential decrypt), `ExceptionLogService`, `RockBlock`, `SlidingDateRangePicker`, plugin migrations.
+- **Third-party:** PayPal **PayFlow Pro Reporting Engine** (XML over HTTPS — hand-rolled transport in `PayFlowProRequest`, XSD-generated types in `PayFlowProReportSvc.cs`); PayPal classic **Merchant API** via `PayPalMerchantSDK` / `PayPalCoreSDK` (`TransactionSearch`); EntityFramework 6; Newtonsoft.Json (referenced).
+- **Cross-plugin:** none.
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/`:
+
+- `001_CreateDb` — creates `_org_secc_PayPalReporting_Transaction` (PK on `GatewayTransactionId`, PersonAlias FKs, a covering index on `TenderType`).
+- `002_AddFinancialGateway` — adds the `FinancialGatewayId` column + FK to `FinancialGateway` (lets a row be attributed to the gateway it came from, supporting multiple PayFlow Pro gateways).
+
+## Edge Cases & Constraints
+
+- **Synchronous poll with `Thread.Sleep`.** `XMLReport.RunReport` blocks the job thread, sleeping `PollingTimeout` (default 10s) between status checks with **no overall timeout or max-iteration cap** — a report PayPal never finishes will hang the job indefinitely (mitigated by `[DisallowConcurrentExecution]`).
+- **Status re-poll resends the original request.** Inside the poll loop the code rebuilds a `GetResultsRequest` but then calls `SendRequest( req )` with the *original* `req` (still the run-report payload), reading `statusCode` off the response — it relies on the run-report response carrying status, not a true results poll.
+- **Report column names are a hard contract.** Any rename in the PayPal report template (`"Transaction ID"`, `"Amount"`, `"PayPal Transaction ID"`, …) breaks `ProcessTransaction` with a `KeyNotFoundException`. The `DataTable` indexer is also accessed without a `Columns.Contains` guard.
+- **`PayPal Fees` column maps to `0`.** When the report includes a `PayPal Fees` column, `ProcessTransaction` sets `Fees = 0` regardless of value, deferring the real fee to the Merchant API pass.
+- **A `0` fee from the Merchant API is treated as failure**, not as a legitimately fee-free transaction — such rows are re-queried on every run unless `IsZeroFee` is manually set on the row (e.g. via the block).
+- **`PayFlowProRequest.FormatEndpointURL` has a no-op bug** (`URL.Replace("http://","https://")` discards its result), so an `http://`-prefixed URL is not actually upgraded to HTTPS.
+- **Amounts are stored as `double`.** Currency is held as a floating-point `double` (both the SQL `float` column and the model), not `decimal` — acceptable for reporting but not exact.
+
+## Observations
+
+*Noticed while documenting — not a full audit; the import/credential paths stood out.*
+
+- **Security (low):** Merchant API credentials are stored as `EncryptedTextField` job attributes and decrypted only in-memory at run time via `Rock.Security.Encryption` — good. Worth confirming the Jobs admin page (where these attributes are edited) and the **PayPal Reporting Transaction** block are restricted to finance/admin staff, since the block lets a user freely rewrite stored giving amounts/fees.
+- **Improvement:** the poll loop (see Edge Cases) has no timeout/iteration cap and re-sends the run-report request instead of a results request; a hung or slow PayPal report blocks the job thread. Consider a bounded retry with a max wait.
+- **Improvement:** `ProcessTransaction` indexes the `DataTable` by literal column names with no `Columns.Contains` guard and `!= null` checks on the indexer (which never returns null) — a missing/renamed report column throws rather than skips. Harden the column mapping.
+- **Improvement:** `FormatEndpointURL`'s `URL.Replace(...)` result is discarded (a real no-op); the method only prepends a scheme when none is present.
+- **Improvement:** several DB contexts/services are newed up inline in the job and block (`new TransactionService( new PayPalReportingContext() )` per call). Fine for a nightly job, but the block creates a fresh context on each of show/edit/save.
+
+## Extending
+
+To capture an additional report column, add the property to the model + a migration column, then map it in `ProcessTransaction` (guarding the column first):
+
+```csharp
+// Model/Transaction.cs
+[StringLength( 255 )]
+[DataMember]
+public string AuthCode { get; set; }
+
+// ImportData.cs — ProcessTransaction
+if ( dr.Table.Columns.Contains( "Auth Code" ) && dr["Auth Code"] != null )
+{
+    transaction.AuthCode = dr["Auth Code"].ToString();
+}
+```
+
+Add a numbered migration under `/Migrations/` (`ALTER TABLE … ADD AuthCode …`) — don't hand-edit migrations that have already run. The PayPal report template must also be configured to emit the new column.
+
+## Making Changes
+
+- Import behavior (gateway selection, report params, fee pass) lives in `ImportData.cs`; the report request/poll/paging logic is in `Engine/XMLReport.cs`, and the raw HTTP/XML transport is in `Services/PayFlowProRequest.cs`.
+- Fee-lookup logic against the classic Merchant API is in `Engine/API.cs`.
+- The view/edit screen is `org_secc/PayPalReporting/Transaction.ascx(.cs)`; add new tables/columns via a new numbered migration in `/Migrations/`.
+- Report authentication uses the PayFlow Pro `FinancialGateway`'s own Rock attributes — change those in Rock admin (Finance > Gateways), not here.

--- a/Plugins/org.secc.PersonMatch/README.md
+++ b/Plugins/org.secc.PersonMatch/README.md
@@ -1,0 +1,99 @@
+# org.secc.PersonMatch
+
+> A `PersonService.GetByMatch` extension method that resolves loose name/contact fields to existing Rock people (nickname-aware), with optional nameless-person creation.
+
+## Overview
+
+PersonMatch is a thin library plugin: it adds one extension method, `GetByMatch`, to Rock's
+`PersonService` that takes loose identity fields (first/last name, DOB, email, phone, address) and
+returns the matching `Person` records. Matching is nickname-aware via a "Diminutive Names" defined
+type the plugin installs. It has no UI of its own — it's consumed by other plugins (notably the
+*Person Attribute From Fields* action in [org.secc.Workflow](../org.secc.Workflow/README.md)) to
+de-duplicate people when ingesting form/registration/SMS data.
+
+## Project Info
+
+- **Project file:** `org.secc.PersonMatch.csproj`
+- **Root namespace:** `org.secc.PersonMatch`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly only; PostBuildEvent xcopies the DLL)
+
+## Project Layout
+
+```
+Extension.cs    PersonService.GetByMatch extension method (the entire matching logic)
+/Migrations/    DiminutiveNames_DefinedType — installs the nickname defined type + values
+```
+
+## Components
+
+### Extension Method
+
+`org.secc.PersonMatch.Extension.GetByMatch` — extends `PersonService`.
+
+```
+IEnumerable<Person> GetByMatch(
+    string firstName, string lastName, DateTime? birthDate,
+    string email = null, string phone = null,
+    string street1 = null, string postalCode = null,
+    bool createNameless = false )
+```
+
+Matching algorithm:
+
+| Step | Behavior |
+|------|----------|
+| Required inputs | `firstName` + `lastName` + at least one of (`birthDate`, `email`, `phone`, `street1`). Otherwise returns an empty list — unless `createNameless` and an email/phone are present, in which case it returns a single nameless person (found or created). |
+| Fast path | If `birthDate` or `email` is present, tries an exact query on first/nick name + last name (+ DOB + email). Returns immediately on a single exact match. |
+| Lenient pass | Queries everyone with the same `LastName` (and matching/absent `BirthDate`), then keeps only those where the phone or email appears anywhere in the person's family, **or** the home address `Street1` matches. Address matching only runs when **both** `street1` and `postalCode` are supplied (the supplied address is geocoded once via `LocationService.Verify` if a literal `Street1` compare fails). |
+| Nickname narrowing | Final list is filtered by first name, treating entries in the "Diminutive Names" defined type as equivalent (e.g. "Bob" ≈ "Robert"), comparing against the person's `FirstName`/`NickName`. |
+
+`createNameless` routes to the private `GetOrCreateNamelessPerson`, which looks up an existing
+nameless-record-type person by email/phone and **creates and saves a new one** (mobile phone with
+messaging enabled) if exactly one isn't found.
+
+## Dependencies & Integrations
+
+- **Rock:** `PersonService`, `RockContext`, `LocationService` (address geocode/verify),
+  `AttributeValueService`, `DefinedTypeCache`/`DefinedValueCache`/`AttributeCache`, `PhoneNumber`,
+  nameless-person record type and mobile phone-type system Guids.
+- **Cross-plugin:** consumed by [org.secc.Workflow](../org.secc.Workflow/README.md)
+  (*Person Attribute From Fields* action).
+- No third-party APIs.
+
+## Migrations
+
+Ships one Rock plugin migration that installs the matching reference data:
+
+- `DiminutiveNames_DefinedType` (`MigrationNumber 1`, `1.2.0`) — adds the **Diminutive Names**
+  defined type (`3E2D2BEE-…`) with a "Goes By" attribute (`C31FDA8A-…`, pipe-delimited alternates)
+  and 2,168 name defined values. `Down()` removes the "Goes By" attribute, all 2,168 defined
+  values, and the defined type.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** With `createNameless = true`, `GetByMatch` will **insert and `SaveChanges()`
+  a new person** as a side effect of a "lookup" call. Callers driven by public/untrusted input
+  (forms, SMS) can therefore create person records — review which workflows pass that flag.
+- **Improvement:** The nickname-narrowing loop dereferences `av.Value` and
+  `matchingPerson.FirstName`/`NickName` without null guards (`av` from
+  `attributeValues.Where(...).FirstOrDefault()` can be null; FirstName/NickName can be null). A
+  defined value missing its "Goes By" value, or a person with a null name, risks a
+  `NullReferenceException` — worth confirming.
+- **Improvement:** The method opens a second `RockContext` internally for its `LocationService`
+  and `AttributeValueService`, while the actual person queries still run on the caller's
+  `personService` context — so two contexts are live at once for a single call. The address-match
+  block also swallows all exceptions silently (`catch (Exception) {}`), which can mask
+  geocoding/verify failures.
+
+## Making Changes
+
+- Matching logic lives entirely in `Extension.cs` (`GetByMatch` and `GetOrCreateNamelessPerson`).
+  The defined-type/attribute Guids are hardcoded constants at the top of the class.
+- To add or remove recognized nicknames, prefer editing the **Diminutive Names** defined type in
+  Rock (admin UI) rather than re-running the migration; the migration is a one-time seed.
+- The primary caller is the *Person Attribute From Fields* action in
+  [org.secc.Workflow](../org.secc.Workflow/README.md) — changes to the signature or matching
+  behavior ripple there.

--- a/Plugins/org.secc.Purchasing/README.md
+++ b/Plugins/org.secc.Purchasing/README.md
@@ -1,0 +1,132 @@
+# org.secc.Purchasing
+
+> Southeast's in-house purchasing system — requisitions, purchase orders, receiving, vendors, payment methods, and capital requests — built on a custom LINQ-to-SQL data layer with Sage Intacct GL validation.
+
+## Overview
+
+Purchasing is a full procurement application embedded in Rock as a set of UI blocks. Staff create
+**requisitions** (with line items, GL coding, attachments, and an approval chain), which become
+**purchase orders** sent to **vendors**; items are then **received** against the PO, and
+**payments** / credit-card charges are tracked. A separate **capital request** flow handles larger
+purchases with competing **bids** and finance approval. Unlike most SECC plugins, it does not use
+the Rock EF model — it has its own LINQ-to-SQL domain model over `_org_secc_Purchasing_*` tables,
+and validates GL account/dimension coding against **Sage Intacct** via that vendor's XML API.
+
+## Project Info
+
+- **Project file:** `org.secc.Purchasing.csproj`
+- **Root namespace:** `org.secc.Purchasing`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup,
+  the PO PDF Lava template, logo), via the PostBuildEvent `xcopy`.
+
+## Project Layout
+
+```
+/org_secc/Purchasing/   UI blocks (.ascx + .ascx.cs); PurchaseOrderPDF.lava; SE logo
+/App_Code/              Domain model — Requisition, PurchaseOrder, Receipt, Vendor, Payment,
+                        CapitalRequest, Approval, Note, Attachment, etc. (all : PurchasingBase)
+/App_Code/DataLayer/    Purchasing.dbml LINQ-to-SQL context, ContextHelper, StaffMemberData
+/App_Code/Helpers/      Person / Address / Phone helpers
+/App_Code/Enums/        HistoryType
+/Intacct/               Sage Intacct XML API client (Api, Auth, Functions, Model, ApiClient)
+/Properties/            AssemblyInfo, Settings
+```
+
+No `/Migrations` folder — the `_org_secc_Purchasing_*` tables are not provisioned by an EF/Rock
+plugin migration in this project (see Observations).
+
+## Components
+
+### Blocks
+
+All blocks live under `org_secc/Purchasing/`. The detail/list blocks are `RockBlock`s; the
+embedded widgets (`Attachments`, `Notes`, `StaffPicker`, `StaffSearch`, `VendorSelect`) are plain
+`UserControl`s reused inside the others.
+
+| Block (class) | Purpose | Key settings |
+|---------------|---------|--------------|
+| `RequisitionList` | List/filter requisitions. | Requisition Detail Page, Person Detail Page |
+| `RequisitionDetail` | Create/edit a requisition: line items, GL coding, approvals, vendor, ship-to. | Validate GL Account (`ValidateAccounts`), Default Requisition Type, Default/footer/scripture text, Expedited Shipping Window, Allow New Vendor Selection, Display Inactive Items, Send-notification toggles, Prompt for Note on Decline, Purchase Order Detail Page |
+| `POList` | List/filter purchase orders. | Purchase Order Detail Page, Ministry Area / Position Person Attribute |
+| `PODetail` | View/manage a purchase order; receive items; render the PO PDF. | Purchase Order List Page, Requisition Detail Page, Person Detail Page, Default Ship To Name/Attention/Campus, Show Inactive Vendors, Ministry Person Attribute ID, PDF Report Lava, Receiving User Group |
+| `VendorList` | List/filter vendors. | Vendor Detail Page, Active Only By Default |
+| `VendorDetail` | Create/edit a vendor (preferred-vendor records, addresses, contacts). | — (no block settings) |
+| `PaymentMethodList` | Manage payment methods / credit cards. | Show Active By Default, Credit Card Expriation Date Year Options |
+| `CapitalRequestList` | List/filter capital requests. | Capital Request Detail Page, Ministry Area Lookup Type, Location Lookup Type, Location Admin Group, Ministry Area / SECC Location Person Attribute |
+| `CapitalRequestDetail` | Create/edit a capital request with bids and finance approval. | List Page, Person Detail Page, Allow Ministry/Requester Selection, Ministry Area / Location Lookup Type, Default Title, Minimum Required Bids, Quote Document Type, Finance Approver Tag, ministry/finance/approved/returned notification templates, Requisition Detail Page |
+| `Attachments` (UserControl) | Reusable file-attachment list (used by requisition / PO / capital request). | — |
+| `Notes` (UserControl) | Reusable note thread. | — |
+| `StaffPicker` / `StaffSearch` (UserControl) | Staff lookup widgets (back `StaffMemberData`). | — |
+| `VendorSelect` (UserControl) | Vendor picker modal. | — (the "Choose Vendor Instructions" text is a `RequisitionDetail` block setting) |
+
+### Domain Model (LINQ-to-SQL)
+
+`App_Code/DataLayer/Purchasing.dbml` maps the tables below; each is wrapped by a hand-written
+business class in `App_Code/` deriving from `PurchasingBase`. `ContextHelper.GetDBContext()`
+builds the `PurchasingContext` from the **Rock connection string** (so it runs against the Rock
+database, not the legacy Shelby/Arena strings still in `app.config`).
+
+| Table | Business class |
+|-------|----------------|
+| `_org_secc_Purchasing_Requisition` | `Requisition` |
+| `_org_secc_Purchasing_RequisitionItem` | `RequisitionItem` |
+| `_org_secc_Purchasing_PurchaseOrder` | `PurchaseOrder` |
+| `_org_secc_Purchasing_PurchaseOrderItem` | `PurchaseOrderItem` |
+| `_org_secc_Purchasing_Receipt` / `_ReceiptItem` | `Receipt` / `ReceiptItem` |
+| `_org_secc_Purchasing_Vendor` | `Vendor` (`PreferredVendor` is a code-only class, no own table) |
+| `_org_secc_Purchasing_Campus` | (no business class; mapped for joins) |
+| `_org_secc_Purchasing_Payment` / `_PaymentCharge` / `_PaymentMethod` / `_CreditCard` | `Payment` / `PaymentCharge` / `PaymentMethod` / `CreditCard` |
+| `_org_secc_Purchasing_CapitalRequest` / `_CapitalRequestBid` | `CapitalRequest` / `CapitalRequestBid` |
+| `_org_secc_Purchasing_Approval` | `Approval` |
+| `_org_secc_Purchasing_Note` / `_Attachment` / `_History` | `Note` / `Attachment` / `History` |
+| (Rock) `Person`, `PersonAlias`, `DefinedValue` | mapped read-only for joins |
+
+### Lava
+
+- `org_secc/Purchasing/PurchaseOrderPDF.lava` — the print/PDF template rendered for a purchase
+  order (used by `PODetail`).
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext` (connection string only), `RockBlock`, Rock attribute framework
+  (`DefinedTypeField`, `GroupField`, `LinkedPage`, etc.), `GlobalAttributesCache`,
+  `Rock.Security.Encryption`, `RockCache` (Intacct response caching), DotLiquid (Lava).
+- **Third-party:** **Sage Intacct** XML API (`https://api.intacct.com/ia/xml/xmlgw.phtml`) via
+  `RestSharp`; `Newtonsoft.Json`; `System.Data.Linq` (LINQ-to-SQL); EntityFramework 6 (referenced).
+- **Cross-plugin:** none at build time.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** `app.config` ships hardcoded legacy connection strings for `ShelbyDBRepl`
+  (`ar-sql02`) and an `ArenaDB_ChrisF` dev database. At runtime the active context is built from the
+  Rock connection string in `ContextHelper`, so these appear unused, but the stale server/catalog
+  names are worth removing to avoid confusion and accidental reconnection.
+- **Security (low):** Intacct API credentials are read from the `IntacctAPISettings` global
+  attribute and `Rock.Security.Encryption.DecryptString`-decrypted in `RequisitionDetail`. That's
+  the right place to store them; confirm the global attribute is flagged encrypted and that
+  edit/view rights on it are limited to finance/admin staff.
+- **Improvement:** The domain layer is custom LINQ-to-SQL (`Purchasing.dbml`) rather than the Rock
+  EF model — a parallel data stack with its own connection handling, history/audit, and no plugin
+  migration to create the `_org_secc_Purchasing_*` tables (they must be installed out-of-band).
+  New maintainers should expect to manage schema/DDL separately from the code.
+- **Improvement:** `AssemblyInfo.cs` carries a blank `AssemblyCompany` and `Copyright © 2012`
+  (the file otherwise has the standard SECC license header) — the assembly metadata is stale and
+  worth refreshing.
+
+## Making Changes
+
+- Block UI and behavior live in the matching `org_secc/Purchasing/*.ascx(.cs)`; the embedded
+  `Attachments`, `Notes`, `StaffPicker`, and `VendorSelect` user controls are shared across the
+  detail blocks, so a change there affects requisitions, POs, and capital requests alike.
+- Business rules (validation, status transitions, history) live in the `App_Code/*.cs` class for
+  the entity (e.g. `Requisition.cs`, `PurchaseOrder.cs`); the table mapping is in
+  `App_Code/DataLayer/Purchasing.dbml`. Regenerate the designer if you change the dbml.
+- Intacct/GL validation is gated per-block by the **Validate GL Account** (`ValidateAccounts`)
+  setting and implemented in `/Intacct/`; credentials come from the `IntacctAPISettings` global
+  attribute.
+- The PO printout is the `PurchaseOrderPDF.lava` template, not C#.
+</content>
+</invoke>

--- a/Plugins/org.secc.QRManager/README.md
+++ b/Plugins/org.secc.QRManager/README.md
@@ -1,0 +1,74 @@
+# org.secc.QRManager
+
+> Generates QR-code images and Lava filters that turn a person into a scannable check-in / Fast Pass QR URL.
+
+## Overview
+
+QRManager exposes a REST endpoint that renders a QR-code PNG for an arbitrary code string,
+plus a set of Lava filters that build the QR URL (and an `<img>` tag) for a person. It is used
+to produce personal check-in codes and "Personal Fast Pass" (PFP) codes that can be embedded in
+emails, statements, and Lava templates and scanned at a kiosk.
+
+## Project Info
+
+- **Project file:** `org.secc.QRManager.csproj`
+- **Root namespace:** `org.secc.QRManager`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `QRCoder.dll`)
+
+## Project Layout
+
+```
+/Lava/         CustomFilters.cs   — Lava filters (QRUrl, QRImage, PersonalFastPass*)
+/Controllers/  QRController        — REST endpoint that renders the QR PNG
+/Startup/      LoadCustomFilters   — IRockOwinStartup hook that registers the filters
+```
+
+## Components
+
+### REST Endpoints
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `api/qr/{code}` | GET (authenticated) | Returns a PNG QR-code image encoding `{code}`. |
+
+### Lava Filters
+
+Registered at startup via `LoadCustomFilters` (`IRockOwinStartup`).
+
+| Filter | Purpose |
+|--------|---------|
+| `QRUrl` | Builds the QR URL for a person (accepts `Person`, `PersonAlias`, `GroupMember`, `RegistrationRegistrant`, or a person Id). |
+| `QRImage` | Same as `QRUrl` but returns an `<img>` tag (optional `width`, default 300). |
+| `PersonalFastPassUrl` | QR URL using the `PFP` (Personal Fast Pass) prefix. |
+| `PersonalFastPassImage` | `<img>` tag variant of the Fast Pass URL. |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, `PersonService`, Rock REST (`ApiControllerBase`).
+- **Third-party:** `QRCoder` (QR generation), `System.Drawing` (PNG output), DotLiquid (Lava).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** The QR "code" is a person's randomly-generated **Alternate Id** search key
+  (`GenerateRandomAlternateId`), not a sequential/guessable Id or the person Guid — so codes aren't
+  easily enumerable. The `api/qr/{code}` endpoint is `[Authenticate]`-gated and only renders the
+  string as an image, so it doesn't leak data on its own. Worth confirming the alternate-id search
+  path that *consumes* these codes is itself access-controlled.
+- **Improvement:** `GetURL` is a **Lava filter that writes to the database** — when a person has no
+  alternate-id search key it creates one and calls `SaveChanges()`. Template rendering should be
+  side-effect-free; as written, rendering a Lava template can mutate data and isn't idempotent.
+  Consider provisioning the search key up front (job/workflow) and keeping the filter read-only.
+- **Improvement:** A new `RockContext` is constructed on every filter call, so rendering a list of N
+  people spins up N contexts. Acceptable for one-offs, wasteful in loops.
+
+## Making Changes
+
+- To add or change a filter, edit `Lava/CustomFilters.cs`; filters are auto-registered because
+  the whole `CustomFilters` type is passed to `Template.RegisterFilter` in
+  `Startup/LoadCustomFilters.Partial.cs`.
+- The person-resolution logic (which input types map to a `Person`) lives in the private
+  `GetURL` helper in `CustomFilters.cs`.
+- See [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md) for where these codes are scanned.

--- a/Plugins/org.secc.RecurringCommunications/README.md
+++ b/Plugins/org.secc.RecurringCommunications/README.md
@@ -1,0 +1,103 @@
+# org.secc.RecurringCommunications
+
+> Lets staff define email/SMS/push communications that re-send on a Rock schedule to a Data View audience, sent by a scheduled job.
+
+## Overview
+
+RecurringCommunications adds a custom entity (`RecurringCommunication`) plus two admin blocks for
+authoring communications that fire on a repeating Rock **Schedule** against a **Data View** of
+people. A scheduled job walks the saved definitions, and for any whose schedule has fired since the
+last run it builds a real Rock `Communication` and enqueues it for sending. Optionally a
+**Data Transform** can map the Data View's people to a different recipient set (e.g. parents of the
+matched people) while carrying the original person through as an `AppliesTo` merge field.
+
+## Project Info
+
+- **Project file:** `org.secc.RecurringCommunications.csproj`
+- **Root namespace:** `org.secc.RecurringCommunications`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup), via the PostBuildEvent `xcopy`
+
+## Project Layout
+
+```
+/Model/         RecurringCommunication entity + RecurringCommunicationService
+/Data/          RecurringCommunicationsContext (EF DbContext) + RecurringCommunicationsService<T> (generic base service)
+/Jobs/          SendRecurringCommunications — Quartz IJob that builds & enqueues communications
+/Migrations/    Rock plugin migrations (table create, transformation column)
+/org_secc/RecurringCommunications/   List + Detail admin blocks (.ascx + .ascx.cs)
+```
+
+## Components
+
+### Models
+
+| Model | Table | Notes |
+|-------|-------|-------|
+| `RecurringCommunication` | `_org_secc_RecurringCommunications_RecurringCommunication` | `ISecured`/`IRockEntity` Rock entity. Holds the audience (`DataViewId`), repeat `ScheduleId`, `CommunicationType`, the email/SMS/push payload fields, optional SMS `PhoneNumberValueId`, optional `TransformationEntityTypeId`, and `LastRunDateTime` (the de-dupe watermark). |
+
+### Jobs
+
+Quartz `IJob`, registered as a Rock Job in the admin UI.
+
+| Job (class) | Purpose | Key settings |
+|-------------|---------|--------------|
+| `SendRecurringCommunications` | For each saved `RecurringCommunication` whose `Schedule` has a scheduled start time in the last day not yet covered by `LastRunDateTime`, builds an `Approved` `Communication` for the Data View recipients and enqueues it via `ProcessSendCommunication`. | **`SQLCommandTimeout`** (IntegerField, default 30s) |
+
+### Blocks
+
+Category in Rock: **SECC > Communication**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Recurring Communications List | Grid of all recurring communications; "Add" navigates to the detail page. | **`DetailsPage`** (LinkedPage) |
+| Recurring Communications Detail | Create/edit a recurring communication (name, Data View, schedule, type, payload, optional transform). | **`EnabledCommunicationTypes`** (CustomCheckboxListField: `0`=Recipient Preference, `1`=Email, `2`=SMS, `3`=Push Notification; default `0,1,2`) |
+
+## Dependencies & Integrations
+
+- **Rock:** EF `DbContext` (`Rock.Data.DbContext` with a `NullDatabaseInitializer`), Rock model
+  framework (`Model<T>`, `ISecured`), Schedule (`GetScheduledStartTimes`), Data Views
+  (`DataView.GetQuery`), Data Transforms (`DataTransformContainer` / `FilterExpressionExtractor`),
+  the Communication engine (`CommunicationService`, `ProcessSendCommunication.Message`), Quartz job
+  framework, the Rock block/UI framework, and plugin migrations (`Rock.Plugin`).
+- **Third-party:** Quartz, EntityFramework 6, Common.Logging (transitive); DotLiquid / Rock.Lava.Shared (project references).
+- No external HTTP APIs.
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/` (both `[MigrationNumber]`, not EF code-first):
+
+- `201910311455314_Init` — `MigrationNumber 1`: creates `_org_secc_RecurringCommunications_RecurringCommunication` with FKs to DataView, Schedule, DefinedValue, PersonAlias.
+- `20200107104400_AddTransformationColumn` — `MigrationNumber 2`: adds the nullable `TransformationEntityTypeId` column, FK to `EntityType`, and its index.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** `Init.Down()` drops `dbo.RecurringCommunication`, but the table the migration
+  actually creates is `dbo._org_secc_RecurringCommunications_RecurringCommunication`. A rollback would
+  fail to find the table (and leave the real one behind). Worth correcting the `DropTable` name.
+- **Improvement:** In the transform branch of `EnqueRecurringCommunication`, `communication.Recipients`
+  is reassigned to the shared `recipients` list inside the per-person loop, and a single
+  `fieldValues`/`recipients` accumulation is reused across people — worth reviewing that the
+  `AppliesTo` merge value lands on the right recipients and that duplicates aren't produced.
+- **Improvement:** The job sets `LastRunDateTime` and calls `SaveChanges()` *before* attempting the
+  send; if `EnqueRecurringCommunication` throws, the error is logged and the communication is added to
+  the `errors` list, but the watermark has already advanced — so a failed run will be skipped next
+  time rather than retried. Confirm that's the intended behavior.
+- **Note:** There are two service classes, but they aren't duplicates: `Data/RecurringCommunicationsService<T>`
+  is a generic `Rock.Data.Service<T>` base (with a no-op `CanDelete`), and
+  `Model/RecurringCommunicationService` is the concrete subclass for `RecurringCommunication` that the job
+  and blocks use. This is the standard Rock plugin base/derived service pattern.
+
+## Making Changes
+
+- To change the authoring UI or available communication types, edit
+  `org_secc/RecurringCommunications/RecurringCommunicationsDetail.ascx[.cs]` (the
+  `EnabledCommunicationTypes` block setting controls the type picker).
+- To change how/when communications are built and sent, edit `Jobs/SendRecurringCommunications.cs`;
+  the schedule-vs-`LastRunDateTime` watermark logic in `Execute` decides what fires.
+- New columns/data belong in a new numbered migration under `/Migrations/` (don't hand-edit
+  migrations that have already run); keep the `RecurringCommunication` model and migration in sync.
+- Related: this plugin builds standard Rock `Communication` records, so it rides on Rock's core
+  communication mediums and transports rather than a sibling plugin.

--- a/Plugins/org.secc.Reporting/README.md
+++ b/Plugins/org.secc.Reporting/README.md
@@ -1,0 +1,162 @@
+# org.secc.Reporting
+
+> Southeast's custom reporting surface for Rock — a large set of admin/ministry report blocks, a "SQL Filter" data-view component, a camp-medication Excel export workflow action, and supporting EF models, migrations, and SQL objects.
+
+## Overview
+
+This plugin is Southeast's grab-bag of custom **reporting** building blocks. The bulk of it is RockBlock
+report screens (`.ascx` under `org_secc/Reporting/`) grouped by ministry area — Children's, NextGen,
+Home Groups, metrics entry, decision analytics, financial aid, worship-attendance entry. Alongside the
+blocks it ships a reusable **SQL Filter** data-view component (filter any entity by a raw `SELECT [Id]`
+query), an **Event Medication Export** workflow action that produces an Excel file, and the EF models /
+migrations / stored procedures / views / triggers those screens read from. It is used by staff and
+ministry leaders for operational reporting and data entry.
+
+## Project Info
+
+- **Project file:** `org.secc.Reporting.csproj`
+- **Root namespace:** `org.secc.Reporting`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/Plugins/org_secc/` (the `.ascx` markup) and `RockWeb/bin/` (assembly, `.pdb`,
+  and `Google.Apis.*`), via the PostBuildEvent `xcopy`.
+
+## Project Layout
+
+```
+/org_secc/Reporting/      Report blocks (.ascx + .ascx.cs), grouped by ministry:
+                            (root)        DecisionAnalytics, AttendanceQuickEntry, FinancialAidFamilyProfile,
+                                          GroupAttendanceAnalytics, MetricsEntry, ServiceMetricsEntry,
+                                          BirthdayListFetchingData, MedReportTest
+                            Children/     BreakoutGroup* , ChildrenAudit, WithoutBreakoutGroupAttendance
+                            NextGen/      Believe(+Leader), BibleAndBeach, FallRetreat, Mix, SignatureAudit,
+                                          MedicationDispense, MedicationInformation
+                            HomeGroups/   HomeGroupAttendance
+                            Scripts/      isotope.pkgd.js / isotope.pkgd.min.js (layout for some grids)
+/CampMedicationReport/    "Event Medication Export" workflow action + filter/item DTOs (EPPlus Excel)
+/DataFilter/              SQLFilter — DataFilterComponent that filters by a raw SQL Id query
+/Model/                   EF models + services: DataViewSQLFilterStore (skinny cache table), DecisionReportItem
+/Data/                    ReportingContext (Rock DbContext) + ReportingService
+/Transactions/            SqlFilterCleanupTransaction — prunes orphaned SQL-filter cache rows
+/Migrations/              Rock plugin migrations (tables, view, stored proc, triggers)
+Helpers.cs                Md5Hash helper (keys the SQL-filter cache)
+```
+
+## Components
+
+### Blocks
+
+All are `RockBlock`s; categories shown are the Rock block-type categories. Roughly grouped:
+
+| Block (class) | Category | Purpose |
+|---------------|----------|---------|
+| `DecisionAnalytics` | SECC > Reporting | Reports of people who made a next-step decision (reads the `_org_secc_DecisionForm` table / analytics view). |
+| `AttendanceQuickEntry` | SECC > Reporting | Lets campuses quickly enter worship-service attendance. Config: **Worship Attendance Parent Categories**. |
+| `FinancialAidFamilyProfile` | SECC > Reporting | Displays financial-aid information for an entire family. |
+| `GroupAttendanceAnalytics` | SECC > Reporting | Attendance graph configurable by group, date range, etc. Config: **DataViewCategories**. |
+| `MetricsEntry` | SECC > Reporting | Add/edit metric values for metrics partitioned by campus & service time. Config: **Schedule Categories**. |
+| `ServiceMetricsEntry` | SECC > Reporting | As above, service-metrics variant. Config: **Schedule Categories**. |
+| `BirthdayListFetchingData` | SECC2 > Project | Simple sample/data-fetch block (`ICustomGridColumns`). |
+| `MedReportTest` | SECC > Report | Test/scratch block (`[Description("Test Application")]`). |
+| `Children/BreakoutGroupAttendance` | SECC > Reporting > Children | Filterable/sortable list of breakout groups. |
+| `Children/BreakoutGroupAttendanceSummary` | SECC > Reporting > Children | Summary variant of the breakout-group list. |
+| `Children/BreakoutGroupHandout` | SECC > Reporting > Children | Generates breakout-group handouts. |
+| `Children/ChildrenAudit` | SECC > Reporting > Children | Audit information for children's ministry. |
+| `Children/WithoutBreakoutGroupAttendance` | SECC > Reporting > Children | Lists children with no breakout group plus attendance. |
+| `NextGen/Believe`, `BelieveLeader`, `BibleAndBeach`, `FallRetreat`, `Mix` | SECC > Reporting > NextGen | Trip-attendee management reports for NextGen trips/events. |
+| `NextGen/SignatureAudit` | SECC > Reporting > NextGen | Audits signature documents. |
+| `NextGen/MedicationDispense` | SECC > Reporting > NextGen | Notes when medications should be given out. |
+| `NextGen/MedicationInformation` | SECC > Reporting > NextGen | Medication-information report. |
+| `HomeGroups/HomeGroupAttendance` | SECC > Reporting > Home Groups | Home-group attendance reporting tool. |
+
+### Data Filters
+
+| Component | Applies to | Purpose |
+|-----------|-----------|---------|
+| `SQLFilter` (`DataFilterComponent`, section "Additional Filters") | any entity (`AppliesToEntityType` empty) | Filters a data view by a raw SQL query that returns entity `Id`s. Small result sets (≤1000) filter in-memory; larger sets are staged into the `_org_secc_Reporting_DataViewSQLFilterStore` cache table (keyed by an MD5 hash of the SQL) and sub-selected, to avoid huge `IN (...)` clauses. |
+
+### Workflow Actions
+
+| Action (class) | ComponentName | Purpose | Key attributes |
+|----------------|---------------|---------|----------------|
+| `CampMedicationReportExportAction` | `Event Medication Export` (action category `SECC > Events`) | Produces an Excel file (EPPlus) of event participants who have medications and stores it on a workflow attribute. | **RegistrationTemplate** (Registration Template), **ExcelFile** (File — output) |
+
+### Models
+
+| Model (table) | Notes |
+|---------------|-------|
+| `DataViewSQLFilterStore` (`_org_secc_Reporting_DataViewSQLFilterStore`) | Skinny cache table for the SQL Filter; composite key `(Hash, EntityId)`. `[HideFromReporting]`; the standard Rock audit/Id columns are `[NotMapped]`. |
+| `DecisionReportItem` (`_org_secc_Reporting_DecisionForm`) | Denormalized decision-form row (person, decision type/date, campus, baptism, address, etc.) backing `DecisionAnalytics`. `[HideFromReporting]`; populated by migration SQL, not EF writes. |
+
+`ReportingContext` is a Rock `DbContext` (uses the `RockContext` connection, `NullDatabaseInitializer`)
+exposing `DataViewSQLFilterStores` and `DecisionReportItems`. Each model has a matching `Service<T>`.
+
+## Dependencies & Integrations
+
+- **Rock:** Reporting framework (`DataFilterComponent`, `FilterExpressionExtractor`), workflow engine
+  (`ActionComponent`, `WorkflowAttribute`), `RockContext` / Rock services, `RockBlock` UI, EF plugin
+  migrations (`Rock.Plugin`), `RockQueue` transactions, `DotLiquid` / `Rock.Lava.Shared`.
+- **Third-party:** EPPlus (Excel export), Google.Apis / Google.Apis.Sheets.v4 (referenced in the project;
+  Google Sheets client libraries are copied to `RockWeb/bin`), Newtonsoft.Json, EntityFramework 6.
+- **Database objects (created by migrations):** stored procedure `_org_secc_CampManager_GetMedicationReport`,
+  view `_org_secc_DecisionForm_Analytics`, table `_org_secc_Reporting_DecisionForm`, and two history
+  triggers on `MetricValue` (`_org_secc_trgMetricValueWorshipAttendance{Insert,Update}LogToHistory`).
+  Note the medication stored proc is named under the `CampManager` prefix — it is shared with / overlaps
+  camp-management functionality.
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/` (all compiled per the `.csproj`):
+
+- `001_Init` (`MigrationNumber 1`) — creates `_org_secc_Reporting_DataViewSQLFilterStore` (composite PK on
+  `Hash`,`EntityId`; index on `Hash`).
+- `WorshipAttendanceHistory` (`MigrationNumber 2`) — creates insert/update triggers on `MetricValue` that
+  log worship-attendance metric changes to history.
+- `DecisionReportView` (`MigrationNumber 3`) — creates the `_org_secc_DecisionForm_Analytics` view.
+- `DecisonFormReportTable` (`MigrationNumber 4`) — creates the `_org_secc_Reporting_DecisionForm` table.
+- `005_MedicationReportStoredProcedure` (`MigrationNumber 5`) — creates the
+  `_org_secc_CampManager_GetMedicationReport` stored procedure.
+- `006_MedicationReportFilterInactive` (`MigrationNumber 6`) — re-creates that stored proc to exclude
+  medications whose `MedicationActive` matrix attribute is off.
+
+`Configuration.cs` is the EF `DbMigrationsConfiguration` (automatic migrations disabled, empty `Seed`).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** `SQLFilter` runs arbitrary operator-supplied SQL directly against the Rock
+  database (`Context.Database.SqlQuery<int>(selection)`). The UI shows a prominent warning, and the filter
+  is only usable by people who can edit data views, but it is effectively raw DB access via the reporting
+  UI. The cache-maintenance paths in `GetExpression` and `SqlFilterCleanupTransaction` also build
+  `DELETE`/`IN` statements via `string.Format` with the MD5 hash and entity Ids; the hash and Ids are not
+  externally controlled, so injection risk there is low, but the design is worth confirming against
+  Southeast's data-access policy.
+- **Improvement:** `GetExpression` (a data-view filter evaluation) **writes to the database** — it bulk-inserts
+  and deletes cache rows for result sets over 1000. Filter evaluation thus has side effects and isn't
+  idempotent; large data views will repeatedly churn the cache table. The orphan cleanup runs as a queued
+  transaction enqueued from `GetSelection` (i.e. when the filter is saved), which is a reasonable place,
+  but the two paths together make the cache lifecycle non-obvious.
+- **Improvement:** Several blocks look like leftovers/scratch: `MedReportTest` ("Test Application"),
+  `BirthdayListFetchingData` ("A simple block to fetch some data", category `SECC2 > Project`), and
+  `NextGen/MedicationInformation` whose description is just `"T"`. Worth confirming which are still in use.
+- **Improvement:** Several NextGen trip blocks (`Believe`, `BelieveLeader`, `FallRetreat`) carry the
+  copy-pasted description "A report for managing the trip attendeeds for NextGen's Bible & Beach Trip"
+  inherited from `BibleAndBeach`, so the displayed description is wrong for them. (`Mix` was correctly
+  updated to "...NextGen's MIX Trip"; note the typo "attendeeds" is present in all of them.)
+- **Note:** The medication stored procedure is prefixed `_org_secc_CampManager_` rather than `_Reporting_`,
+  indicating shared ownership with camp-management code; renaming/moving it touches both areas.
+
+## Making Changes
+
+- To add a report screen, drop a new `.ascx`/`.ascx.cs` `RockBlock` under the matching folder in
+  `org_secc/Reporting/` (use a ministry-area `[Category]`), then register it as a block type in the admin UI;
+  the PostBuildEvent copies the markup to `RockWeb/Plugins/org_secc/`.
+- To change the SQL-filter staging behavior (size thresholds, caching), edit
+  `DataFilter/SQLFilter.cs` and the cache lifecycle in `Transactions/SqlFilterCleanupTransaction.cs`.
+- To change the medication export, edit the SQL in `Migrations/006_MedicationReportFilterInactive.cs`
+  (the live stored proc) and/or the Excel generation in `CampMedicationReport/CampMedicationReport.cs`.
+- New SQL objects (procs, views, triggers) or tables belong in a **new numbered migration** under
+  `/Migrations/` — don't hand-edit migrations that have already run; note that the numeric `MigrationNumber`
+  is what orders them (file names like `DecisionReportView.cs` carry number 3).
+- Related medication/camp logic lives in the camp-management plugins; decision-form data is produced by the
+  migration view/table here and consumed by `DecisionAnalytics`.

--- a/Plugins/org.secc.Rest/README.md
+++ b/Plugins/org.secc.Rest/README.md
@@ -1,0 +1,184 @@
+# org.secc.Rest
+
+> Custom Rock REST controllers for SECC's apps — account/SMS login, the Groups mobile app, content-channel/sermon feeds, person matching, and financial-statement data.
+
+> **Doc tier: deep.** This is an externally-facing API surface (several endpoints back native/mobile apps and OAuth clients), with non-trivial auth contracts that differ per controller — so it's documented at the deeper tier (per-endpoint reference, auth model, request/response shapes, extending). Most SECC plugins use the lighter standard tier.
+
+## Overview
+
+This plugin adds Web API controllers to Rock that aren't part of core. They fall into a few groups: **Account / Security** endpoints that back OAuth-client account creation and SMS/forgot-password login flows; the **GroupApp** family that powers SECC's Groups mobile app (group list, members, attendance/self-check-in, schedule and location editing, leader communication); read-only **content feeds** (`ChannelItems`, `SermonFeed`); and a few **extension** controllers (`People/MatchOrCreatePerson`, `GroupMembers/OData`, `Groups` photo upload, `FinancialTransactions` contribution data). Controllers are discovered by Rock's standard Web API routing; one (`SecurityController`) maps its own session-enabled routes.
+
+## Project Info
+
+- **Project file:** `org.secc.Rest.csproj`
+- **Root namespace:** `org.secc.Rest` (the sermon controller lives under `org.secc.SermonFeed.Rest`)
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly only, via `xcopy` PostBuildEvent)
+- **Cross-plugin dependencies:** [org.secc.OAuth](../org.secc.OAuth/README.md), [org.secc.Authentication](../org.secc.Authentication/README.md), [org.secc.PersonMatch](../org.secc.PersonMatch/README.md)
+
+## How Routing & Auth Work
+
+Most controllers extend Rock's `ApiControllerBase` (or `ApiController`) and declare their routes with `[Route(...)]` attributes, so Rock's standard Web API route discovery registers them. `SecurityController` is the exception: it implements `IHasCustomHttpRoutes` and registers its own `api/org.secc/People/{action}` routes against a `SessionRouteHandler` so those calls run with ASP.NET session state.
+
+```mermaid
+flowchart TD
+    A[HTTP request to api/...] --> B{Route source}
+    B -->|attribute route| C[Rock Web API discovery]
+    B -->|IHasCustomHttpRoutes| D[SecurityController.AddRoutes -> SessionRouteHandler]
+    C --> E{Auth model on the action}
+    D --> E
+    E -->|"[Authenticate, Secured]"| F[Rock login + entity security]
+    E -->|"[Authorize] + OAuth client check"| G[ASP.NET principal == OAuth API key, client.Active]
+    E -->|UserLoginService.GetCurrentUser| H[Logged-in Rock user, else 401/403]
+    F --> I[Handler logic]
+    G --> I
+    H --> I
+```
+
+**Auth models in use (they are not uniform — confirm per endpoint):**
+- **`[Authenticate, Secured]`** — Rock's filter pair: authenticates the caller and checks entity-level security on the controller action. Used by the extension controllers.
+- **`[Authorize]` + OAuth client gate** — `AccountController` resolves the ASP.NET identity name as an OAuth API key via `ClientService.GetByApiKey(...)` and requires `client.Active`. Backs OAuth-client app flows.
+- **`UserLoginService.GetCurrentUser()`** — the GroupApp controllers have **no auth attribute**; they call `GetCurrentUser()` and return `401` if null, then do their own per-group leader/member checks (`group.IsAuthorized`, group-member role queries) before acting.
+- **`GetPerson()` + `IsAuthorized(VIEW, ...)`** — the content feeds resolve the caller's person and check VIEW on the content channel.
+
+## REST Endpoints
+
+### Account / Security
+
+| Route | Method | Auth | Purpose |
+|-------|--------|------|---------|
+| `api/account/create` | POST | `[Authorize]` + active OAuth client | Match-or-create a person from a profile, create an Internal (or SMS) `UserLogin`, send confirmation email if unconfirmed. Min age 13 is enforced only when a `Username` is supplied (the validation block is gated on a non-empty username). |
+| `api/account/confirmaccount` | POST | `[Authorize]` + active OAuth client | Confirm an account by Rock confirmation code, or by a 6-digit MD5-derived mobile code. |
+| `api/account/family` | GET | `[Authorize]` | Family members of the current user (`UserLoginService.GetCurrentUser`). |
+| `api/account/forgotpassword` | POST | `[Authorize]` + active OAuth client | Send a forgot-username/password email for resettable logins matching an address. |
+| `api/account/profile` | GET | `[Authorize]` | Current user's `Profile`. |
+| `api/account/smslogin` | POST | `[Authorize]` + active OAuth client | Start SMS auth: match a single living person of min age by phone, send code via Rock's `SMSAuthentication`. |
+| `api/org.secc/People/CurrentUser` | GET | session route; current user **or** a Forms-auth ticket in `{param}` | Returns a small person report (name, campus, gender). Registered via `IHasCustomHttpRoutes`. |
+| `api/org.secc/People/Post` | POST | session route | Echoes the posted `phone` string. |
+
+### GroupApp (Groups mobile app)
+
+All require a logged-in user (`GetCurrentUser`, else `401`) and apply per-group authorization as noted.
+
+| Route | Method | Authorization | Purpose |
+|-------|--------|---------------|---------|
+| `api/GroupApp/GroupList/` | GET | current user | Groups the user is an active member of, within configured GroupApp group types. |
+| `api/GroupApp/GetGroup/{groupId}` | GET | member or VIEW | Group summary; optional `getContent` / `getAllowEmailParents`. |
+| `api/GroupApp/GetGroupMembers/{groupId}` | GET | member or VIEW | Members; leaders also see address/email/phone/parent contact. Table-based groups filter by `TableNumber`. |
+| `api/GroupApp/GroupMembers/{groupId}/Communicate` | POST | EDIT **and** MANAGE_MEMBERS | Send an email to all/one member (optionally parents). |
+| `api/GroupApp/GroupMembers/{groupId}/Add` | POST | EDIT **and** MANAGE_MEMBERS | Match-or-create a person and add as a member; copies leader's `TableNumber`. |
+| `api/GroupApp/GroupMembers/{groupId}/Remove/{groupMemberId}` | DELETE | EDIT **and** MANAGE_MEMBERS | Hard-delete a group member. |
+| `api/GroupApp/Attendance/{groupId}/{occurrenceDate}` | GET | VIEW or leader | Attendance for an occurrence. |
+| `api/GroupApp/Attendance/` | POST | leader | Mark a member present for an occurrence. |
+| `api/GroupApp/Attendances/{attendanceId}` | DELETE | leader | Delete an attendance record. |
+| `api/GroupApp/Attendance/SelfReport` | GET / POST | member (POST: adult only) | Read/set the current user's own attendance, gated to a window around the occurrence start. |
+| `api/GroupApp/Attendance/DidNotMeet` | POST | leader | Mark an occurrence as "Did Not Meet" and clear its attendance. |
+| `api/GroupApp/AttendanceSchedules/{groupId}` | GET | VIEW or leader | Past-12-months occurrence list (scheduled + recorded). |
+| `api/GroupApp/Groups/{groupId}/Schedule` | GET / PUT | leader | Read/update the group's weekly schedule as iCal (forks a shared schedule on edit). |
+| `api/GroupApp/Groups/{groupId}/Location` | GET / PUT | GET: member, PUT: leader | Read/replace the group's single location; PUT runs Rock address `Verify` (geocode). |
+
+### Content / extension
+
+| Route | Method | Auth | Purpose |
+|-------|--------|------|---------|
+| `api/ChannelItems/{contentChannelId}[/{tag}]` | GET | content-channel VIEW | Paged content-channel items with attributes, tags, child/parent ids; query-string keys filter on attribute values. |
+| `api/ChannelItem/{identifier}` | GET | content-channel VIEW | One item by id or slug. |
+| `api/sermonfeed/[{slug}/]` | GET | none declared | Speaker-filtered sermon series feed (1-hour `RockCache`). Hardcodes content-channel ids (24/23) and the Speaker attribute id (30285). |
+| `api/People/MatchOrCreatePerson` | POST | `[Authenticate, Secured]` | Match a person via [PersonMatch](../org.secc.PersonMatch/README.md); add if none, return the id. |
+| `api/GroupMembers/OData` | GET | `[Authenticate, Secured]` | OData query over `GroupMember` with expand support (math functions only). |
+| `api/Groups/GetPhoto/{id}` | GET | `[Authenticate, Secured]` | URL of the group's `GroupPhoto` attribute binary file. |
+| `api/Groups/UploadPhoto/{id}` | POST | `[Authenticate, Secured]` + binary-file-type EDIT | Upload/replace the group's `GroupPhoto`. |
+| `api/secc/FinancialTransactions/GetContributionTransactions/{groupId}[/{personId}]` | POST | `[Authenticate, Secured]` | Build a `DataSet` of contribution transactions (cash only) for a giving group or person. |
+
+## Detailed Reference
+
+Keys / ids in **bold** are load-bearing in code.
+
+### GroupApp group-type configuration *(GroupAppGroupListController / MembersController)*
+
+GroupApp behavior is driven by **defined types** resolved by Guid (not block settings):
+
+| Defined Type Guid | Meaning |
+|-------------------|---------|
+| **`f75bdfa7-582b-4e0d-9715-5e47b0eb57cf`** | Group types surfaced in the app's group list. |
+| **`90526a36-fda6-4c90-997c-636b82b793d8`** | "Table-based" group types — members are filtered to the leader's `TableNumber`. |
+| **`3780965b-3da0-4609-9577-cf8d39ec601a`** | "Student" group types. |
+
+Each defined value's `Value` is parsed as an integer GroupTypeId. Other in-code constants: `GroupTracker` is set for GroupTypeId 107/109 on CampusId 1; home/meeting location types resolved via Rock system Guids.
+
+### Account create *(AccountController)*
+
+| Field | Notes |
+|-------|-------|
+| **EmailAddress** | Must match an existing person for a confident match; mobile last-10 also compared. |
+| **Username / Password** | Optional; password validated via `UserLoginService.IsPasswordValid`. |
+| **Birthdate** | Min age **13** (`MINIMUM_AGE`) enforced — but only inside the `if ( !string.IsNullOrEmpty( account.Username ) )` block, so a request with no username skips the age check. |
+| Match path | `PersonService.GetByMatch`; single match + matching email → reuse, else create a Web-Prospect/Pending person. |
+
+### ChannelItems query filtering *(ChannelItemController)*
+Reserved query keys (`contentchannelid`, `tag`, `take`, `page`, `hideInactive`, `orderby`, `reverse`) control paging/sort; **any other query key** is treated as a content-channel-item **attribute key** and filtered on exact attribute value.
+
+### Contribution transactions *(FinancialTransactionsExtensionsController)*
+Returns a nested `DataSet` (transactions + per-account details), filtered to the Contribution transaction type and excluding the **non-cash** currency type (`F64662E7-0E12-4604-BBB0-DB774AC3C830`). Without `personId`, pulls everyone whose `GivingGroupId` equals `groupId`.
+
+## Dependencies & Integrations
+
+- **Rock:** `Rock.Rest` (`ApiControllerBase`, `IHasCustomHttpRoutes`, `[Authenticate]`/`[Secured]` filters), Web API + OData, `RockContext` and many services (Person, Group, GroupMember, Attendance, Communication, ContentChannelItem, Schedule, Location, FinancialTransaction), `RockCache`, defined values, `SMSAuthentication`, Rock email/communication.
+- **Cross-plugin:** [org.secc.OAuth](../org.secc.OAuth/README.md) (client/API-key validation in `AccountController`), [org.secc.Authentication](../org.secc.Authentication/README.md), [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) (`GetByMatch`, `MatchOrCreatePerson`).
+- **Third-party:** Newtonsoft.Json, ASP.NET Web API (incl. OData), EntityFramework, System.Linq.Dynamic (used for the `orderby` string in `ChannelItems`).
+
+## Edge Cases & Constraints
+
+- **GroupApp endpoints carry no auth attribute.** They rely entirely on `GetCurrentUser()` plus hand-rolled per-group checks. Any new GroupApp action must repeat that pattern — there is no filter enforcing it.
+- **Hardcoded ids.** `SermonController` hardcodes content-channel ids (24, 23) and a Speaker attribute id (30285); `GetGroups` hardcodes GroupTypeIds 107/109 and CampusId 1; some location lookups use literal `GroupLocationTypeValueId` 19/209. These break if the target environment's ids differ.
+- **Schedule edit forks shared schedules.** `PUT .../Schedule` creates a new `Schedule` if the current one is shared by another group/group-location, then repoints the group; legacy `WeeklyDayOfWeek`/`WeeklyTimeOfDay` are cleared in favor of iCal.
+- **Location PUT is destructive.** It deletes *all* existing `GroupLocation` rows for the group before adding one (single-location app requirement).
+- **`MatchOrCreatePerson` adds the posted `Person` directly** when no match is found — the request body is persisted as a new person with no field sanitization beyond what matching uses.
+
+## Observations
+
+*Noticed while documenting — not a full audit; the auth surface and a few endpoints stood out.*
+
+- **Security (review):** Authorization is inconsistent across controllers and several checks are easy to read as inverted/loose — worth a careful pass. In `ChannelItemController.ChannelItems` the guard is `if ( !contentChannel.IsAuthorized( VIEW, GetPerson() ) ) throw Unauthorized`, but `GetGroup` in `GroupAppGroupListController` uses `if ( isGroupMember || !group.IsAuthorized( VIEW, ... ) )` to *grant* access — i.e. it returns the group when the user is **not** authorized to view it. That condition reads backwards and should be confirmed against intent.
+- **Security (low/medium):** GroupApp endpoints have no `[Authenticate]`/`[Secured]` filter and depend solely on `GetCurrentUser()` + manual checks; `GetGroupMembers` exposes member email/phone/address and minors' parent contact info to group leaders. Confirm leader determination is correct and that these routes can't be reached by an unauthenticated session. `api/sermonfeed` has no declared authorization.
+- **Security (low):** `SecurityController.CurrentUser(param)` decrypts a Forms-auth ticket from the URL and returns the matching user's report — confirm this `{param}` path is intended to be callable without a Rock login and can't be used to probe accounts.
+- **Improvement:** Several handlers `new RockContext()` per request and some construct multiple contexts in one call (e.g. `RemoveGroupMember` opens a second context; `GetGroupMembers` calls `_personService.Get` and `GetFamily` per member — an N+1). `AccountController` calls `MD5` for a 6-digit confirmation code, which is fine for non-secret short codes but shouldn't be mistaken for a security primitive.
+- **Improvement:** `AssemblyInfo.cs` still carries the Visual Studio template metadata (`AssemblyCompany("Microsoft")`, `Copyright © Microsoft 2016`) — cosmetic, but worth fixing to SECC.
+- **Improvement:** The `.csproj` lists `Rock.Rest` and `DotLiquid` `ProjectReference`s twice each (duplicate entries) — harmless but worth cleaning.
+
+## Extending
+
+Add a controller alongside the others under `Controllers/` (file convention `*Controller.Partial.cs`); attribute routes are picked up by Rock's Web API discovery — no registration step. For GroupApp endpoints, follow the existing auth pattern:
+
+```csharp
+public partial class GroupAppExampleController : Rock.Rest.ApiControllerBase
+{
+    [HttpGet]
+    [System.Web.Http.Route( "api/GroupApp/Example/{groupId}" )]
+    public IHttpActionResult GetExample( int groupId )
+    {
+        var currentUser = UserLoginService.GetCurrentUser();
+        if ( currentUser == null )
+            return StatusCode( HttpStatusCode.Unauthorized );
+
+        var group = new GroupService( new RockContext() ).Get( groupId );
+        if ( group == null )
+            return NotFound();
+
+        // per-group check — leader or member, per your needs
+        // if ( !group.IsAuthorized( Rock.Security.Authorization.VIEW, currentUser.Person ) )
+        //     return StatusCode( HttpStatusCode.Forbidden );
+
+        return Ok( /* dto */ );
+    }
+}
+```
+
+Only `SecurityController` needs the `IHasCustomHttpRoutes.AddRoutes` + `SessionRouteHandler` machinery (for session state); the rest do not.
+
+## Making Changes
+
+- New API methods go in the matching `Controllers/*.Partial.cs`; DTOs live in `Models/` (or inline response classes for the account/security controllers).
+- GroupApp group-type behavior is configured through the three **defined types** above, not block settings — add/remove GroupTypeIds there rather than editing code.
+- Account/login flows depend on [org.secc.OAuth](../org.secc.OAuth/README.md) (active client check) and Rock's `SMSAuthentication`; person matching/creation defers to [org.secc.PersonMatch](../org.secc.PersonMatch/README.md).
+- Watch the hardcoded ids in `SermonController` and `GetGroups` when promoting between environments.

--- a/Plugins/org.secc.RoomScanner/README.md
+++ b/Plugins/org.secc.RoomScanner/README.md
@@ -1,0 +1,132 @@
+# org.secc.RoomScanner
+
+> A REST API (plus two admin blocks) that lets a kids' room-scanner app move children and volunteers in and out of check-in rooms with PIN-authorized overrides and two-volunteer safety rules.
+
+## Overview
+
+RoomScanner is the server side of Southeast's room-door scanning app for SE!Kids check-in. A
+scanner at a classroom door reads a check-in code, and the app calls these `api/org.secc/roomscanner/*`
+endpoints to look up the room roster, mark a child as entering or exiting, move a child to a
+different room (with a staff PIN override), and enforce ratio rules (e.g. a child can't enter until
+two volunteers are checked in, and a volunteer can't check out if it would drop a room with children
+below two volunteers). It also ships two Rock blocks — a small config block for two global-attribute
+settings, and a "Room Report" timeline visualization of where a child was during the day.
+
+## Project Info
+
+- **Project file:** `org.secc.RoomScanner.csproj`
+- **Root namespace:** `org.secc.RoomScanner`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup), via the PostBuildEvent `xcopy`
+- **Cross-plugin dependency:** [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md)
+
+## Project Layout
+
+```
+/Rest/Controllers/   RoomScannerController.Partial.cs — all api/org.secc/roomscanner/* endpoints
+/Models/             DTOs: Request, MultiRequest, Response, Template, Attendee, AttendanceEntry, AttendanceCodes
+/Utilities/          ValidationHelper (PIN/room/threshold checks), DataHelper (attendance mutation + person history)
+/org_secc/RoomScanner/  Two blocks (.ascx + .ascx.cs): Configuration, RoomReport
+```
+
+## Components
+
+### REST Endpoints
+
+All routes are `[Authenticate, Secured]`. Errors are logged via `ExceptionLogService` and returned
+as an empty/failure result rather than thrown.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `api/org.secc/roomscanner/test` | GET | Connectivity smoke test; returns `"TEST GOOD!"`. |
+| `api/org.secc/roomscanner/pin/{pinCode}` | GET | Validates a PIN (a `UserLogin` username) is in the configured override group. |
+| `api/org.secc/roomscanner/templates` | GET | Check-in templates (group types) whose name contains "kids". |
+| `api/org.secc/roomscanner/areas/{templateId}` | GET | Child group types (areas) under a template. |
+| `api/org.secc/roomscanner/groups/{groupTypeId}` | GET | Active groups of a group type. |
+| `api/org.secc/roomscanner/locations/{groupId}` | GET | Scheduled locations for a group. |
+| `api/org.secc/roomscanner/locationbyguid/{guid}` | GET | Resolve a location by Guid (name + campus). |
+| `api/org.secc/roomscanner/attendees/{locationId}` | GET | Today's attendees at a location (name, did-attend, checked-out). |
+| `api/org.secc/roomscanner/getroster/{locationId}` | GET | Full room roster for today (handles subrooms via parent location). |
+| `api/org.secc/roomscanner/GetAttendanceCode/{attendanceGuid}` | GET | The person's check-in code(s) for today. |
+| `api/org.secc/roomscanner/entry` | POST | Mark an attendee as entering a room; supports `Override` to move from another location, enforces the 2-volunteer rule and room thresholds. |
+| `api/org.secc/roomscanner/exit` | POST | Check an attendee out of a room; blocks volunteer checkout that would leave children under-staffed. |
+| `api/org.secc/roomscanner/insert` | POST | PIN-authorized direct insert of a person (volunteer) into a room's volunteer occurrence. |
+| `api/org.secc/roomscanner/movetowithparent` | POST | Flag people (pipe-delimited ids) as "with parent" and log history. |
+| `api/org.secc/roomscanner/returntoroom` | POST | Clear the "with parent" flag and log history. |
+
+POST bodies are `Request` (`AttendanceGuid`, `LocationId`, `Override`, `PIN`) or `MultiRequest`
+(`PersonIds`, pipe-delimited). Responses are the `Response` DTO (`Success`, `Message`, `Overridable`,
+`RequireConfirmation`, `PersonId`, `BirthdayText`).
+
+### Blocks
+
+Category in Rock: **SECC > Security**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| RoomScanner Configuration | Edits the `RoomScannerSettings` global attribute — `AllowedGroupId` (override-approval group) and `SubroomLocationType` (defined-value id). | Roomscanner Config Attribute Key (`TextField`, default `RoomScannerSettings`) |
+| RoomScanner RoomReport | Timeline (Google Charts) of a child's room entries/exits for a date, built from person History records (`CategoryId` 4) related to the page's `LocationId`. | (none; reads `LocationId` page param and a per-block date user preference) |
+
+### Models (DTOs)
+
+Plain serialization types returned by / posted to the controller — not EF entities.
+
+| Type | Role |
+|------|------|
+| `Request` / `MultiRequest` | POST bodies (single attendee vs. pipe-delimited person ids). |
+| `Response` | Standard result envelope for all mutating endpoints. |
+| `Template` | Lightweight `{ Id, Name, Description }` used for templates/areas/groups/locations dropdowns. |
+| `Attendee` / `AttendanceEntry` | Roster rows (the latter adds `IsVolunteer` / `WithParent` flags). |
+| `AttendanceCodes` | A person's name + today's check-in codes. |
+
+## Dependencies & Integrations
+
+- **Rock:** Rock REST (`ApiController`, `[Authenticate, Secured]`), `RockContext` and Rock services
+  (`AttendanceService`, `AttendanceOccurrenceService`, `GroupService`, `GroupTypeService`,
+  `LocationService`, `GroupLocationService`, `PersonService`, `PersonAliasService`,
+  `UserLoginService`, `GroupMemberService`, `AttributeValueService`, `HistoryService`), the attribute
+  framework, `GlobalAttributesCache`, cache types (`AttributeCache`, `CampusCache`, `CategoryCache`,
+  `EntityTypeCache`), and the Rock block/UI framework.
+- **Cross-plugin:** [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md) — uses its
+  `Cache` (`AttendanceCache`, `OccurrenceCache`) for live in-room state and the volunteer/with-parent
+  flags, and `Utilities.Constants` for the volunteer attribute Guid.
+- **Third-party:** Google Charts (Timeline) loaded client-side in the RoomReport block; Newtonsoft.Json (transitive).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (low):** The "PIN" for overrides/inserts is a person's `UserLogin` **username**
+  (`UserLoginService.GetByUserName`), gated on membership in the configured `AllowedGroupId` group.
+  It is not a password and is matched as a plain username, so its security rests entirely on that
+  group's membership being tightly controlled. Worth confirming `AllowedGroupId` is locked to
+  trusted staff and that usernames in scope aren't easily guessable.
+- **Improvement:** `ValidationHelper` reads `RoomScannerSettings` into **static fields initialized
+  once at type load** (`settings`, `allowedGroupId`, `subroomLocationTypeId`). Changing those global
+  attributes via the Configuration block won't take effect until the app domain recycles. Same
+  pattern in `DataHelper` static ids. Consider reading the settings per request.
+- **Improvement:** `GetAttendeeAttendance` (`ValidationHelper`) has a likely bug in its
+  username-fallback branch — the predicate references `attendeeAttendance.StartDateTime` (the
+  local being assigned, still null) instead of the row `a.StartDateTime`, so that lambda would throw
+  / never match as intended. Worth reviewing; in practice callers pass an `AttendanceGuid`.
+- **Improvement:** `CategoryCache.Get( 4 )` and `CategoryId == 4` are **hard-coded integer ids** for
+  the person-history category (in `DataHelper` and `RoomReport`). A Guid lookup would survive a
+  reseed/import. There are also **OAuth copy-paste leftovers** in the **Configuration** block — its
+  XML summary (`/// OAuth configuration`), `[Description( "Configuration settings for OAuth." )]`, and
+  the auto-created attribute's description (`"Settings for the OAuth server plugin."`) all still
+  reference OAuth. (`RoomReport` only carries the stray `/// OAuth configuration` XML comment; its
+  `[Category]`/`[Description]` are correct.)
+- **Improvement:** Nearly every endpoint and helper constructs a fresh `RockContext` (several methods
+  new up a second context mid-call, e.g. `Entry`'s override branch and `DataHelper.CloneAttendance`).
+  Acceptable per-request, but mutations split across contexts can make the save boundary hard to reason about.
+
+## Making Changes
+
+- To add or change an endpoint, edit `Rest/Controllers/RoomScannerController.Partial.cs`; keep the
+  ratio/threshold and subroom logic in `Utilities/ValidationHelper.cs` and the attendance-mutation +
+  person-history writes in `Utilities/DataHelper.cs`.
+- The override group and subroom location type are data in the `RoomScannerSettings` global
+  attribute, edited via the **RoomScanner Configuration** block (note the static-cache caveat above).
+- Live in-room counts, volunteer detection, and the "with parent" flag come from
+  [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md)'s `AttendanceCache` / `OccurrenceCache` —
+  changes to room state should go through that cache so the scanner and check-in stay consistent.

--- a/Plugins/org.secc.SafetyAndSecurity/README.md
+++ b/Plugins/org.secc.SafetyAndSecurity/README.md
@@ -1,0 +1,131 @@
+# org.secc.SafetyAndSecurity
+
+> Campus lock-down SMS alerting plus workflow actions for volunteer background-check applications, incident-report PDFs, and MinistrySafe training.
+
+## Overview
+
+SafetyAndSecurity bundles Southeast's safety/security tooling: two Rock UI blocks that let
+staff fire a campus lock-down SMS blast (and send follow-up / all-clear updates), a pair of
+EF-backed models that record those alerts, and a set of workflow actions that drive the
+volunteer-application background-check process — validating references, storing an encrypted SSN,
+filling and flattening confidential PDF forms (volunteer application, minor application, medical
+and digital incident reports, external church reference), and creating/updating users in the
+external MinistrySafe training API. Used by Safety & Security and volunteer-screening staff.
+
+## Project Info
+
+- **Project file:** `org.secc.SafetyAndSecurity.csproj`
+- **Root namespace:** `org.secc.SafetyAndSecurity`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` — the PostBuildEvent runs
+  `xcopy ...bin\Debug\org.secc.SafetyAndSecurity.* ...RockWeb\bin` (assembly only).
+  The block `.ascx`/`.ascx.cs` files under `org_secc/SafetyAndSecurity/` are **not** referenced
+  by this `.csproj` and are **not** copied by the build event; they live in the RockWeb source
+  tree (`RockWeb/Plugins/org_secc/SafetyAndSecurity/`) and are compiled there.
+
+## Project Layout
+
+```
+/Data/         SafetyAndSecurityContext (EF DbContext) + SafetyAndSecurityService base
+/Model/        AlertNotification / AlertMessage entities + their *Service classes
+/Migrations/   EF plugin migration (001_Init) that stands up the two alert tables
+/Workflows/    Workflow ActionComponents (PDF merges, validation, SSN, MinistrySafe)
+/org_secc/SafetyAndSecurity/   UI blocks (.ascx + .ascx.cs): CampusLockDown, CampusLockDownAlerts
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Safety And Security**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Campus Lock Down | Pick a campus, then send a lock-down SMS to a defined-value audience (staff only or staff + volunteers); supports a custom-message modal. | **LockdownTitle**, **LockdownAlert**, **DefinedType** (audience defined type), **From** (SMS from number) |
+| Campus Lock Down Active Alerts | Lists active alerts and their messages; lets staff send an update or an "All Clear" (which deactivates the alert). | **StandardAlert**, **Default Review DataView** |
+
+Audience selection keys off the configured **DefinedType**: each defined value carries `Campus`
+and `HasVolunteer` attributes, and the block matches the selected campus + volunteer flag to one
+defined value, whose `DataView` attribute resolves the recipient query.
+
+### Workflow Actions
+
+All under action category **SECC > Safety and Security** (`ActionComponent` exports).
+
+| Component (class) | Purpose | Key settings |
+|-------------------|---------|--------------|
+| Volunteer Application Merge (`VolunteerApplicationMerge`) | Fill + flatten the adult/minor confidential volunteer-application PDF from ~80 workflow attributes; saves as a background-check binary file. | Adult/Minor Application PDF (binary files), **IsMinorApplication** |
+| Minor Volunteer Application Merge (`MinorVolunteerApplicationMerge`) | Minor-specific volunteer-application PDF merge. | Minor Application PDF |
+| Medical Incident Report Merge (`MedicalIncidentReportMerge`) | Fill + flatten the medical incident report PDF. | Report PDF, **binaryFileType** |
+| Digital Incident Report Merge (`DigitalIncidentReportMerge`) | Fill + flatten the digital incident report PDF. | Report PDF, **binaryFileType** |
+| External Church Reference Merge (`ExternalChurchReferenceMerge`) | Fill + flatten the external-church reference PDF. | Reference PDF, **binaryFileType** |
+| Volunteer Application Validation (`VolunteerApplicationValidation`) | Per-step server-side validation (personal info, each reference, special circumstances, statement of faith); branches to a success/fail activity. | **Action Step**, **Error Messages**, Success/Fail Activity, **IsMinorApplication** |
+| Reference Validation (`ReferenceValidation`) | Validate one "Get References" entry (name/phone/email/address) and reject duplicates across references. | **Error Messages**, **IsMinorApplication**, **ReferenceCount**, **MaxReferenceLimit** |
+| Volunteer Application SSN (`VolunteerApplicationSSN`) | Validate the SSN (regex), store it encrypted on the person's `SSN` attribute, then mask the workflow's SSN fields. | Success Activity |
+| MinistrySafe Create (`MinistrySafeRequest`) | POST a person to the MinistrySafe API, then GET their `direct_login_url` back into a workflow attribute. | **Person**, **MinistrySafe URL**, **MinistrySafe Tags** |
+| MinistrySafe Update (`MinistrySafeUpdate`) | GET a MinistrySafe user's score / completion date into workflow attributes. | **Person**, **Score**, **Completion Date** |
+
+### Models
+
+EF entities stored in the Rock database (Rock `IRockEntity` / `ISecured`).
+
+| Model | Table | Notes |
+|-------|-------|-------|
+| `AlertNotification` | `_org_secc_SafetyAndSecurity_AlertNotification` | An alert: Title, IsActive, AudienceValue (DefinedValue), AlertNotificationTypeValue (DefinedValue), child AlertMessages. |
+| `AlertMessage` | `_org_secc_SafetyAndSecurity_AlertMessage` | A message belonging to an alert; `SendCommunication(fromGuid)` resolves the audience's `DataView` to recipients and sends a `RockSMSMessage`. |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, Rock workflow engine (`ActionComponent`), plugin migrations
+  (`Rock.Plugin`), defined types/values, DataViews, `Encryption`, `RockSMSMessage`
+  (Rock.Communication), binary-file services, the Rock block/UI framework, EF (`Rock.Data.DbContext`).
+- **Third-party:** iText7 (`itext.*`) for PDF form fill/flatten, RestSharp for the MinistrySafe
+  HTTP calls, Newtonsoft.Json. The `.csproj` also references `Rock.SignNow` / `SignNowSDK` /
+  `CSLibrary` (CudaSign), though no code in this project currently calls them.
+- **External APIs:** MinistrySafe (`MinistrySafeAPIURL` + `MinistrySafeAPIToken` Global Attributes).
+
+## Migrations
+
+Ships one EF plugin migration under `/Migrations/`:
+
+- `001_Init` (`MigrationNumber 1`, `1.10.2`) — creates `_org_secc_SafetyAndSecurity_AlertNotification`
+  and `_org_secc_SafetyAndSecurity_AlertMessage` with their FKs (DefinedValue, PersonAlias) and indexes.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** This plugin handles highly sensitive data — Social Security Numbers,
+  background-check applications, and medical/incident reports. `VolunteerApplicationSSN` and
+  `VolunteerApplicationValidation` decrypt SSN parts and re-store the SSN encrypted, which is good;
+  worth confirming the binary-file types the PDF merges write to (`5C701472-…`, `9510D232-…`,
+  `E68932AD-…`, `A72B7149-…`) are locked down so the rendered confidential PDFs aren't broadly readable.
+- **Security (low):** `CampusLockDown` hard-codes `int alertTypeId = 31480` (a DefinedValue Id) rather
+  than resolving by Guid. Ids are environment-specific, so this will break or mis-tag alerts on any
+  database where that value Id differs (e.g. a restored/rebuilt environment). Worth switching to a
+  Guid-based lookup or a block setting.
+- **Improvement:** The MinistrySafe API token is read from a Global Attribute and sent as
+  `Authorization: Token token=…`. Confirm `MinistrySafeAPIToken` is stored as an encrypted/field-type
+  global attribute and not broadly readable.
+- **Improvement:** `MinistrySafeRequest` declares the **same `MinistrySafe URL` `WorkflowAttribute`
+  twice** (duplicate attribute decoration). Harmless but should be deduped.
+- **Improvement:** Several actions `new RockContext()` internally instead of using the passed-in
+  `rockContext` (e.g. `MinistrySafe*` person-alias lookups, `ReferenceValidation` location lookup),
+  which can split work across contexts. `AlertMessage.GetRecipients` also spins up its own context.
+- **Improvement:** `AssemblyInfo.cs` still carries the scaffolded `AssemblyCompany("Microsoft")` /
+  `Copyright © Microsoft 2016` despite the Southeast copyright header — worth correcting.
+
+## Making Changes
+
+- To change lock-down behavior or who receives an alert, edit
+  `org_secc/SafetyAndSecurity/CampusLockDown.ascx.cs` (audience matching lives in `GetAudience`,
+  send logic in `CreateAlert` → `AlertMessage.SendCommunication`); update/all-clear logic is in
+  `CampusLockDownAlerts.ascx.cs`.
+- To add or adjust a workflow action, drop/edit an `ActionComponent` under `/Workflows/`, decorate it
+  with `[ActionCategory]` / `[ExportMetadata("ComponentName", …)]` and its `[WorkflowAttribute]` config,
+  and follow a sibling as a template. PDF field mapping for the volunteer app lives in
+  `VolunteerApplicationMerge.BuildFieldDictionary` (PDF form field name → workflow attribute).
+- New supporting data or schema belongs in a new numbered migration under `/Migrations/` — don't
+  hand-edit `001_Init` once it has run.
+- Related: workflow-engine helpers and other custom actions live in
+  [org.secc.Workflow](../org.secc.Workflow/README.md).

--- a/Plugins/org.secc.Sass/README.md
+++ b/Plugins/org.secc.Sass/README.md
@@ -1,0 +1,98 @@
+# org.secc.Sass
+
+> Adds SCSS/SASS compilation to Rock themes — Rock natively compiles only LESS, so this plugin compiles each theme's `Styles/*.scss` to CSS on startup and from the CMS theme blocks.
+
+## Overview
+
+Rock's built-in theme pipeline compiles LESS (via `dotless`). This plugin extends `RockTheme`
+with a `CompileSass()` method (using the `SharpScss`/LibSass native library) and runs it at
+application startup against every theme, so SCSS authored under a theme's `Styles/` folder is
+turned into CSS. It also ships drop-in replacements for three Rock CMS blocks (Site Detail,
+Theme List, Include Admin CSS) so that compiling a theme from the admin UI runs **both** the
+LESS and the new SCSS compile. It is used by Southeast's web team to author themes in SCSS.
+
+## Project Info
+
+- **Project file:** `org.secc.Sass.csproj`
+- **Root namespace:** `org.secc.Sass`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (`org.secc.Sass.dll` + `.pdb` and `SharpScss.*`),
+  `RockWeb/LibSass/` (the `SharpScss.1.3.8/runtimes` native LibSass binaries), and
+  `RockWeb/Plugins/org_secc/` (the entire `org_secc` tree — the three block `.ascx` +
+  `.ascx.cs` files) — all via the `PostBuildEvent` `xcopy` steps.
+
+## Project Layout
+
+```
+Startup.cs            IRockStartup hook — compiles SASS for every theme on app start
+ThemeExtensions.cs    RockTheme.CompileSass() extension (SharpScss/LibSass wrapper)
+/org_secc/Sass/       Overridden Rock CMS blocks (.ascx + .ascx.cs):
+                        SiteDetail, ThemeList, AdminCss
+```
+
+## Components
+
+### Startup hook
+
+| Class | Type | Purpose |
+|-------|------|---------|
+| `Startup` | `IRockStartup` (`StartupOrder` 0) | On app start, loops `RockTheme.GetThemes()` and calls `CompileSass()` on each. |
+
+### Extension method
+
+| Method | Purpose |
+|--------|---------|
+| `ThemeExtensions.CompileSass(this RockTheme, out string messages)` | Recursively collects `.scss` files under the theme's `Styles/` folder, skips partials (names starting with `_`), and writes a sibling `.css` for each top-level `.scss` via `Scss.ConvertToCss`. Honors `theme.AllowsCompile`. Selects the `win-x64` / `win-x86` native LibSass directory via `SetDllDirectory` based on process bitness. |
+
+### Blocks
+
+These are forks of the corresponding stock Rock CMS blocks, modified so theme compilation also
+runs the SASS compile. They live in namespace `RockWeb.Plugins.org_secc.Sass`.
+
+| Block | Category | Purpose | Key settings |
+|-------|----------|---------|--------------|
+| Theme List | SECC > CMS | Lists themes; clone / compile / delete. Compile runs `theme.Compile()` (LESS) **and** `theme.CompileSass()`. | Theme Styler Page (`LinkedPage`) |
+| Site Detail | CMS | Stock site editor with a "Compile Theme" button that runs both LESS and SASS compiles for the site's theme. | Default File Type (`BinaryFileTypeField`, key `DefaultFileType`) |
+| Include Admin CSS | SECC > CMS | Adds `~~/Styles/theme.css` only when `PageCache.IncludeAdminFooter` is set **and** the user can administrate the page or administrate/edit any block on it (so admin styling loads only when needed). | (none) |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockTheme` (extended), `IRockStartup`, the Rock block/UI framework (`RockBlock`),
+  `SiteService` / `PageService` / `LayoutService` / `AttributeService` and the attribute /
+  authorization framework (used by the forked Site Detail block).
+- **Third-party:** `SharpScss` 1.3.8 (LibSass binding) with native `LibSass` runtimes — the
+  only NuGet package in `packages.config`. The `.csproj` also carries an explicit assembly
+  reference to `dotless.Core` (Rock's LESS compiler) from `RockWeb\Bin`; note the LESS pass
+  itself runs through Rock's own `RockTheme.Compile()`, not a direct call into dotless from
+  this plugin. `Newtonsoft.Json` (used for Site Detail view-state) comes transitively via the
+  Rock project reference, not as a direct package reference here.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** `CompileSass` returns `true` in the happy path even when nothing matched
+  (no `Styles/` dir, no files, or `AllowsCompile` false), and only returns `false` on an
+  exception. The single `out messages` is also overwritten by each successive compile call in
+  the blocks (`Compile` then `CompileSass` both write the same variable), so a LESS error
+  message can be lost once the SASS pass succeeds. Worth confirming the surfaced message
+  reflects the failing step.
+- **Improvement:** `Startup.OnStartup` ignores the `themeSuccess` / `themeMessage` results of
+  every per-theme `CompileSass` call, so a theme that fails to compile at boot does so silently
+  with no log entry. Consider logging failures.
+- **Improvement:** The forked Site Detail / Theme List / Include Admin CSS blocks are copies of
+  stock Rock blocks with small edits. On a Rock upgrade these will not pick up upstream changes
+  and can drift from the core blocks — worth re-diffing against the current Rock versions
+  periodically.
+
+## Making Changes
+
+- To change how SCSS is discovered or compiled (partials handling, output path, source maps),
+  edit `ThemeExtensions.CompileSass` — it is the single point that wraps `SharpScss`.
+- To change when compilation runs at boot, edit `Startup.OnStartup`; the admin-triggered
+  compiles live in `gCompileTheme_Click` (`ThemeList.ascx.cs`) and `btnCompileTheme_Click`
+  (`SiteDetail.ascx.cs`), each of which calls both `theme.Compile()` and `theme.CompileSass()`.
+- If a Rock upgrade changes the stock Site Detail / Theme List / Admin CSS blocks, re-apply the
+  SASS-compile edits to the forked `.ascx.cs` files under `org_secc/Sass/`.
+- New compiled files must end in `.scss` and live under a theme's `Styles/` folder; prefix
+  shared partials with `_` to keep them from being compiled to standalone CSS.

--- a/Plugins/org.secc.Search/README.md
+++ b/Plugins/org.secc.Search/README.md
@@ -1,0 +1,93 @@
+# org.secc.Search
+
+> Adds custom Rock person-search components (address, DOB, envelope) plus admin blocks for person, bulk, and Apple Pass lookups.
+
+## Overview
+
+Search supplies Southeast's custom person-search extensions. The compiled assembly contributes
+three Rock `SearchComponent`s — search people by home/previous **address**, **date of birth**, or
+**giving envelope number** — that appear in Rock's universal search alongside the built-in ones. The
+plugin also ships several RockWeb admin blocks (a richer person-results grid, a bulk email/phone
+lookup, and an Apple-Pass generator/test pair) under `org_secc/Crm/`. Staff use these to find people
+during data work and to issue event passes.
+
+## Project Info
+
+- **Project file:** `org.secc.Search.csproj`
+- **Root namespace:** `org.secc.Search`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup, via the PostBuildEvent `xcopy`)
+- **Note:** Only the three `Person/*.cs` search components are in the `.csproj` `<Compile>` list. The
+  `org_secc/Crm/*.ascx.cs` blocks are **RockWeb-compiled** (compiled in place by RockWeb, not into this assembly).
+
+## Project Layout
+
+```
+/Person/        SearchComponent exports — Address, DOB, Envelope (compiled into the assembly)
+/org_secc/Crm/  RockWeb blocks (.ascx + .ascx.cs) — PersonSearch, BulkSearch, GenerateApplePass, ApplePassTest
+```
+
+## Components
+
+### Search Components
+
+MEF exports of Rock's `SearchComponent`, discovered at startup. Each appears in Rock's universal
+search as a search type; `Search(searchterm)` returns a list of matching display strings.
+
+| Component (ComponentName) | Search Label | Matches on |
+|---------------------------|--------------|------------|
+| `SECC Person Address` (`Address`) | Address | Family home/previous `GroupLocation` where Street1 or PostalCode contains the term; returns `Street1 - PostalCode`. |
+| `SECC Person DOB` (`DOB`) | DOB | Distinct birth dates whose short/long string form contains the term (case-insensitive); falls back to a full long-date (`"D"`) match. |
+| `SECC Person Envelope` (`Envelope`) | Envelope | Exact match of the person `GivingEnvelopeNumber` attribute value. |
+
+### Blocks
+
+RockWeb blocks under `org_secc/Crm/`. Categories below are taken from each block's `[Category]` attribute.
+
+| Block | Category | Purpose | Key settings |
+|-------|----------|---------|--------------|
+| Person Search (`PersonSearch`) | SECC > CRM | Results grid for a `SearchType` + `SearchTerm` (name, phone, address, email, envelope, dob) passed as page parameters; redirects to the person if a single match. | Person Detail Page (linked page), Show Performance (bool) |
+| Bulk Search (`BulkSearch`) | SECC > Search | Paste a newline-delimited list of emails and/or phone numbers into a grid of matching people. | (none) |
+| My Account - Generate Apple Pass (`GenerateApplePass`) | SECC > CRM | Headless block (hidden field + hidden button, no person picker): a client-side `GeneratePass(personAliasGuid)` script stuffs the alias guid into `hfPassInfo` and clicks the hidden button; the block then returns the person's existing pass file, or runs the configured pass workflow if the person's pass attribute is empty, and redirects to `GetFile.ashx`. | Pass Template Id (`PassTemplateId`, int, optional), Apple Pass Workflow (`ApplePassWorkflow`, workflow type, required), Event Pass Person Attribute (`EventPassAttribute`, person attribute, required) |
+| Apple Pass Test (`ApplePassTest`) | SECC > CRM | Test harness: pick a person, then it emits the `GeneratePass("<primaryAliasGuid>")` startup script (the same hook the `GenerateApplePass` block listens for). Has no `[Description]` attribute. | (none) |
+
+## Dependencies & Integrations
+
+- **Rock:** universal search (`SearchComponent`), `RockContext` and Rock services (`PersonService`,
+  `GroupMemberService`, `PhoneNumberService`, `AttributeService`/`AttributeValueService`,
+  `PersonAliasService`, `WorkflowService`), the Rock block/UI framework, workflow engine (Apple Pass),
+  defined-value/cache helpers, EntityFramework 6.1.3.
+- **Third-party:** none.
+- The Apple-Pass blocks delegate file generation to a configured Rock **workflow type** (the block
+  reads the resulting `PassFile` attribute), so the actual pass-building logic lives in that workflow,
+  not in this plugin.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** The `DOB` search component and the `PersonSearch` `dob` branch pull **all** birth
+  dates into memory (`Distinct().AsEnumerable()`) and format/compare each string client-side. On a
+  large person table this is an unindexed full scan per search — review for performance. The same
+  logic is duplicated between `Person/DOB.cs` and `PersonSearch.ascx.cs`.
+- **Improvement:** `BulkSearch` lives in folder `org_secc/Crm/` but declares namespace
+  `RockWeb.Plugins.org_secc.Search` and category `SECC > Search`, while its siblings use
+  `RockWeb.Plugins.org_secc.Crm` / `SECC > CRM`. Its `[Description]` is also placeholder text
+  ("Takes the ten two csv..."). Worth tidying so the block path/namespace/category line up.
+- **Security (low):** These search/results blocks surface person PII (addresses, DOB, email, envelope
+  numbers). Confirm the Rock **page/block security** on the pages hosting them is limited to staff who
+  should see it; envelope search in particular ties a person to giving data.
+- **Improvement:** `Properties/AssemblyInfo.cs` still carries a scaffolded `AssemblyCopyright`
+  (`"Copyright ©  2016"`) with empty company/description rather than Southeast Christian Church.
+
+## Making Changes
+
+- To add a new search type, drop a `SearchComponent` subclass in `Person/`, decorate it with
+  `[Export(typeof(SearchComponent))]` + `[ExportMetadata("ComponentName", "…")]` and a `SearchLabel`
+  default, implement `Search(string)`, and add it to the `.csproj` `<Compile>` list. MEF discovers it
+  at startup — no further registration needed. Follow `Person/Envelope.cs` as the simplest template.
+- The results grid and its per-type query logic live in `org_secc/Crm/PersonSearch.ascx.cs`
+  (`BindGrid` switch). Keep its branches in sync with the standalone search components if behavior
+  should match.
+- Apple-Pass generation is driven by the workflow configured on the `GenerateApplePass` block, not by
+  code here — change the pass output by editing that workflow type.

--- a/Plugins/org.secc.Security/README.md
+++ b/Plugins/org.secc.Security/README.md
@@ -1,0 +1,209 @@
+# org.secc.Security
+
+> A grab-bag of SECC security/identity Rock **blocks** — Wi-Fi captive portals, SAML/SSO redirects to third-party services (WellRight, Church Online), PIN management, and self-service account blocks — plus a small reusable SAML 2.0 assertion library.
+
+> **Doc tier: deep.** This plugin brokers credentials and identity to external systems (it builds and signs SAML assertions, derives SSO tokens, and stands up public Wi-Fi onboarding pages), so it's documented at the deeper technical tier — the SSO/redirect flow, per-block config attributes, and the security-sensitive edges. Most SECC plugins use the lighter standard tier.
+
+## Overview
+
+This is Southeast's catch-all **security and identity** plugin. Most of it is RockWeb-compiled blocks (`.ascx` + code-behind) under `org_secc/Security/`, grouped loosely into three jobs: (1) **Wi-Fi captive portals** that register a guest/staff device and bounce the browser back to the FrontPorch controller; (2) **outbound SSO redirects** that log a Rock user into an external service by POSTing a signed SAML assertion (WellRight) or a signed SSO token (Church Online / Tymio-style MultiPass); and (3) **self-service account blocks** (view/edit profile, login-status menu, PIN management). The only csproj-compiled code is a tiny **SAML 2.0** helper library (`SAML2/`) consumed by the WellRight block.
+
+## Project Info
+
+- **Project file:** `org.secc.Security.csproj` — compiles **only** the `SAML2/` library (`CertificateUtility`, `SAML20Assertion`, `SAMLSchema`). The blocks under `org_secc/` are RockWeb-compiled (`.ascx`/`.ascx.cs`), not in the csproj.
+- **Root namespace:** `org.secc.Security` (library) / `RockWeb.Plugins.org_secc.Security` (blocks)
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (the `org.secc.Security.dll` SAML library), `RockWeb/Plugins/org_secc/` (block markup + code-behind), and `RockWeb/Themes/` (the `my-secc` theme) — all via the PostBuildEvent xcopy.
+- **Cross-plugin dependency:** [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) (used by the Captive Portal block).
+
+## Project Layout
+
+```
+/                       org.secc.Security.csproj (compiles SAML2/ only)
+/SAML2/                 SAML 2.0 assertion library: SAML20Assertion (build+sign Response),
+                        CertificateUtility (X509 XML signing), SAMLSchema (xsd-generated OASIS types)
+/org_secc/Security/     RockWeb blocks (.ascx + .ascx.cs) — the bulk of the plugin (see Components)
+/Themes/my-secc/        A full Rock theme (Layouts, Styles/less, Lava asset partials, logo)
+```
+
+There is **no `/Migrations` folder** — this plugin ships no plugin migrations; blocks are placed on pages through Rock admin.
+
+## How Outbound SSO Works
+
+Two blocks log an already-authenticated Rock user into an external service. They differ in the token format but share the same shape: read `CurrentPerson`, build a payload, sign it with a configured secret/cert, and POST/redirect the browser to the external endpoint. Both special-case administrators (show a debug screen instead of redirecting, so an admin can inspect the payload).
+
+```mermaid
+flowchart TD
+    A[User hits SSO redirect block<br/>WellrightRedirect / ChurchOnlineRedirect] --> B{CurrentPerson set?}
+    B -->|no| Z[No-op / empty response]
+    B -->|yes| C[Build payload from person<br/>name, email, DOB, gender]
+    C --> D{Which block?}
+    D -->|WellRight| E[SAML20Assertion.CreateSAML20Response<br/>sign with X509 cert from Binary File]
+    D -->|Church Online| F[AES-256-CBC encrypt MultiPass JSON<br/>+ HMAC-SHA1 signature with SSO key]
+    E --> G{Admin + ShowDebug?}
+    F --> G
+    G -->|yes| H[Render debug: show payload / target URL,<br/>do NOT redirect]
+    G -->|no| I[Auto-POST SAML form / Response.Redirect<br/>to external service]
+```
+
+**Conventions / contracts:**
+- **Admin escape hatch.** Every redirect/captive-portal block checks `IsUserAuthorized(ADMINISTRATE)` (or `UserCanAdministrate`) and, instead of redirecting, shows the would-be target URL/payload. This is intentional so staff can configure/debug without being bounced out. WellRight additionally gates the debug screen on a `ShowDebug` block setting and a `Continue` page param.
+- **SAML assertions are signed, enveloped, RSA-SHA256.** `SAML20Assertion.CreateSAML20Response` builds an OASIS `ResponseType`/`AssertionType`, and `CertificateUtility.AppendSignatureToXMLDocument` signs the assertion (enveloped + ExcC14N transforms) using the X509 cert's private key, returning a Base64 `SAMLResponse` auto-POSTed via a self-submitting `<form>`.
+- **Church Online uses MultiPass-style SSO:** AES-256-CBC encrypt (`RijndaelManaged`, PKCS7) the JSON profile prefixed with a fixed init vector `"OpenSSL for Ruby"`, key = SHA-256 of the SSO key; then HMAC-SHA1 the ciphertext with the raw SSO key; redirect to `…/sso?sso=<cipher>&signature=<hmac>`.
+- **Captive portals** validate the MAC-address query param against a regex, create/refresh a Rock `PersonalDevice` (platform/OS parsed from the UA via `UAParser`), link it to a `PersonAlias`, and redirect to the configured release/FrontPorch URL carrying the alias id + original query string.
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Security** (the Captive Portal block uses the plain **Security** category).
+
+| Block | Purpose |
+|-------|---------|
+| Captive Portal | Public Wi-Fi onboarding: registers a `PersonalDevice` by MAC, matches/creates a person, redirects to the release URL. |
+| Staff Captive Portal | Staff Wi-Fi variant that computes a SHA-256 hash and forwards to the SECC FrontPorch cloud endpoint, optionally only on/off a given network (CIDR). |
+| Account Detail | Public block for a user to view their own account info (name, email, optional home address). |
+| Account Edit | Public block for a user to edit their account info; optional/required address. |
+| User Login Status | Login/logout menu + links to My Account / My Profile / My Settings pages. |
+| PIN Manager | Person-context block to add/edit/remove PIN logins (`PINAuthentication`), tagged by a "purpose" defined type. |
+| ChurchOnline SSO Redirect | Logs the user into Church Online via an encrypted+signed MultiPass token; also posts a check-in `Attendance` record. |
+| Wellright Redirect | Logs the user into WellRight by POSTing a signed SAML 2.0 assertion. |
+| SignNow Test | Developer/test harness that pushes a hardcoded Binary File to SignNow and resolves an invite link. Not a production block (see Observations). |
+
+#### Captive Portal  *(Security)*
+Keys in **bold** are the block attribute keys.
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **MacAddressParam** | text (default `client_mac`) | Query-string param holding the device MAC; validated against a MAC regex. |
+| **ReleaseLink** | text (required) | Absolute http/https URL the browser is redirected to after registration. |
+| **ShowName** / **ShowMobilePhone** / **RequireMobilePhone** / **ShowEmail** / **ShowDOB** | bool | Field visibility; visible name/email/DOB fields are also required. |
+| **ShowAccept** / **AcceptanceLabel** | bool / text | "I Accept" checkbox + label (pair with the legal note). |
+| **ButtonText** | text (default `Accept and Connect`) | Connect-button caption. |
+| **ShowLegalNote** / **LegalNote** | bool / HTML (Lava) | Terms & Conditions rendered into an iframe `srcdoc`; ships a long default T&C. |
+| Connection Status | defined value | Connection status for newly created people (default Visitor). |
+
+If no input fields are visible the block "direct-connects" (immediate redirect). Person resolution calls `personService.GetByMatch(...)` — the `GetByMatch` extension method from [org.secc.PersonMatch](../org.secc.PersonMatch/README.md), not a built-in Rock method — before creating a new record.
+
+#### Staff Captive Portal  *(SECC > Security)*
+| Setting | Type | Notes |
+|---------|------|-------|
+| **SECCSecure** | encrypted text (password) | Key used to compute the SHA-256 hash sent to FrontPorch. |
+| **MacAddressParam** | text (default `client_mac`) | MAC query param. |
+| **NetworkSSID** | text | SSID of the network being connected to. |
+| **SeccFPUrl** | text | SECC FrontPorch captive-portal endpoint. |
+| **Redirect When** | dropdown | `Always` / `When On Provided Network` / `When NOT On Provided Network`. |
+| **Network** | text | CIDR (e.g. `192.168.0.0/24`) compared against the client IP for the redirect condition. |
+| **TestingEnabled** | bool | Use the test network. |
+
+Reads the `FrontporchAPIToken` / `FrontporchHost` global attributes for the API call.
+
+#### Wellright Redirect  *(SECC > Security)*
+| Setting | Type | Notes |
+|---------|------|-------|
+| **RequestUrl** | text | `Recipient`/request URL put in the SAML assertion. |
+| **PostUrl** | text | Where the signed `SAMLResponse` form auto-POSTs. |
+| **CertificateFile** | file (Binary File) | PFX certificate used to sign the assertion. |
+| **CertificatePassword** | text | PFX password (stored as a plain block setting — see Observations). |
+| **DaysValid** | integer (default 30) | Assertion lifetime (converted to minutes). |
+| **ShowDebug** | bool (default false) | Show admins the formatted XML before forwarding. |
+
+Sends `FirstName, LastName, DateOfBirth, Gender, Email` as SAML attributes; `BirthDate.Value` is dereferenced unconditionally (see Edge Cases).
+
+#### ChurchOnline SSO Redirect  *(SECC > Security)*
+| Setting | Type | Notes |
+|---------|------|-------|
+| **RedirectURL** | url (required) | Church Online base URL; SSO appended as `/sso?sso=…&signature=…`. |
+| **CheckInGroup** | group-type-group | Group online guests are checked into (requires "Show in Group Lists"). |
+| **OnlineCampusLocation** | campus | Campus for the check-in attendance record. |
+| **OnlineCampusSchedules** | schedules | Schedules Church Online is available; only an active/check-in-enabled one is used. |
+| **SSOKey** | text (password) | Church Online SSO key; SHA-256'd for the AES key and used raw for the HMAC. |
+
+On load it posts an `Attendance` record (if group+campus+active schedule resolve) and then performs the SSO redirect.
+
+#### PIN Manager  *(SECC > Security)*
+| Setting | Type | Notes |
+|---------|------|-------|
+| **PurposeDefinedType** | defined type | Source of the PIN "purpose" checkbox list (stored on the `PINPurpose` UserLogin attribute). |
+| **MinimumPINLength** | integer (default 6) | Minimum PIN digit count enforced on save. |
+
+A `PersonBlock`; add/edit/delete are gated on `PINAuthentication` entity-type `ADMINISTRATE` authorization, and the code guards against editing a non-PIN `UserLogin`.
+
+#### Account Detail / Account Edit  *(SECC > Security)*
+Both `RockBlock`s with a **Detail Page** (`LinkedPage`, Detail only), a **Show (Home) Address** toggle, a **Location Type** (`GroupLocationTypeField`, family), and (Edit) an **Address Required** toggle.
+
+#### User Login Status  *(SECC > Security)*
+**MyAccountPage**, **MyProfilePage**, **MySettingsPage** linked pages. The menu renders only two items — **My Account** and **My Profile** — each hidden when its page attribute is blank (a blank **My Account Page** falls back to the `MyAccount` page route). **MySettingsPage** is declared as a block attribute but is currently unused: there is no "My Settings" menu item in the markup or code-behind. Logout also fires a `UpdateUserLastActivity` task and signs out via `FormsAuthentication`.
+
+### SAML 2.0 Library (`SAML2/`)
+
+| Type | Purpose |
+|------|---------|
+| `SAML20Assertion` | Static `CreateSAML20Response(issuer, expirationMinutes, audience, subject, recipient, attributes, cert)` → Base64 signed SAML `Response`. Builds Response/Assertion/Subject/Conditions/AuthnStatement/AttributeStatement, serializes, and signs. |
+| `CertificateUtility` | `AppendSignatureToXMLDocument(...)` — enveloped RSA-SHA256 XML signature over the `<Assertion>` using the cert's exported private key via a PROV_RSA_AES CSP. |
+| `SAMLSchema` | `xsd.exe`-generated OASIS SAML 2.0 / XML-DSig types (`ResponseType`, `AssertionType`, etc.). |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockBlock` / `PersonBlock`, `RockContext`, `PersonService` / `PersonalDeviceService` / `UserLoginService` / `AttendanceService`, `RockPage.LinkPersonAliasToDevice`, `Rock.Security.Authorization`, `DefinedValueCache` / `DefinedTypeCache`, `GlobalAttributesCache`, `Rock.SignNow` (`SignNow`, `SignNowSDK`), block-attribute framework, Lava merge-field resolution.
+- **Third-party:** `System.Security.Cryptography.Xml` (SAML signing), `UAParser` (device/OS parsing in captive portals), `Newtonsoft.Json` (MultiPass + SignNow), external services **WellRight**, **Church Online**, **SignNow**, and the SECC **FrontPorch** captive-portal cloud.
+- **Cross-plugin:** [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) — imported by the Captive Portal block.
+
+## Edge Cases & Constraints
+
+- **WellRight requires a birthdate.** `GetResponse()` calls `CurrentPerson.BirthDate.Value.ToString("o")` with no null check — a logged-in person without a DOB throws. Confirm the WellRight audience always has DOB, or guard it.
+- **Captive Portal `CreateRedirectUrl` appends `Request.QueryString` verbatim** onto the release link. The release link itself is validated as an absolute http/https URL, but the trailing query string is the raw inbound one.
+- **Admin users never actually SSO.** WellRight, Church Online and the Captive Portal all short-circuit for `ADMINISTRATE` users into a debug message rather than redirecting — testing SSO end-to-end requires a non-admin account (or, for WellRight, `?Continue=true`).
+- **Church Online MultiPass tokens are short-lived** (`Expires = now + 5 minutes`, UTC) and the init vector is the fixed string `"OpenSSL for Ruby"` — a MultiPass/Tymio convention, not a per-request IV.
+- **PIN Manager parses PINs as numbers.** A PIN is converted via `AsDouble()`; a PIN of `0` (or non-numeric) is rejected, and uniqueness is checked against existing usernames before save.
+
+## Observations
+
+*Noticed while documenting — not a full audit; the SSO/redirect blocks and the test block stood out.*
+
+- **Security (review):** `WellrightRedirect.CertificatePassword` is a plain `TextField` block setting (the PFX itself is a Binary File). Anyone who can administer the block can read the signing-cert password, and it isn't an `EncryptedTextField` like Staff Captive Portal's `SECCSecure`. Worth confirming block security is locked to trusted staff and considering an encrypted attribute.
+- **Security (review):** Church Online's SSO scheme uses a **fixed IV** (`"OpenSSL for Ruby"`) and HMAC-**SHA1**. Both are dictated by the Church Online/MultiPass spec, so they likely can't change unilaterally, but they're weak primitives worth noting if the integration is ever revisited. The `SSOKey` is a non-encrypted password `TextField`.
+- **Security (low):** `SignNowTest` is a "Test for sign now" block with a **hardcoded document Guid** (`5bb17a5b-…`) that creates a SignNow document/invite for `CurrentPerson` on every page load, writes a temp PDF to disk, and has no auth gating beyond page security. It looks like dev scaffolding; confirm it isn't deployed on a reachable production page.
+- **Security (low):** `CertificateUtility` exports the signing cert's private key to an XML string (`PrivateKey.ToXmlString(true)`) and re-imports it into a CSP on every sign. Functional, but the private key transits managed memory in the clear; fine for an internal signing path, noted for awareness.
+- **Improvement:** Several blocks `new RockContext()` repeatedly within a single request (e.g. Captive Portal creates a fresh context in `DoesPersonalDeviceExist`, `CreateDevice`, `VerifyDeviceInfo`, `Prefill`). Minor, but consolidating to one context per request would be cleaner.
+- **Improvement:** The compiled assembly contains only the SAML2 library; everything else is RockWeb-compiled. A maintainer touching a block won't see it in the csproj — note that when adding files.
+
+## Extending
+
+To add another outbound-SSO block, follow `WellrightRedirect` and reuse the SAML library (or `ChurchOnlineRedirect` for a token scheme). Minimal SAML skeleton:
+
+```csharp
+[DisplayName( "My SSO Redirect" )]
+[Category( "SECC > Security" )]
+[FileField( Rock.SystemGuid.BinaryFiletype.DEFAULT, "Certificate", "Signing PFX.", key: "CertificateFile" )]
+[TextField( "Certificate Password", Key = "CertificatePassword" )]
+[TextField( "Post Url", Key = "PostUrl" )]
+public partial class MySsoRedirect : Rock.Web.UI.RockBlock
+{
+    protected override void OnLoad( EventArgs e )
+    {
+        base.OnLoad( e );
+        if ( IsPostBack || CurrentPerson == null ) return;
+
+        var cert = LoadCertFromBinaryFile( GetAttributeValue( "CertificateFile" ).AsGuid(),
+                                           GetAttributeValue( "CertificatePassword" ) );
+        var attrs = new Dictionary<string, string> { { "Email", CurrentPerson.Email } };
+        var saml = org.secc.Security.SAML2.SAML20Assertion.CreateSAML20Response(
+            "Southeast Christian Church", 60, "MyAudience",
+            CurrentPerson.Email, GetAttributeValue( "PostUrl" ), attrs, cert );
+
+        if ( UserCanAdministrate ) { /* show debug, don't redirect */ return; }
+        // auto-POST a self-submitting <form> with the Base64 SAMLResponse
+    }
+}
+```
+
+There is no MEF/registration step — these are Rock blocks, placed on a page via Rock admin and configured through the block settings.
+
+## Making Changes
+
+- Block behavior lives in `org_secc/Security/<Block>.ascx.cs` (markup in the matching `.ascx`); these are RockWeb-compiled, not in the csproj.
+- SAML payload/signing changes go in `SAML2/SAML20Assertion.cs` / `CertificateUtility.cs` (the only csproj-compiled code, shipped as `org.secc.Security.dll`).
+- Captive-portal person matching delegates to the `GetByMatch` extension method in [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) (invoked on `PersonService`) — change matching there, not here.
+- The bundled `Themes/my-secc` theme (Layouts/Styles/Lava partials) is deployed by the same PostBuildEvent; theme edits live under `Themes/my-secc/`.
+- `SignNowTest` is test scaffolding — don't extend it for production; build a proper block instead.

--- a/Plugins/org.secc.ServiceReef/README.md
+++ b/Plugins/org.secc.ServiceReef/README.md
@@ -1,0 +1,136 @@
+# org.secc.ServiceReef
+
+> Scheduled jobs that pull mission-trip events, participants, and payments from the ServiceReef API into Rock as groups, people, and financial transactions.
+
+## Overview
+
+ServiceReef integrates Southeast's [ServiceReef](https://www.servicereef.com/) mission-trip
+platform with Rock. It ships two Quartz scheduled jobs: `ImportTrips` builds a year/trip group
+hierarchy and enrolls participants as group members (matching or creating the Rock person), and
+`ImportData` imports trip payments as `FinancialTransaction`s under per-trip financial sub-accounts.
+Both call the ServiceReef REST API using a custom HMAC authenticator. There is no UI — the jobs are
+configured entirely through Rock job attributes.
+
+## Project Info
+
+- **Project file:** `org.secc.ServiceReef.csproj`
+- **Root namespace:** `org.secc.ServiceReef`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `PayPal*` SDK DLLs, via the PostBuildEvent `xcopy`)
+- **Cross-plugin dependencies:** [org.secc.PayPalReporting](../org.secc.PayPalReporting/README.md),
+  [org.secc.PersonMatch](../org.secc.PersonMatch/README.md)
+
+## Project Layout
+
+```
+/ (root)        ImportTrips, ImportData (the two IJobs) + HMACAuthenticator
+/Contracts/     POCOs deserialized from the ServiceReef API (Events, Event, Participants,
+                Member, Payments, Address, PageInfo)
+/Migrations/    Rock plugin migrations (ServiceReef financial source + account-type defined values)
+```
+
+## Components
+
+### Jobs
+
+Both are Quartz `IJob`s decorated with `[DisallowConcurrentExecution]`; configuration is per-job via
+Rock job attributes (read from the `JobDataMap`). Each pages the ServiceReef API 100 records at a
+time and throws (failing the job) on a non-200 response or accumulated warnings.
+
+| Job (class) | Purpose | Key settings |
+|-------------|---------|--------------|
+| `ImportTrips` | Pull ServiceReef events into a Parent Group → "{Year} Mission Trips" → trip group hierarchy, set trip attributes from event categories, and add each participant as a `GroupMember`. | Service Reef API Key / Secret / URL, Parent Group, Year Group Type, Trip Group Type, Default Connection Status, ServiceReef UserId / Profile URL person attributes, Date Range |
+| `ImportData` | Pull ServiceReef payments into `FinancialTransaction`s under per-event financial sub-accounts of a parent Account. | PayPal API Username / Password / Signature, Service Reef API Key / Secret / URL, Date Range, Account, Financial Gateway, Transaction Source, Connection Status, ServiceReef Account Type |
+
+#### `ImportTrips` job attributes
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Service Reef API Key** / **Secret** | EncryptedText | HMAC credentials; decrypted at runtime. |
+| **Service Reef API URL** | Text | Base API URL (trailing `/` enforced). |
+| **Parent Group** | Group | Root group; year groups created as children, trips as grandchildren. |
+| **Year Group Type** / **Trip Group Type** | GroupType | Group types for the two created levels. |
+| **Default Connection Status** | DefinedValue (Person Connection Status) | Applied to newly created people. |
+| **ServiceReef UserId** / **ServiceReef Profile URL** | Attribute (Person) | Person attributes populated with the ServiceReef user id / profile URL; UserId attr is also used as a match key. |
+| **Date Range** | SlidingDateRange | Events to import (default `Previous 2 Day`). |
+
+#### `ImportData` job attributes
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **PayPal API Username** / **Password** / **Signature** | EncryptedText | PayPal API credentials (declared; transaction tender detail is read from the PayPalReporting table). |
+| **Service Reef API Key** / **Secret** / **URL** | EncryptedText / Text | ServiceReef HMAC credentials and base URL. |
+| **Account** | Account | Parent financial account; one sub-account is created per ServiceReef event. |
+| **Financial Gateway** | FinancialGateway | Gateway stamped on imported transactions. |
+| **Transaction Source** | DefinedValue (Financial Source Type) | Defaults to the `Service Reef` source value (migration 001). |
+| **Connection Status** | DefinedValue (Person Connection Status) | Applied to newly created people. |
+| **ServiceReef Account Type** | DefinedValue (Financial Account Type) | Account type for created sub-accounts; defaults to the `Service Reef` value (migration 002). |
+| **Date Range** | SlidingDateRange | Payments to import (default `Previous 2 Day`). |
+
+### Person matching
+
+Both jobs resolve a ServiceReef participant/payer to a Rock `Person` in tiered fashion: (1) look up
+the ServiceReef member's `ArenaId` against `PersonAlias.AliasPersonId`; (2) (`ImportTrips` only)
+match on the **ServiceReef UserId** person attribute; (3) fall back to `PersonService.GetByMatch`
+(via [org.secc.PersonMatch](../org.secc.PersonMatch/README.md)); (4) create a new person + home
+location if no match. When multiple matches are found, Member records are preferred over Attendee,
+then the lowest `Id`.
+
+## Dependencies & Integrations
+
+- **Rock:** Quartz job framework (`IJob`, `JobDataMap`), `RockContext` and Rock services
+  (Financial*, Person*, Group*, Attribute*, DefinedValue/Type, Location), attribute framework,
+  `Encryption`, plugin migrations (`Rock.Plugin`).
+- **Cross-plugin:** [org.secc.PayPalReporting](../org.secc.PayPalReporting/README.md) —
+  `ImportData` reads tender type from its `_org_secc_PaypalReporting_Transaction` table via
+  `TransactionService`; [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) — `GetByMatch`.
+- **Third-party:** ServiceReef REST API (`v1/events`, `v1/events/{id}`, `v1/events/{id}/participants`,
+  `v1/members/{id}`, `v1/payments`) over `RestSharp`, authenticated with a custom HMAC-SHA256
+  `IAuthenticator` (`HMACAuthenticator`, `amx` scheme). PayPal Core/Merchant SDKs are referenced;
+  Newtonsoft.Json (transitive).
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/`:
+
+- `001_CreateAttributes` — adds the `Service Reef` **Financial Source Type** defined value
+  (`MigrationNumber 1`).
+- `002_CreateAccountType` — adds the `Service Reef` **Financial Account Type** defined value
+  (`MigrationNumber 2`).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** Both migration files declare `namespace org.secc.PayPalReporting.Migrations`
+  rather than `org.secc.ServiceReef.Migrations` — almost certainly a copy/paste artifact from the
+  PayPalReporting plugin. Harmless at runtime but misleading; worth correcting.
+- **Improvement:** `ImportData` mis-assigns the tender type when the result `Type` is not
+  `"CreditCard"`: it sets `tran.TransactionTypeValueId` (transaction *type*) to a currency-type id
+  rather than `CurrencyTypeValueId`. The later code re-sets `TransactionTypeValueId` to the
+  contribution type, so the earlier write is effectively dead/wrong — worth confirming non-card
+  payments record the intended currency type.
+- **Improvement:** In `ImportTrips`, the no-email matching branch (`ImportTrips.cs:300`) calls
+  `matches.Remove( person )` inside `foreach ( Person match in matches )`, but `person` is still
+  `null` there — it almost certainly meant `matches.Remove( match )`. As written, `Remove( null )`
+  removes nothing, so non-address-matching candidates are never pruned and disambiguation falls
+  through to the member/attendee/lowest-`Id` tiebreak on the unfiltered list. Review that
+  address-disambiguation path.
+- **Improvement:** New-person creation dereferences `result.Address.*` (e.g. `ImportData` line ~306,
+  `ImportTrips` line ~395) without the null guard used a few lines earlier, so a participant/payer
+  with a null Address will throw a `NullReferenceException` for the create path.
+- **Security (low):** API keys/secrets and PayPal credentials are stored as `EncryptedTextField`
+  job attributes and decrypted at runtime — appropriate. Confirm the ServiceReef API base URL and
+  these job attributes are only visible to Finance/admin roles in the Jobs admin UI.
+
+## Making Changes
+
+- To change import behavior, edit `ImportTrips.cs` (groups/participants) or `ImportData.cs`
+  (payments/transactions); both read all config from `context.JobDetail.JobDataMap`, so keep the
+  attribute `Key` and the `dataMap.GetString(...)` lookups in sync.
+- The ServiceReef request signing lives in `HMACAuthenticator.cs`; API response shapes are the POCOs
+  under `/Contracts/` (add fields there to capture more of the ServiceReef payload).
+- New supporting defined values belong in a new numbered migration under `/Migrations/` — don't
+  hand-edit migrations that have already run.
+- Related: person matching is shared with [org.secc.PersonMatch](../org.secc.PersonMatch/README.md);
+  transaction tender lookups come from [org.secc.PayPalReporting](../org.secc.PayPalReporting/README.md).

--- a/Plugins/org.secc.SignNowWorkflow/README.md
+++ b/Plugins/org.secc.SignNowWorkflow/README.md
@@ -1,0 +1,98 @@
+# org.secc.SignNowWorkflow
+
+> Two Rock workflow actions that push a PDF into SignNow for e-signature and pull the signed copy back when it's done.
+
+## Overview
+
+SignNowWorkflow ships a pair of `ActionComponent`s (under the **SECC > Sign Now** category) used by
+Southeast's volunteer-application / background-check flow. `SignNow Create` uploads a rendered PDF to
+SignNow, creates a guest signer, and produces a signing invite link; `SignNow Download` polls the
+document and, once a signature is present, downloads the signed PDF back into a Rock binary-file
+attribute. Both lean on Rock's built-in `Rock.SignNow` integration for account access tokens and on
+the `SignNowSDK` project for the actual API calls.
+
+## Project Info
+
+- **Project file:** `org.secc.SignNowWorkflow.csproj`
+- **Root namespace:** `org.secc.SignNowWorkflow`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`, via the PostBuildEvent `xcopy`)
+
+## Project Layout
+
+```
+/Workflows/    SignNowCreate.cs    — upload PDF, create signer, build invite link
+               SignNowDownload.cs  — check for a signature, download the signed PDF
+/Properties/   AssemblyInfo.cs
+```
+
+## Components
+
+### Workflow Actions
+
+Both are `ActionComponent`s exported via MEF (`[Export(typeof(ActionComponent))]`) under
+`ActionCategory("SECC > Sign Now")`.
+
+| Action (`ComponentName`) | Purpose |
+|--------------------------|---------|
+| `SignNow Create` | Reads the `Document` attribute's binary file, writes it to a temp path, uploads it to SignNow (`Document.Create`), creates a throwaway guest signer + OAuth token, sends an invite (`Document.Invite`, email disabled), and stores the document id and a `dispatch` invite link on workflow attributes. Returns `false` (no-op) when there is no `HttpContext` (i.e. not browser-initiated). |
+| `SignNow Download` | Looks up the SignNow document by id (`Document.Get`); if it has any `signatures`, downloads the file (`Document.Download`) and stores it into the `Document` binary-file attribute (creating the `BinaryFile`, honoring the attribute's `binaryFileType` qualifier), then sets `PDF Signed` = `True`. Otherwise sets `PDF Signed` = `False`. |
+
+#### `SignNow Create` — attributes
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **SignNow Invite Link** | Workflow attribute (Text) | Output — the generated `signnow.com/dispatch?route=fieldinvite…` URL. |
+| **SignNow Document Id** | Workflow attribute (Text) | Output — the SignNow document id. |
+| **Document** | Workflow attribute (BinaryFile/File) | Input — the PDF to upload. |
+| **Redirect Uri** | Text (Lava-enabled) | Optional. Page to return to after signing; `document_id` is appended and the URI is URL-encoded onto the invite link. |
+| **Signer Role** | Text | Role the signature is assigned to (default `Applicant`). |
+
+#### `SignNow Download` — attributes
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **SignNow Document Id** | Workflow attribute (Text) | Input — document to check (required; errors if blank). |
+| **Document** | Workflow attribute (BinaryFile/File) | Output — where the signed PDF is stored. |
+| **PDF Signed** | Workflow attribute (Boolean) | Output — `True` once a signature is detected, else `False`. |
+
+## Dependencies & Integrations
+
+- **Rock:** workflow engine (`ActionComponent`, `WorkflowAttribute`, `WorkflowAction`), `RockContext`,
+  `BinaryFileService` / `BinaryFileTypeService`, `AttributeCache`, MEF (`System.ComponentModel.Composition`).
+- **Rock.SignNow:** `Rock.SignNow.SignNow` — supplies the account-level OAuth access token
+  (`GetAccessToken`) from Rock's SignNow configuration.
+- **SignNowSDK:** `Document.Create` / `Invite` / `Get` / `Download`, `User.Create`, `OAuth2.RequestToken`.
+- **Third-party:** Newtonsoft.Json 11.0.2 (`JObject`/`JArray` response parsing), SignNow REST API.
+- **Other project refs:** `Rock.Common`, and `DotLiquid` (Lava `ResolveMergeFields` on the **Redirect Uri**).
+- **Other:** EntityFramework 6.1.3 (referenced; no plugin migrations shipped).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** `SignNow Download` opens a `FileStream` on the downloaded temp file and assigns it to
+  `signedPDF.ContentStream`, then calls `File.Delete(tempPath + tempFileName)` — note the download path is
+  `{tempPath}{tempFileName}.pdf` but the delete drops the `.pdf` suffix, so the temp file may not actually
+  be removed, and the stream is opened without an explicit `using`/dispose. Worth confirming temp files are
+  cleaned up and not left open.
+- **Improvement:** The "is it signed?" check is a simple `signatures.Count() > 0` poll with no timeout or
+  expiration handling — the workflow must re-run `SignNow Download` itself (e.g. on a delay/loop) until a
+  signature appears. There's no detection of a declined/expired invite.
+- **Security (low):** `SignNow Create` mints a guest signer with a random email/password and embeds that
+  user's `access_token` directly in the invite URL query string. The link is short-lived and per-document,
+  but it is a bearer credential in a URL (loggable in proxies/history) — worth confirming it isn't persisted
+  or surfaced beyond the intended recipient.
+- **Improvement:** `SignNow Download` hardcodes `MimeType = "application/pdf"` (flagged with a `// TODO` in
+  the source) and assumes the downloaded file is a PDF.
+
+## Making Changes
+
+- Both actions live in `/Workflows/`; to change inputs/outputs, edit the `[WorkflowAttribute]` /
+  `[TextField]` declarations at the top of `SignNowCreate.cs` / `SignNowDownload.cs` and keep the
+  `GetActionAttributeValue(action, "…")` keys in sync.
+- The actual SignNow API surface is **not** in this plugin — it's in the solution's `SignNowSDK` and
+  `Rock.SignNow` projects; account credentials/config come from Rock's built-in SignNow integration.
+- New actions: add another `ActionComponent` in `/Workflows/`, decorate it with `[ActionCategory]`,
+  `[Description]`, `[Export(typeof(ActionComponent))]`, and `[ExportMetadata("ComponentName", …)]`, then
+  add it to the `<Compile>` list in the `.csproj`.

--- a/Plugins/org.secc.SportsAndFitness/README.md
+++ b/Plugins/org.secc.SportsAndFitness/README.md
@@ -1,0 +1,104 @@
+# org.secc.SportsAndFitness
+
+> Rock blocks and a theme for Southeast's Activities Center — member/guest check-in, group-fitness session tracking, guest self-registration, and a staff "control center".
+
+## Overview
+
+SportsAndFitness is the UI for Southeast's Sports & Fitness (Activities Center) ministry. It ships
+kiosk check-in blocks (members and group-fitness sessions), a multi-step guest self-registration
+flow with a liability waiver and emergency contacts, and a set of "control center" blocks staff use
+to search participants, check in guests, manage PINs, and view per-person actions/history. It also
+carries its own Rock **theme** (`Themes/SportsAndFitness`). Behavior is driven by Rock check-in
+workflows, group membership, and person/group-member attributes the blocks read and write.
+
+## Project Info
+
+- **Project file:** `org.secc.SportsAndFitness.csproj` — but it compiles **only** `Properties/AssemblyInfo.cs`; the block `.ascx.cs` files are **not** in the `<Compile>` list, so they are **RockWeb-compiled** (the project's job is really to `xcopy` markup into RockWeb).
+- **Root namespace:** `org.secc.SportsAndFitness` (blocks live under `RockWeb.Plugins.org_secc.SportsAndFitness`)
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/Plugins/org_secc/` (block `.ascx`/`.cs`/`.lava`) and `RockWeb/Themes/` (the theme), via the **PreBuildEvent** `xcopy` of `org_secc` and `Themes\*`.
+- **Cross-plugin dependency:** [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md) — `GroupFitness` uses `org.secc.FamilyCheckin.Utilities.LabelPrinter`.
+
+## Project Layout
+
+```
+/org_secc/SportsAndFitness/                Kiosk + guest blocks (.ascx + .cs) and guest-flow Lava partials
+/org_secc/SportsAndFitness/ControlCenter/  Staff "control center" blocks (search, guest check-in, PINs, person actions)
+/Themes/SportsAndFitness/                  Rock theme — Layouts, Styles (.less), Assets/Lava partials
+/Migrations/                               A single hand-run SQL stored proc (not an EF plugin migration)
+/Properties/                               AssemblyInfo.cs (the only compiled file)
+```
+
+## Components
+
+### Blocks
+
+All blocks are RockWeb-compiled `.ascx` controls. Categories vary (`SECC > Check-in`,
+`SECC > Sports and Fitness`, `Sports and Fitness > Control Center`).
+
+| Block (class) | Category | Purpose | Key settings |
+|---------------|----------|---------|--------------|
+| `ActivitiesCheckin` | SECC > Check-in | Kiosk check-in into the Activities Center; shows member cards with expiration/alert notes. | Checkin Activity, Expiration Date Attribute (group-member) |
+| `GroupFitness` | SECC > Check-in | Phone-number kiosk check-in for group-fitness classes; decrements/reads remaining sessions and prints labels. | Process Activity, Checkin Activity, Sessions Attribute Key, Group Fitness Parent Group, Minimum Digits |
+| `GuestRegistration` | SECC > Sports and Fitness | Multi-panel guest self-registration: welcome, returning-guest lookup, new-guest form, waiver, emergency contacts, finish; launches a registration workflow. | Guest Registration Workflow, Connection Status, Default Campus, Lava message attributes (welcome/new/finish/waiver/etc.) |
+| `ControlCenter/GuestCheckin` | SECC > Sports and Fitness | Staff tool to check in guests against the guest-registration workflow. | Guest Registration Workflow, Workflow Status, Cancel/Checkin Activity Type Name, Checkin Group Type, Maximum Guests |
+| `ControlCenter/Search` | Sports and Fitness > Control Center | Search participants by PIN and/or phone number. | Search By PIN, Search By Phone Number, Search Result Page |
+| `ControlCenter/SearchResults` | Sports and Fitness > Control Center | Renders the participant result list via Lava. | Person Detail (linked page), Sports and Fitness PIN Purpose (defined value), Results Lava, Lava Commands, Show Debug Panel |
+| `ControlCenter/PersonActions` | Sports and Fitness > Control Center | Per-person action panel with links to Sports/Group-Fitness/Childcare history. | Sports & Fitness / Group Fitness / Childcare History pages, Group Fitness Group |
+| `ControlCenter/ManageSportsPINs` | Sports and Fitness > Control Center | Manage a person's sign-in PINs (used alongside Person Actions). | (none) |
+
+#### GuestRegistration attribute keys
+
+Keys are defined in a `GuestRegistration.AttributeKeys` constants class. Most message fields are
+Lava `CodeEditorField`s rendered through a local `ProcessLava` helper.
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **GuestWorkflow** | workflow type, required | Registration workflow activated on finish (`Workflow.Activate`, sets `Guest` + `IsAdult`). |
+| **ConnectionStatus** | defined value, required | Connection status stamped on newly created guests. |
+| **DefaultCampus** | campus, required | Campus for the new guest's family group. |
+| **WelcomeIntro / ExistingGuestMessage / NeweGuestMessage / GuestDetailMessage / ConfirmEmergencyContact / FinishMessage / GuestWaiverText** | Lava code editors | Panel copy for each step (note the misspelled `NeweGuestMessage` key). |
+| **LavaCommands** | lava commands | Commands enabled when rendering the above. |
+
+### Lava partials
+
+The guest flow and theme ship `.lava` files rather than registered filters — e.g.
+`GuestRegistration_*.lava` (waiver, confirm-info, emergency contacts, finish),
+`ControlCenter/PersonDetails.lava`, `ControlCenter/SearchResults.lava`, and the theme's
+`Themes/SportsAndFitness/Assets/Lava/*` (calendar/event/group/page templates). These are content,
+not C# components.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext` and Rock services (`PersonService`, `GroupService`, `GroupMemberService`, `PhoneNumberService`, `AttributeMatrix*Service`), the check-in framework (`CheckInBlock`, `CheckInState`, `ProcessActivity`), Rock workflow engine, attribute framework / attribute matrices, `RockBlock`, Lava (`ResolveMergeFields`).
+- **Cross-plugin:** [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md) — `LabelPrinter` for kiosk label printing in `GroupFitness`.
+- **Third-party:** none beyond Rock/.NET. Kiosk label printing pulls in `cordova-2.4.0.js` / `ZebraPrint.js` from RockWeb.
+
+## Migrations
+
+There is a `/Migrations/` folder, but it is **not** a Rock EF plugin-migration set — it contains a
+single hand-run script, **`sf stored proc.sql`**, that creates
+`_org_secc_spSportsAndFitnessMigrate`: a **one-off, hard-coded** stored proc that copies legacy
+group members (active / expired / red-flagged card groups and the old group-fitness group) into new
+groups by **literal Id** and backfills expiration/session attribute values. It targets `RockDBStaging`
+and is not wired into any build or `Rock.Plugin.Migration`.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** `Migrations/sf stored proc.sql` hard-codes database **Ids** (group Ids, attribute Ids) and the `RockDBStaging` database name. It's a point-in-time data move that will not be correct against any other environment — keep it as historical reference, not something to re-run.
+- **Security (low):** `GuestRegistration` is a public-facing self-service kiosk block that **creates Person/Family records** and writes a liability-waiver acceptance (with the client IP read from `HTTP_X_FORWARDED_FOR`). It records a `Pending` record status and dedupes against existing people, but confirm the page hosting it is locked to the kiosk and that the trusted-proxy assumption behind `X_FORWARDED_FOR` holds (otherwise the stored "accepted from" IP is client-spoofable).
+- **Improvement:** Several blocks `new RockContext()` repeatedly within a single request/handler (e.g. `GuestRegistration` opens many short-lived contexts), and `GetEmergencyContactMatrixTypeId()` dereferences the looked-up attribute without a null check. Works in practice but is fragile if the expected attribute/matrix template is missing.
+- **Improvement:** `ActivitiesCheckin`'s membership/notes logic keys off a `ConnectionStatusValueId == Member` or `Person.GetAttributeValue("Employer") == "Southeast Christian Church"` string check (`ActivitiesCheckin.ascx.cs` lines 172 and 329) — brittle business rules embedded in code rather than configuration.
+
+## Making Changes
+
+- Kiosk check-in behavior lives in `org_secc/SportsAndFitness/ActivitiesCheckin.ascx.cs` and `GroupFitness.ascx.cs`; both are `CheckInBlock`s that call `ProcessActivity(...)` against workflow-activity names set in block attributes — change the activity wiring there, and the check-in workflow itself in Rock.
+- The guest self-registration flow (panels, waiver, emergency contacts) is `org_secc/SportsAndFitness/GuestRegistration.ascx(.cs)` plus the `GuestRegistration_*.lava` partials; per-step copy is all block attributes (Lava), so wording changes don't need a rebuild.
+- Staff tooling is under `org_secc/SportsAndFitness/ControlCenter/`; search rendering is Lava (`SearchResults.lava`, `PersonDetails.lava`).
+- Theme/layout/styling changes go in `Themes/SportsAndFitness/`.
+- This project is RockWeb-compiled — editing a `.cs` here changes behavior only after the markup is deployed to `RockWeb/Plugins/org_secc/`; the `.csproj` itself only compiles `AssemblyInfo.cs`.
+- Label printing relies on [org.secc.FamilyCheckin](../org.secc.FamilyCheckin/README.md)'s `LabelPrinter`.
+</content>
+</invoke>

--- a/Plugins/org.secc.SystemsMonitor/README.md
+++ b/Plugins/org.secc.SystemsMonitor/README.md
@@ -1,0 +1,143 @@
+# org.secc.SystemsMonitor
+
+> A pluggable system-monitoring framework: define "system tests" (HTTP, SQL, or Lava checks), run them on a schedule, record pass/fail history, and alert staff by email/SMS when an alarm condition is met.
+
+## Overview
+
+SystemsMonitor lets Southeast define **system tests** that probe Rock's health — is a website
+reachable, does a SQL query return an expected value, does a Lava template match a pattern. Each
+test type is a MEF-discovered `SystemTestComponent`, so new check types can be added without touching
+the framework. A scheduled job runs due tests, writes a `SystemTestHistory` row per run, and sends
+email/SMS notifications to a configured group when a test trips its alarm condition. A separate
+`ServerHealth` block provides a lightweight HTTP probe endpoint for load-balancer health checks.
+
+## Project Info
+
+- **Project file:** `org.secc.SystemsMonitor.csproj`
+- **Root namespace:** `org.secc.SystemsMonitor`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup), via the PostBuildEvent `xcopy`
+- **Cross-plugin dependency:** [org.secc.DevLib](../org.secc.DevLib/README.md) (project reference)
+
+## Project Layout
+
+```
+/ (root)        SystemTestComponent (abstract base), SystemTestContainer (MEF), SystemTestResult
+/Component/     The three built-in test types — ServerIsUp, SQLMatchExpression, LavaMatchExpression
+/Model/         SystemTest + SystemTestHistory entities, services, AlarmCondition/AlarmNotification enums
+/Data/          SystemsMonitorContext (EF DbContext bound to RockContext) + SystemsMonitorService<T> base service
+/Controllers/   SystemTestController — REST endpoint to run a single test on demand
+/Jobs/          RunSystemTests — Quartz job that runs due tests and sends alarm notifications
+/Helpers/       TestResult (name + alarm-notification holder used by the job)
+/Migrations/    Rock plugin migrations (create the two tables, add AlarmNotification column)
+/org_secc/SystemsMonitor/   UI blocks (.ascx + .ascx.cs)
+```
+
+## Components
+
+### Test Types (`SystemTestComponent`)
+
+MEF-exported (`[Export(typeof(SystemTestComponent))]`), discovered via `SystemTestContainer`. Each
+declares its config as Rock attributes (created automatically on container refresh). `RunTest`
+returns a `SystemTestResult` (`Passed`, `Score`, `Message`).
+
+| Component | Purpose | Config attributes | Supported alarms |
+|-----------|---------|-------------------|------------------|
+| `ServerIsUp` | Opens a URL and passes if it responds before timeout. | **Url**, **Timeout** (seconds, default 30) | Never, Fail |
+| `SQLMatchExpression` | Runs a scalar SQL query; passes if the result matches a regex. | **SQL Query** (CodeEditor/Sql), **Matching Expression** (regex) | Never, Fail |
+| `LavaMatchExpression` | Resolves a Lava template; passes if the output matches a regex. | **Lava** (CodeEditor/Lava), **Lava Commands**, **Matching Expression** (regex) | Never, Fail |
+
+The base `SystemTestComponent` advertises `Never`, `Fail`, `ScoreAbove`, `ScoreBelow`; all three
+built-ins narrow this to `Never`/`Fail` (none currently emit a non-zero `Score`).
+
+### Jobs
+
+| Job (class) | Purpose | Key settings |
+|-------------|---------|--------------|
+| `RunSystemTests` | Runs each test whose `RunIntervalMinutes` has elapsed since its last history row; sends notifications for any test meeting its alarm condition. `[DisallowConcurrentExecution]`. | **Notification Communication** (SystemCommunication), **Notification Group**, **From Number** (SMS defined value) |
+
+> Note: the class lives in namespace `org.secc.Jobs`, not `org.secc.SystemsMonitor`.
+
+### REST Endpoints
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `api/systemtest/runtest/{id}` | GET (`[Authenticate]`) | Runs test `{id}` immediately; returns `200 "Passed"` or `500` on failure. |
+
+### Blocks
+
+Category in Rock: **SECC > Systems Monitor**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Monitor Tests | Grid of all defined tests; add / run / drill into a test. | Details Page (LinkedPage) |
+| Monitor Test Detail | Create/edit a single test — pick the component type and set its attributes, interval, and alarm. | (none) |
+| Server Health | HTTP health probe for this node; returns `200 Healthy` or `503` when `~/_maintenance.flag` exists. | (none) |
+
+### Models
+
+| Entity (table) | Purpose |
+|----------------|---------|
+| `SystemTest` (`_org_secc_SystemsMonitor_SystemTest`) | A monitor definition: name, the component `EntityType`, run interval, alarm condition/score, and `AlarmNotification` flags. `Run()` loads attributes, invokes the component, and logs a history row. |
+| `SystemTestHistory` (`_org_secc_SystemsMonitor_SystemTestHistory`) | One row per test run: `Score`, `Passed`, `Message`. |
+
+`AlarmCondition` = `Never` / `Fail` / `ScoreAbove` / `ScoreBelow`; `AlarmNotification` is a `[Flags]`
+enum of `Email` / `SMS`.
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext`, the Rock entity/model + service framework (`IRockEntity`, `Model<T>`),
+  the MEF component container (`Rock.Extension.Container`), attribute framework, REST
+  (`ApiControllerBase`), the block/UI framework, `DbService` (SQL scalar), Lava, and Rock
+  communications (`RockEmailMessage` / `RockSMSMessage`).
+- **Third-party:** Quartz (`IJob`), EntityFramework 6, Newtonsoft.Json, DotLiquid (Lava).
+- **Cross-plugin:** [org.secc.DevLib](../org.secc.DevLib/README.md) (project reference).
+- **External:** the `ServerIsUp` test reaches arbitrary configured URLs over HTTP; `ServerHealth`
+  is designed to back an external probe (e.g. Azure Application Gateway).
+
+## Migrations
+
+Ships Rock plugin migrations under `/Migrations/`:
+
+- `001_Init` — creates `_org_secc_SystemsMonitor_SystemTest` and `_org_secc_SystemsMonitor_SystemTestHistory`
+  (keys, FKs to `PersonAlias` / `EntityType`, indices) (`MigrationNumber 1`).
+- `002_AlarmNotification` — adds the nullable `AlarmNotification` column to the `SystemTest` table (`MigrationNumber 2`).
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** The `SQLMatchExpression` and `LavaMatchExpression` test bodies are stored
+  test attributes that execute arbitrary SQL / Lava (with configurable `Lava Commands`, including
+  potentially `Sql`/`Execute`) under Rock's privileges. Whoever can create/edit a test via the
+  *Monitor Test Detail* block effectively gets server-side SQL and Lava execution — confirm those
+  pages/blocks are locked to administrators.
+- **Improvement:** The Rock **pages and blocks are not installed by any migration** (only the two
+  tables are). The `.ascx` files are deployed to `RockWeb/Plugins/org_secc/`, but the page/block
+  entries must be created by hand in the admin UI. Worth confirming this is intentional rather than
+  a missing `003_Pages` migration.
+- **Improvement:** `RunSystemTests` keys "due" off whether a history row exists newer than
+  `now - RunIntervalMinutes`. Because `SystemTest.Run()` always writes a history row, the next job
+  tick after a run sees the fresh row and skips — so effective cadence is the max of the test
+  interval and the job interval, and a test with no interval never auto-runs (intentional, but
+  subtle).
+- **Improvement:** `ServerIsUp.WebClientEx` sets `request.Timeout = Timeout * 10000` — for the
+  default `Timeout` of 30 ("seconds" per the attribute description) this is 300,000 ms (5 min), not
+  30 s. The unit math looks off; review whether the multiplier should be `1000`.
+- **Improvement:** `SystemTest.Run()` opens a second `RockContext` (separate from the caller's) just
+  to save the history row, and `MeetsAlarmCondition` is re-checked by the job rather than by `Run`,
+  so a manual run via the REST endpoint or block records history but never alarms.
+
+## Making Changes
+
+- To add a new test type, create a class in `/Component/` deriving from `SystemTestComponent`,
+  decorate it with `[Export(typeof(SystemTestComponent))]` + `[ExportMetadata("ComponentName", ...)]`
+  and its Rock `*Field` config attributes, and implement `Name`, `Icon`, and `RunTest`; MEF picks it
+  up and `SystemTestContainer.Refresh()` provisions its attributes. Follow `ServerIsUp` as a template.
+- To change alarm delivery, edit `Jobs/RunSystemTests.cs` (`SendNotificationEmail` / `SendNotificationSms`);
+  notification recipients come from the configured **Notification Group**.
+- New columns/tables belong in a new numbered migration under `/Migrations/` — don't hand-edit
+  migrations that have already run.
+- Related: scheduled-job patterns and other custom jobs live in [org.secc.Jobs](../org.secc.Jobs/README.md).
+</content>
+</invoke>

--- a/Plugins/org.secc.Themes/README.md
+++ b/Plugins/org.secc.Themes/README.md
@@ -1,0 +1,107 @@
+# org.secc.Themes
+
+> Southeast's Rock site themes — the master pages, page layouts, and styling that skin Rock's external and check-in sites.
+
+## Overview
+
+This "plugin" is not compiled code; it is the collection of Rock **themes** Southeast maintains.
+Each theme is a folder of ASP.NET master pages, page layouts (`.aspx`), styling (LESS/SCSS), scripts,
+and image/Lava assets that Rock loads to render a Site. They cover the public website, the member
+portal, landing pages, child/check-in screens, seasonal sites (Easter, Christmas Together), and a
+Church Online Platform skin. Designers and developers edit these to change how Rock-rendered pages
+look.
+
+## Project Info
+
+- **Project file:** none — no `.csproj`; these are RockWeb theme assets (not a compiled assembly).
+- **Root namespace:** the few code-behind files use `RockWeb.Themes.*.Layouts` — in practice only two values appear: `RockWeb.Themes.Stark.Layouts` (Stark starter-theme leftover, in most themes' `Error.aspx.cs`) and `RockWeb.Themes.MySecc.Layouts` (`my-secc`, plus an Easter copy-paste — see Observations).
+- **Target framework:** n/a (markup, styles, and ASP.NET page code-behind compiled in-place by RockWeb).
+- **Deploys to:** `RockWeb/Themes/<ThemeName>/` (each top-level folder maps to a Rock theme of the same name).
+
+## Project Layout
+
+```
+/Themes/
+  SECC2019/               Primary public-site theme (Layouts/Styles/Scripts/Assets + ChurchOnline/)
+  SECC2019Portal/         Member-portal variant of SECC2019 (ships a Compass config.rb)
+  SECC2019_Child_Invert/  Check-in / children's screens variant (Checkin.aspx, Checkin-Site.Master)
+  SECC2019_LandingPage/   Landing-page theme — many Full*/Simple* card/overlay layouts
+  SECC2024/               Newer public-site theme (adds TwoColumn layout)
+  SECC2014/               Legacy public-site theme
+  Easter/                 Seasonal site theme (+ Lava assets under Assets/Lava)
+  ChristmasTogether/      Seasonal check-in theme (Checkin layout only)
+  LWYA/                   "Love Where You Are" site theme (own fonts, map .kmz assets)
+  Rogers/                 Campus/site theme
+  KyleIdlman17/           One-off event/site theme
+  my-secc/                "my.secc" theme (ships Site.Master.cs code-behind)
+  SECC2019/ChurchOnline/  Church Online Platform skins (Template.liquid + SCSS, 3 sub-themes)
+  SEMobileApp/            Lava snippets for the mobile app (GrowTabs, Give card) — no layouts
+  RockConfiguration_Baks/ Backup copies of Global Attribute email-template Lava (header/footer/full)
+```
+
+## Components
+
+Each theme follows Rock's theme convention: a `Layouts/Site.Master` plus one `.aspx` per page layout,
+with `Styles/`, `Scripts/`, and `Assets/` alongside. There are no REST endpoints, blocks, jobs, or
+field types here.
+
+### Themes
+
+| Theme | Kind | Layouts | Notes |
+|-------|------|---------|-------|
+| `SECC2019` | Public site | 10 | Primary site theme; also hosts the `ChurchOnline/` skins. |
+| `SECC2019Portal` | Site (portal) | 10 | Ships a Compass `config.rb` for SCSS compilation. |
+| `SECC2019_Child_Invert` | Check-in | 11 | Adds `Checkin.aspx` + `Checkin-Site.Master`, `Sections`/`SidebarSections`. |
+| `SECC2019_LandingPage` | Landing pages | 17 | Full*/Simple* card, centered, fifty-fifty, and overlay layouts. |
+| `SECC2024` | Public site | 11 | Newer site theme; adds a `TwoColumn` layout. |
+| `SECC2014` | Public site (legacy) | 9 | Older site theme; LESS styles + vendor scripts. |
+| `Easter` | Seasonal site | 8 | Includes `Assets/Lava/` page-render snippets and `Site.Master.cs`. |
+| `ChristmasTogether` | Seasonal check-in | 1 | `Checkin.aspx` + `Site.Master` only; LESS variable overrides. |
+| `LWYA` | Site | 8 | Own webfonts, component scripts, and map `.kmz` assets. |
+| `Rogers` | Site | 8 | Standard site layout set. |
+| `KyleIdlman17` | Site/event | 9 | One-off themed site. |
+| `my-secc` | Site | 8 | Ships `Site.Master.cs` setting the site-name heading. |
+
+### Other assets (no layouts)
+
+| Folder | Contents |
+|--------|----------|
+| `SECC2019/ChurchOnline/Themes/` | Church Online Platform skins — `SEOnlineDarkTheme`, `SEOnlineDarkThemeYellow`, `SEOnlineLightTheme`, each `Template.liquid` + `javascript.js` + `stylesheet*.scss`. |
+| `SEMobileApp/` | Lava for the mobile app: `GrowTabs.lava`, `Give/Give.lava`, `Give/HtmlToImage/GiveCard.html`. |
+| `RockConfiguration_Baks/GlobalAttributeEmailTemplates/` | Backup Lava for the Email Header / Footer / Full email-template Global Attributes. |
+
+## Dependencies & Integrations
+
+- **Rock:** the page code-behind inherits `Rock.Web.UI.RockMasterPage` / `RockPage`; themes are
+  loaded by Rock's Site/Layout framework. Layouts render Rock blocks via `<Rock:Zone>` placeholders.
+- **Third-party (front-end):** Bootstrap (LESS/SCSS), Font Awesome / glyphicons (LWYA fonts),
+  jQuery and component scripts (Isotope, Magnific Popup, Swiper, WOW, YouTube/Vimeo players, etc.),
+  Compass/Sass (`SECC2019Portal/config.rb`). `Styles/.gitignore` files indicate compiled CSS is
+  generated, not all committed.
+- **Church Online Platform:** `SECC2019/ChurchOnline` skins use the platform's `Template.liquid` format.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Improvement:** Several themes' `Layouts/Error.aspx.cs` still carry the scaffolded
+  `RockWeb.Themes.Stark.Layouts` namespace (the Rock starter theme), and `Easter`'s `Site.Master.cs`
+  declares the `RockWeb.Themes.MySecc.Layouts` namespace / `MySeccMasterPage` class — copy-paste
+  leftovers. Harmless at runtime but misleading; worth renaming if a theme's code-behind is ever
+  touched.
+- **Improvement:** `RockConfiguration_Baks/` is a manual backup of Global-Attribute email Lava sitting
+  in source control with no obvious consumer. Confirm it is intentional documentation rather than dead
+  weight, and that it doesn't drift from the live Global Attribute values.
+- **Improvement:** Many `Styles/` folders carry both source (`.less`/`.scss`) and committed compiled
+  `.css`, plus `.gitignore` rules — the build/compile story differs per theme (Compass for the Portal,
+  LESS elsewhere). Worth confirming which CSS is authoritative before editing styles.
+
+## Making Changes
+
+- To restyle a page, edit the matching theme's `Styles/` source (LESS or SCSS) and recompile to CSS;
+  for `SECC2019Portal` that means running Compass against its `config.rb`.
+- To change page structure, edit the relevant `Layouts/*.aspx` (or `Site.Master`) in that theme; keep
+  Rock `<Rock:Zone>` placeholders intact so block placement still works.
+- New page layouts must be added both as a `.aspx` file here and registered as a Layout on the Site in
+  the Rock admin UI.
+- Church Online skins live under `SECC2019/ChurchOnline/Themes/`; mobile-app Lava under `SEMobileApp/`.

--- a/Plugins/org.secc.Trak1/README.md
+++ b/Plugins/org.secc.Trak1/README.md
@@ -1,0 +1,131 @@
+# org.secc.Trak1
+
+> A Rock background-check provider that submits applicant data to the Trak-1 web service and polls back report status/results through a workflow action.
+
+## Overview
+
+Trak1 integrates Southeast's background-check process with the [Trak-1](https://www.trak-1.com/)
+screening service. It ships a Rock `BackgroundCheckComponent` that builds an applicant payload
+(name, SSN, DOB, home address) and POSTs it to Trak-1's `RunPackage` endpoint, a workflow
+`ActionComponent` that polls `GetReportStatus`/`GetReportUrl` and writes the result back onto the
+workflow and the Rock `BackgroundCheck` record, and an admin block that lists the screening
+packages available from Trak-1. It is driven entirely by Rock's stock background-check workflow
+plumbing — staff pick "Trak-1" as the provider on a background-check workflow.
+
+## Project Info
+
+- **Project file:** `org.secc.Trak1.csproj`
+- **Root namespace:** `org.secc.Trak1`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `.pdb`) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup), via the PostBuildEvent `xcopy`
+
+## Project Layout
+
+```
+/BackgroundCheck/   Trak1.cs       — BackgroundCheckComponent (builds + sends the request)
+/Workflow/          Trak1Status.cs — ActionComponent that polls status/report and writes results back
+/Helpers/           DTOs (request/response): Trak1Authentication, Trak1Applicant, Trak1Request,
+                    Trak1Response, Trak1Package, Trak1Component, Trak1RequiredField, Trak1Report,
+                    Trak1ReportStatus, ErrorInformation
+/org_secc/Trak1/    Trak1Settings block (.ascx + .ascx.cs) — lists available Trak-1 packages
+/Properties/        AssemblyInfo.cs
+```
+
+## Components
+
+### Background Check Provider
+
+`BackgroundCheck/Trak1.cs` — a `BackgroundCheckComponent` (MEF `[Export]`, `ComponentName "Trak-1"`).
+`SendRequest` resolves the workflow's person, gathers a package's required fields, builds a
+`Trak1Request`, POSTs it to the Request URL, and creates/updates a Rock `BackgroundCheck` row keyed
+to the workflow. Configuration is per-provider via Rock component attributes:
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **UserName** | text, required | Trak-1 user name. |
+| **SubscriberCode** | encrypted text, required | Subscriber code from Trak-1 (decrypted at call time). |
+| **CompanyCode** | encrypted text, required | Company code from Trak-1 (decrypted at call time). |
+| **PackageURL** | URL, required | `GetAvailablePackages` endpoint (default points at `stgapi.trak-1.com`). |
+| **RequestURL** | URL, required | `RunPackage` endpoint (default `stgapi`). |
+| **StatusURL** | URL, required | `GetReportStatus` endpoint (default `stgapi`). |
+| **ReportURL** | URL, required | `GetReportUrl` endpoint (default `stgapi`). |
+
+`GetReportUrl(reportKey)` returns a `~/GetFile.ashx?guid=` link, gated on the current person being
+authorized to `VIEW` the component (otherwise returns `"Unauthorized"`).
+
+### Workflow Actions
+
+`Workflow/Trak1Status.cs` — `ActionComponent`, category **Background Check**, `ComponentName
+"Trak-1 Status"`. Looks up the `BackgroundCheck` row by workflow Id, calls the provider's Status and
+Report URLs, and writes the results back.
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Provider** | component (`Rock.Security.BackgroundCheckContainer`) | The background-check provider to query. |
+| **ReportStatus** | workflow attribute (text) | Receives the Trak-1 `ReportStatus`. |
+| **HitColor** | workflow attribute (text) | Receives the Trak-1 `HitColor`; `RecordFound` is set true when `"Green"`. |
+| **ReportUrl** | workflow attribute (text) | Receives the report URL. |
+
+If no `BackgroundCheck` row exists for the workflow, the action logs and sets ReportStatus to
+`"Error"` (returns `true` so the workflow can handle it gracefully).
+
+### Blocks
+
+Category in Rock: **SECC > Background Check**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Trak1 Packages | Read-only admin view listing each Trak-1 package (price, description, components, required fields) returned by `GetAvailablePackages`. | (none — resolves the Trak-1 provider via `EntityTypeService`) |
+
+### Models / DTOs
+
+Plain POCOs under `/Helpers/` used to serialize requests to and deserialize responses from the
+Trak-1 JSON API — not Rock entities. Key ones: `Trak1Request` (`Authentication` + `Applicant` +
+`PackageName`), `Trak1Applicant` (name/SSN/DOB/address + `RequiredFields` dictionary),
+`Trak1Response` (`TransactionId`, optional `Error`), `Trak1ReportStatus` (`ReportStatus`,
+`HitColor`, `Recommendation`), `Trak1Report` (`ReportUrl`, `HitColor`), and `Trak1Package` /
+`Trak1Component` / `Trak1RequiredField` describing the package catalog.
+
+## Dependencies & Integrations
+
+- **Rock:** `BackgroundCheckComponent` / `BackgroundCheckContainer`, `BackgroundCheckService` and
+  the `BackgroundCheck` model, the workflow engine (`ActionComponent`), `RockContext`,
+  `Encryption` (encrypted attributes), `SSNFieldType.UnencryptAndClean`, attribute framework, and
+  the Rock block/UI framework.
+- **Third-party:** Trak-1 REST web service (`api.trak-1.com` / `stgapi.trak-1.com`), `HttpClient`,
+  Newtonsoft.Json.
+- **Cross-plugin:** none.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** `SendRequest` transmits SSN, date of birth, and home address to Trak-1.
+  The DTOs are POSTed over whatever scheme the configured URL uses; confirm the production Request
+  URL is HTTPS (the shipped defaults are `https://stgapi.trak-1.com`, a **staging** host — verify
+  production deploys repoint these to the live endpoint).
+- **Security (low):** The subscriber/company codes are decrypted and embedded directly in the URL
+  path for `GetPackageList` and `Trak1Status` (`/{subscriberCode}/{companyCode}/...`). URLs can be
+  logged by proxies/servers; worth confirming Trak-1 expects credentials in the path and that
+  request logging won't capture them.
+- **Improvement:** Every Trak-1 call (the `RunPackage` POST, `GetAvailablePackages`, and both the
+  status and report GETs in `Trak1Status`) uses `.Result` on async `HttpClient` calls
+  (sync-over-async) and constructs a new `HttpClient` per call. Functional for a low-volume workflow
+  step but can deadlock under some sync contexts and leaks sockets under load.
+- **Improvement:** In `SendRequest`, `person.LoadAttributes(rockContext)` is called immediately
+  after the `PersonAliasService` query without a null guard, so a missing/invalid person alias would
+  NRE before the explicit `person == null` check below it.
+- **Improvement:** Response handling assumes well-formed JSON — `response.Error?.Message` is guarded,
+  but `response`, `status`, and the deserialized report are dereferenced without null checks, so a
+  non-JSON or error HTTP body would throw rather than surface a clean error message.
+
+## Making Changes
+
+- To change the request payload or which person/address/SSN fields are sent, edit
+  `BackgroundCheck/Trak1.cs` (`SendRequest`); the wire shape lives in the `/Helpers/` DTOs.
+- To change how status/results are written back to the workflow, edit `Workflow/Trak1Status.cs`
+  (and keep its `ReportStatus`/`HitColor`/`ReportUrl` workflow-attribute keys in sync).
+- Trak-1 endpoint URLs and credentials are Rock component attributes on the provider — change them
+  in the admin UI, not in code; only the attribute *definitions* (and defaults) live in `Trak1.cs`.
+- The package list is fetched live from Trak-1; the `Trak1 Packages` block (`org_secc/Trak1/`) is
+  display-only.

--- a/Plugins/org.secc.Widgities/README.md
+++ b/Plugins/org.secc.Widgities/README.md
@@ -1,0 +1,130 @@
+# org.secc.Widgities
+
+> A drag-and-drop content-builder: admins define reusable "widgity" types (a Lava/Markdown template plus an attribute schema), then place and configure them against any Rock entity.
+
+## Overview
+
+Widgities is a lightweight page-builder framework. A **WidgityType** is an admin-defined component
+— a name, icon, category, enabled Lava commands, a Markdown/Lava template, and a set of attributes
+(plus optional repeating "item" attributes). Editors drag instances of those types onto an entity
+(today, a Rock **Block**) via the `WidgityContent` block, fill in the attribute values, and publish.
+At render time each instance's attribute values are merged into its type's Markdown template through
+Lava. WidgityTypes can be exported/imported as JSON for moving between environments.
+
+## Project Info
+
+- **Project file:** `org.secc.Widgities.csproj`
+- **Root namespace:** `org.secc.Widgities`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup + `Widgities.css`)
+
+## Project Layout
+
+```
+/Model/                   EF entities + services (Widgity, WidgityItem, WidgityType)
+/Cache/                   ModelCache wrappers (WidgityCache, WidgityItemCache, WidgityTypeCache)
+/Data/                    WidgityContext (Rock DbContext)
+/Controls/                WidgityControl — the drag/drop edit+render CompositeControl
+/Lava/                    CustomFilters.cs — the `TwoPass` Lava filter
+/Startup/                 LoadCustomFilters — IRockOwinStartup hook that registers the filter
+/Utility/EntityCoding/    WidgityType JSON export/import (IExporter / processor)
+/org_secc/Widgities/      UI blocks (.ascx + .ascx.cs) and Widgities.css
+/Migrations/              Rock plugin migration (Init) creating the three tables + junction
+```
+
+## Components
+
+### Models
+
+| Entity | Table | Purpose |
+|--------|-------|---------|
+| `WidgityType` | `_org_secc_Widgities_WidgityType` | Component definition: Name, Icon, Description, Markdown template, EnabledLavaCommands, HasItems, Category, and a many-to-many set of allowed `EntityType`s (`_org_secc_Widgities_WidgityTypeEntityType`). |
+| `Widgity` | `_org_secc_Widgities_Widgity` | A placed instance of a type, bound to a host entity (`EntityTypeId` + `EntityGuid`) with an `Order`. Carries attribute values keyed to its type. |
+| `WidgityItem` | `_org_secc_Widgities_WidgityItem` | Repeating child row under a `Widgity` (used when the type has `HasItems`), with its own attribute values and `Order`. |
+
+Attributes for `Widgity` and `WidgityItem` are stored as Rock attributes qualified by
+`WidgityTypeId` (`EntityTypeQualifierColumn = "WidgityTypeId"`), so each WidgityType effectively
+owns its own attribute schema.
+
+### Blocks
+
+Category in Rock: **SECC > Widgities**.
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Widgity Content | Renders the published widgities for the block and, in custom-settings mode, hosts the drag-and-drop editor. Extends `RockBlockCustomSettings`; binds to `EntityType = Block`, `EntityGuid = BlockCache.Guid`. | (none) |
+| Widgity Type List | Grid of all WidgityTypes; add/edit links to the detail page; JSON import via uploaded file. | **DetailsPage** (LinkedPage) |
+| Widgity Type Detail | Editor for a WidgityType (template, icon, category, allowed entity types, has-items toggle) and its Widgity / WidgityItem attribute grids; JSON export of the type. | (none) |
+
+### Lava Filters
+
+Registered at startup via `LoadCustomFilters` (`IRockOwinStartup`).
+
+| Filter | Purpose |
+|--------|---------|
+| `TwoPass` | Re-resolves its input string as Lava against the current environment's merge fields and enabled commands — lets a WidgityType template emit Lava that is itself evaluated in a second pass. |
+
+### Controls
+
+| Control | Purpose |
+|---------|---------|
+| `WidgityControl` | Server `CompositeControl` that powers both display and editing. View mode merges each widgity's attribute values into its type's Markdown via `ResolveMergeFields`. Edit mode renders a Dragula-based drag/drop palette (loads `dragula.min.js` + `Widgities.css` at runtime), builds attribute editors, and publishes changes in a single wrapped transaction. |
+
+## Dependencies & Integrations
+
+- **Rock:** `RockContext` / `Rock.Data.DbContext`, `ModelCache`, Rock attribute framework
+  (`Rock.Attribute.Helper`), `RockBlock` / `RockBlockCustomSettings`, `Rock.Utility.EntityCoding`
+  (`EntityCoder` / `EntityDecoder`), Rock Lava (`ResolveMergeFields`).
+- **Third-party:** EntityFramework 6.1.3, Newtonsoft.Json 11 (ViewState serialization), DotLiquid
+  (Lava), Owin (startup), Dragula (client-side drag/drop, loaded from `/Scripts/dragula.min.js`).
+- **Cross-plugin:** none required; the host-entity model is generic, so any plugin that places a
+  `WidgityControl` against its own `IEntity` can reuse the framework.
+
+## Migrations
+
+Ships a single **Rock plugin migration** (not standard EF code-first) that stands up the schema. The
+class derives from `Rock.Plugin.Migration` and is run by Rock's plugin-migration framework, ordered by
+its `[MigrationNumber( 1, "1.8.0" )]` attribute rather than an EF timestamp:
+
+- `Init` (file `202001131305110_Init.cs`) — uses Rock's `AddTable` / `AddPrimaryKey` / `AddForeignKey`
+  helpers to create `_org_secc_Widgities_Widgity`, `_org_secc_Widgities_WidgityItem`, and
+  `_org_secc_Widgities_WidgityType`, plus the `_org_secc_Widgities_WidgityTypeEntityType` junction.
+  `Down()` is empty (no rollback). `Configuration.cs` is a leftover EF `DbMigrationsConfiguration`
+  with `AutomaticMigrationsEnabled = false` and an empty `Seed` — it does not drive this schema.
+  `WidgityContext` sets a `NullDatabaseInitializer` so the context never auto-creates a database or
+  runs EF migrations.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** WidgityType templates are arbitrary **Lava/Markdown authored in the admin
+  UI** and rendered with the type's `EnabledLavaCommands`. The `TwoPass` filter additionally
+  re-evaluates rendered output as Lava. Anyone who can edit a WidgityType (or has it enable command
+  Lava such as `Sql`/`Execute`) effectively controls server-side template execution wherever that
+  widgity renders. Worth confirming the Widgity Type Detail/List pages are locked to trusted admins
+  and that enabled-command grants are reviewed.
+- **Improvement:** `WidgityControl` serializes the full `Widgities` / `WidgityItems` model to
+  **ViewState as JSON** on every interaction; pages with many widgities/items will carry a large
+  ViewState payload across postbacks.
+- **Improvement:** Edit-mode drag/drop drives navigation via `window.location = "javascript:__doPostBack(...)"`
+  and parses `__EVENTARGUMENT` by delimiter; the control depends on loading `dragula.min.js` and
+  jQuery at runtime. Brittle to client-side ordering/availability — worth a look if drag/drop misbehaves.
+- **Improvement:** The host entity is hard-wired to `Block` in the `WidgityContent` block
+  (`EntityType = Block`, `EntityGuid = BlockCache.Guid`), even though the model supports any
+  `IEntity`. Reusing widgities against other entities needs a new block/control host.
+
+## Making Changes
+
+- To change how a widgity renders or how the editor behaves, edit `Controls/WidgityControl.cs`
+  (`ShowWidgities` for view rendering, `ShowEdit` / `Publish` for the editor and save path).
+- To change the type editor (template field, attribute grids, JSON export), edit
+  `org_secc/Widgities/WidgityTypeDetail.ascx(.cs)`; the list and JSON import live in
+  `WidgityTypeList.ascx(.cs)`.
+- New columns on the entities require a new Rock plugin migration under `/Migrations/` (next
+  `[MigrationNumber]`) and matching updates
+  to the `Model/` classes and `Cache/` wrappers (caches are cleared via
+  `WidgityCache.Clear()` / `WidgityItemCache.Clear()` / `WidgityTypeCache.Clear()` on publish/save).
+- To add a Lava filter, edit `Lava/CustomFilters.cs`; the whole type is registered in
+  `Startup/LoadCustomFilters.cs`. See [org.secc.QRManager](../org.secc.QRManager/README.md) for the
+  same startup-filter pattern.

--- a/Plugins/org.secc.Workflow/README.md
+++ b/Plugins/org.secc.Workflow/README.md
@@ -1,0 +1,111 @@
+# org.secc.Workflow
+
+> A library of custom Rock workflow actions (plus two bulk-workflow admin blocks) covering people, communications, registrations, media, and workflow control.
+
+## Overview
+
+This is Southeast's catch-all workflow-extension plugin. It supplies ~29 custom workflow
+**actions** that drop into Rock's workflow engine, organized by area (person matching, SMS,
+connections, registrations/discount codes, attribute-matrix manipulation, media processing,
+and workflow control). It also ships two admin blocks for selecting and updating workflows in
+bulk.
+
+## Project Info
+
+- **Project file:** `org.secc.Workflow.csproj`
+- **Root namespace:** `org.secc.Workflow`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly + `FFmpeg.NET.dll`, `Magick*`) and
+  `RockWeb/Plugins/org_secc/` (block markup)
+
+## Project Layout
+
+Actions are grouped into one folder per area; each folder maps roughly to an action category in
+the Rock workflow editor.
+
+```
+/Person/              person matching & history actions
+/Communication/       SMS
+/Connections/         connection-request actions
+/Registrations/       discount codes & registrant field mapping
+/WorkflowAttributes/  attribute & attribute-matrix manipulation
+/WorkflowControl/     activate / reactivate / process / cache actions
+/Schedule/            schedule helpers
+/SignatureDocument/   signed-document storage
+/Media/               FFmpeg / ImageMagick actions
+/Twilio/              Twilio lookup
+/CMS/                 cache-tag actions
+/org_secc/Workflow/   admin blocks (.ascx)
+```
+
+## Components
+
+### Blocks
+
+Category in Rock: **SECC > Workflow**.
+
+| Block | Purpose |
+|-------|---------|
+| Workflow Bulk Select | Tool for bulk-selecting workflows. |
+| Workflow Bulk Update | Tool for updating workflows in bulk. |
+
+### Workflow Actions
+
+| Action | Area | Purpose |
+|--------|------|---------|
+| GetPersonFromFields | Person | Set an attribute to a person via SECC custom matching; optionally create a new person. |
+| PersonAddHistory | Person | Add a history record to the selected person. |
+| SendSms | Communication | Send an SMS to a person or a phone number in the `To` field. |
+| SetConnectionRequestGroup | Connections | Set the group of a connection request. |
+| SetConnectionAttributeValue | Connections | Set attributes of a connection request. |
+| AutoApplyDiscountCode | Registrations | Apply a discount code to an unpersisted RegistrationState. |
+| GenerateDiscountCode | Registrations | Generate a new discount code on a registration template. |
+| UpdateDiscountCodeWithAttribute | Registrations | Update an existing discount code on a registration template. |
+| SetAttributeFromRegistrantField | Registrations | Set an attribute from a registrant field by key + registrant index. |
+| UpdateRegistrationGroupWithPlacementGroup | Registrations | Sync a registration group with its placement group. |
+| SetAttributeValue | WorkflowAttributes | Set an attribute's value to the selected value. |
+| CopyAttributesFromWorkflow | WorkflowAttributes | Copy attribute values from one workflow to another. |
+| AttributeMatrixAddRow / UpdateRow / DeleteRow / Copy | WorkflowAttributes | Add / update / delete / clone attribute-matrix rows. |
+| BinaryFileFromBase64String | WorkflowAttributes | Save a Base64 string as a Binary File. |
+| ActivateWorkflowWithLava | WorkflowControl | Activate a new workflow with provided attribute values. |
+| ProcessWorkflow | WorkflowControl | Process another workflow with provided attribute values. |
+| ReActivateActivity | WorkflowControl | Reactivate an activity instance and its actions. |
+| DeleteVisitActivity | WorkflowControl | Delete a visit activity instance and its actions. |
+| ClearAuthCache | WorkflowControl | Clear the authorization cache. |
+| ScheduleNextStartDate | Schedule | Get the next start date for a schedule. |
+| StoreSignedDocument | SignatureDocument | Create a new signature document. |
+| ClearCacheTags | CMS | Clear all cached items with the selected tag(s). |
+| Lookup | Twilio | Make a Twilio Lookup API call. |
+| FFmpeg | Media | Run FFmpeg commands. |
+| ImageMontage | Media | Create JPG montages of image tiles. |
+| BinaryFileRemove | Media | Remove a Binary File. |
+
+## Dependencies & Integrations
+
+- **Rock:** workflow engine (`ActionComponent`), `RockContext`, connections, registrations, CMS cache.
+- **Cross-plugin:** references [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) (used by `GetPersonFromFields`).
+- **Third-party:** Twilio (lookup), FFmpeg.NET (video/audio), Magick.NET / ImageMagick (image montages).
+
+## Observations
+
+*Noticed while documenting — not a full audit; the `Media/FFmpeg` action stood out.*
+
+- **Security (review):** `FFmpeg` resolves the admin-configured `Command` (Lava, including the
+  `{{file}}` and `{{outputPath}}` merge fields) and passes it straight to the FFmpeg engine. If the
+  `File` workflow attribute can be populated from untrusted input (e.g. a registrant upload/field),
+  that string is interpolated into the command — an argument/command-injection vector. Treat this
+  action as admin-trusted-only and validate/sanitize the `file` value. `OutputPath` is also used to
+  `Directory.CreateDirectory` with no path-traversal guard, so it can write outside the intended root.
+- **Improvement:** `Task.Run( … ).Wait()` is sync-over-async — it blocks the workflow thread on an
+  external process and risks deadlock; there's also no timeout on the FFmpeg run. The default
+  `FFmpegExecutable` is a hardcoded path into an ImageMagick install folder
+  (`C:\Program Files\ImageMagick-…\ffmpeg.exe`), which is brittle and likely wrong on most servers.
+
+## Making Changes
+
+- To add an action, create a class in the appropriate area folder that subclasses Rock's
+  `ActionComponent` and carries the standard `[Description]` / `[ActionCategory]` /
+  `[Export]` attributes; follow an existing sibling as a template.
+- Media actions require the `FFmpeg.NET` and `Magick*` assemblies to be present in `RockWeb/bin`
+  (handled by the PostBuildEvent).
+- `GetPersonFromFields` depends on [org.secc.PersonMatch](../org.secc.PersonMatch/README.md); person-matching changes may belong there.

--- a/Plugins/org.secc.Workflow/README.md
+++ b/Plugins/org.secc.Workflow/README.md
@@ -1,6 +1,10 @@
 # org.secc.Workflow
 
-> A library of custom Rock workflow actions (plus two bulk-workflow admin blocks) covering people, communications, registrations, media, and workflow control.
+> A library of custom Rock workflow **actions** (plus two bulk-workflow admin blocks) covering people, communications, registrations, media, and workflow control.
+
+> **Doc tier: deep.** This is a high-traffic, widely-referenced plugin, so it's documented at the
+> deeper technical tier (action contracts, config attributes, data flow, extending). Most SECC
+> plugins use the lighter standard tier.
 
 ## Overview
 
@@ -8,7 +12,9 @@ This is Southeast's catch-all workflow-extension plugin. It supplies ~29 custom 
 **actions** that drop into Rock's workflow engine, organized by area (person matching, SMS,
 connections, registrations/discount codes, attribute-matrix manipulation, media processing,
 and workflow control). It also ships two admin blocks for selecting and updating workflows in
-bulk.
+bulk. Actions are discovered by Rock via MEF (`[Export(typeof(ActionComponent))]`) and configured
+entirely through Rock block/workflow attributes — no code change is needed to wire one into a
+workflow.
 
 ## Project Info
 
@@ -17,30 +23,115 @@ bulk.
 - **Target framework:** .NET Framework 4.7.2
 - **Deploys to:** `RockWeb/bin/` (assembly + `FFmpeg.NET.dll`, `Magick*`) and
   `RockWeb/Plugins/org_secc/` (block markup)
+- **Cross-plugin dependency:** [org.secc.PersonMatch](../org.secc.PersonMatch/README.md)
 
-## Project Layout
+## How These Actions Work
 
-Actions are grouped into one folder per area; each folder maps roughly to an action category in
-the Rock workflow editor.
+Each action is a subclass of Rock's `ActionComponent` exported via MEF. Rock discovers the
+exported components at startup, renders their declared attributes in the workflow-configuration
+UI, and calls `Execute` when a workflow activity reaches the action.
 
+```mermaid
+flowchart TD
+    A[Workflow activity reached] --> B{Rock resolves<br/>ActionComponent by type}
+    B --> C["action.Execute(rockContext, action, entity, out errorMessages)"]
+    C --> D[Read config via<br/>GetAttributeValue / GetActionAttributeValue]
+    D --> E[Resolve Lava merge fields<br/>GetMergeFields + ResolveMergeFields]
+    E --> F[Do the work<br/>e.g. set attribute, send SMS, run FFmpeg]
+    F --> G{return bool}
+    G -->|true| H[Activity continues]
+    G -->|false + errorMessages| I[Logged on the workflow action]
 ```
-/Person/              person matching & history actions
-/Communication/       SMS
-/Connections/         connection-request actions
-/Registrations/       discount codes & registrant field mapping
-/WorkflowAttributes/  attribute & attribute-matrix manipulation
-/WorkflowControl/     activate / reactivate / process / cache actions
-/Schedule/            schedule helpers
-/SignatureDocument/   signed-document storage
-/Media/               FFmpeg / ImageMagick actions
-/Twilio/              Twilio lookup
-/CMS/                 cache-tag actions
-/org_secc/Workflow/   admin blocks (.ascx)
-```
 
-## Components
+**Conventions every action follows:**
+- `[ActionCategory("SECC > …")]` — the group it appears under in the workflow editor.
+- `[ExportMetadata("ComponentName", "…")]` — the display name.
+- `[Description("…")]` — the help text.
+- Inputs are declared with `[WorkflowTextOrAttribute(...)]` (literal **or** attribute reference,
+  Lava-enabled), `[WorkflowAttribute(...)]` (attribute reference only), `[TextField]`,
+  `[BooleanField]`, etc., and read at runtime via `GetAttributeValue(action, key, checkWorkflowAttributeValue: true)`.
 
-### Blocks
+## Action Reference
+
+| Action (ComponentName) | Category | Purpose |
+|------------------------|----------|---------|
+| Person Attribute From Fields | People | Resolve/insert a person via SECC matching; optionally create. |
+| PersonAddHistory | People | Add a history record to the selected person. |
+| SMS Send | Communication | Send SMS/MMS to a person or phone number. |
+| SetConnectionRequestGroup | Connections | Set the group of a connection request. |
+| SetConnectionAttributeValue | Connections | Set attributes of a connection request. |
+| AutoApplyDiscountCode | Registrations | Apply a discount to an unpersisted RegistrationState. |
+| GenerateDiscountCode | Registrations | Generate a new discount code on a registration template. |
+| UpdateDiscountCodeWithAttribute | Registrations | Update an existing discount code. |
+| SetAttributeFromRegistrantField | Registrations | Set an attribute from a registrant field by key + index. |
+| UpdateRegistrationGroupWithPlacementGroup | Registrations | Sync a registration group with its placement group. |
+| SetAttributeValue (SECC) | Workflow Attributes | Set an attribute to the selected value. |
+| CopyAttributesFromWorkflow | Workflow Attributes | Copy attribute values between workflows. |
+| AttributeMatrix Add / Update / Delete / Copy Row | Workflow Attributes | Manipulate attribute-matrix rows. |
+| BinaryFileFromBase64String | Workflow Attributes | Save a Base64 string as a Binary File. |
+| Activate Workflow with Lava | Workflow Control | Activate a new workflow with provided attribute values. |
+| ProcessWorkflow | Workflow Control | Process another workflow with provided attribute values. |
+| ReActivateActivity | Workflow Control | Reactivate an activity and its actions. |
+| DeleteVisitActivity | Workflow Control | Delete a visit activity and its actions. |
+| ClearAuthCache | Workflow Control | Clear the authorization cache. |
+| ScheduleNextStartDate | Schedule | Get the next start date for a schedule. |
+| StoreSignedDocument | Signature Document | Create a new signature document. |
+| ClearCacheTags | CMS | Clear cached items with the selected tag(s). |
+| Lookup | Twilio | Make a Twilio Lookup API call. |
+| FFmpeg | Media | Run FFmpeg commands. |
+| ImageMontage | Media | Create JPG montages of image tiles. |
+| BinaryFileRemove | Media | Remove a Binary File. |
+
+## Detailed Actions
+
+Configuration reference for the most-used / most-complex actions. Keys in **bold** are the
+attribute keys used in code.
+
+### Person Attribute From Fields  *(People)*
+Resolves a person from loose field data using [org.secc.PersonMatch](../org.secc.PersonMatch/README.md);
+creates one when no single match is found (unless `Match Only`).
+
+| Setting | Type | Notes |
+|---------|------|-------|
+| First Name / Last Name / Date of Birth | text-or-attribute (Lava) | Identity fields used for matching. |
+| Email Address / Phone Number | text-or-attribute (Lava) | Optional; used for match + new-person creation. |
+| Unlisted / Messaging Enabled | text-or-attribute | Only `True`/`False` honored; other values ignored. |
+| Address | attribute | Address for a newly created person. |
+| Default Campus | attribute | Campus used when creating a new person. |
+| Family Group/Member | attribute | Family group/member for a newly created person. |
+| **Person Attribute** | attribute (output) | Set to the matched/created person. |
+| **Match Only** | bool (default false) | If true, never creates; only sets on a single match. |
+| **Create Nameless Person** | bool | With Match Only=false and insufficient data, create a nameless person. |
+| **Continue On Error** | bool (default false) | Let the workflow continue on incomplete data. |
+
+### Activate Workflow with Lava  *(Workflow Control)*
+| Setting | Type | Notes |
+|---------|------|-------|
+| **Workflow Name** | text (required) | Name of the new workflow. |
+| Workflow Type from Attribute | attribute | Either this or a configured Workflow Type must be set. |
+| **Workflow Attribute** | attribute (output) | Holds the newly activated workflow. |
+
+Attribute values for the new workflow are supplied via Lava — letting one workflow spin up
+another with computed values.
+
+### SMS Send  *(Communication)*
+| Setting | Type | Notes |
+|---------|------|-------|
+| **From** | text-or-attribute | Person or number; defaults to the org number `733733`. |
+| **To** (Recipient) | text-or-attribute | Person or phone number. |
+| **Message** | text-or-attribute (Lava) | Body. |
+| Attachment | attribute | MMS attachment (carrier/device dependent). |
+| **SaveCommunicationHistory** | bool (default false) | Persist a communication record (to the person if one is provided). |
+
+### FFmpeg  *(Media)*
+| Setting | Type | Notes |
+|---------|------|-------|
+| **File** | text-or-attribute | Source file; available as `{{file}}` in the command. |
+| **Command** | text (Lava) | FFmpeg parameters; `{{file}}` and `{{outputPath}}` merge fields available. |
+| **FFmpegExecutable** | text | Path to `ffmpeg.exe` (default points into an ImageMagick install dir). |
+| **OutputPath** | attribute | Output dir; if empty a temp dir is created and written back to the attribute. |
+
+## Blocks
 
 Category in Rock: **SECC > Workflow**.
 
@@ -49,63 +140,65 @@ Category in Rock: **SECC > Workflow**.
 | Workflow Bulk Select | Tool for bulk-selecting workflows. |
 | Workflow Bulk Update | Tool for updating workflows in bulk. |
 
-### Workflow Actions
-
-| Action | Area | Purpose |
-|--------|------|---------|
-| GetPersonFromFields | Person | Set an attribute to a person via SECC custom matching; optionally create a new person. |
-| PersonAddHistory | Person | Add a history record to the selected person. |
-| SendSms | Communication | Send an SMS to a person or a phone number in the `To` field. |
-| SetConnectionRequestGroup | Connections | Set the group of a connection request. |
-| SetConnectionAttributeValue | Connections | Set attributes of a connection request. |
-| AutoApplyDiscountCode | Registrations | Apply a discount code to an unpersisted RegistrationState. |
-| GenerateDiscountCode | Registrations | Generate a new discount code on a registration template. |
-| UpdateDiscountCodeWithAttribute | Registrations | Update an existing discount code on a registration template. |
-| SetAttributeFromRegistrantField | Registrations | Set an attribute from a registrant field by key + registrant index. |
-| UpdateRegistrationGroupWithPlacementGroup | Registrations | Sync a registration group with its placement group. |
-| SetAttributeValue | WorkflowAttributes | Set an attribute's value to the selected value. |
-| CopyAttributesFromWorkflow | WorkflowAttributes | Copy attribute values from one workflow to another. |
-| AttributeMatrixAddRow / UpdateRow / DeleteRow / Copy | WorkflowAttributes | Add / update / delete / clone attribute-matrix rows. |
-| BinaryFileFromBase64String | WorkflowAttributes | Save a Base64 string as a Binary File. |
-| ActivateWorkflowWithLava | WorkflowControl | Activate a new workflow with provided attribute values. |
-| ProcessWorkflow | WorkflowControl | Process another workflow with provided attribute values. |
-| ReActivateActivity | WorkflowControl | Reactivate an activity instance and its actions. |
-| DeleteVisitActivity | WorkflowControl | Delete a visit activity instance and its actions. |
-| ClearAuthCache | WorkflowControl | Clear the authorization cache. |
-| ScheduleNextStartDate | Schedule | Get the next start date for a schedule. |
-| StoreSignedDocument | SignatureDocument | Create a new signature document. |
-| ClearCacheTags | CMS | Clear all cached items with the selected tag(s). |
-| Lookup | Twilio | Make a Twilio Lookup API call. |
-| FFmpeg | Media | Run FFmpeg commands. |
-| ImageMontage | Media | Create JPG montages of image tiles. |
-| BinaryFileRemove | Media | Remove a Binary File. |
-
 ## Dependencies & Integrations
 
 - **Rock:** workflow engine (`ActionComponent`), `RockContext`, connections, registrations, CMS cache.
-- **Cross-plugin:** references [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) (used by `GetPersonFromFields`).
+- **Cross-plugin:** [org.secc.PersonMatch](../org.secc.PersonMatch/README.md) (used by *Person Attribute From Fields*).
 - **Third-party:** Twilio (lookup), FFmpeg.NET (video/audio), Magick.NET / ImageMagick (image montages).
+
+## Edge Cases & Constraints
+
+- **`FFmpeg.Command` is Lava-resolved and passed to the FFmpeg engine** including the `{{file}}`
+  merge field. If `File` can come from untrusted input, that's an argument/command-injection
+  vector — see Observations.
+- **`FFmpeg` runs sync-over-async** (`Task.Run(...).Wait()`) with no timeout; it blocks the
+  workflow thread on an external process.
+- **Person matching can create records.** *Person Attribute From Fields* will insert a person
+  unless `Match Only` is set — review that flag in any workflow that takes public input.
 
 ## Observations
 
 *Noticed while documenting — not a full audit; the `Media/FFmpeg` action stood out.*
 
 - **Security (review):** `FFmpeg` resolves the admin-configured `Command` (Lava, including the
-  `{{file}}` and `{{outputPath}}` merge fields) and passes it straight to the FFmpeg engine. If the
-  `File` workflow attribute can be populated from untrusted input (e.g. a registrant upload/field),
-  that string is interpolated into the command — an argument/command-injection vector. Treat this
-  action as admin-trusted-only and validate/sanitize the `file` value. `OutputPath` is also used to
-  `Directory.CreateDirectory` with no path-traversal guard, so it can write outside the intended root.
-- **Improvement:** `Task.Run( … ).Wait()` is sync-over-async — it blocks the workflow thread on an
-  external process and risks deadlock; there's also no timeout on the FFmpeg run. The default
-  `FFmpegExecutable` is a hardcoded path into an ImageMagick install folder
-  (`C:\Program Files\ImageMagick-…\ffmpeg.exe`), which is brittle and likely wrong on most servers.
+  `{{file}}` / `{{outputPath}}` merge fields) and passes it straight to the FFmpeg engine. If the
+  `File` attribute can be populated from untrusted input (e.g. a registrant upload/field), that
+  string is interpolated into the command — an argument/command-injection vector. Treat this
+  action as admin-trusted-only and validate/sanitize `file`. `OutputPath` is used to
+  `Directory.CreateDirectory` with no path-traversal guard.
+- **Improvement:** `Task.Run( … ).Wait()` is sync-over-async (blocks the workflow thread; deadlock
+  risk) with no timeout on the FFmpeg run. The default `FFmpegExecutable` is a hardcoded path into
+  an ImageMagick install folder (`C:\Program Files\ImageMagick-…\ffmpeg.exe`), brittle on most servers.
+
+## Extending
+
+To add an action, drop a class in the relevant area folder following this shape:
+
+```csharp
+[ActionCategory( "SECC > Workflow Control" )]
+[Description( "What it does." )]
+[Export( typeof( ActionComponent ) )]
+[ExportMetadata( "ComponentName", "My Action" )]
+[WorkflowTextOrAttribute( "Some Input", "Some Input", "Help text.", true, "", "", 0, "SomeInput" )]
+public class MyAction : ActionComponent
+{
+    public override bool Execute( RockContext rockContext, WorkflowAction action,
+        object entity, out List<string> errorMessages )
+    {
+        errorMessages = new List<string>();
+        var input = GetAttributeValue( action, "SomeInput", true );
+        // … do work …
+        return true;
+    }
+}
+```
+
+No registration step is required — MEF discovers `[Export(typeof(ActionComponent))]` at startup,
+and the attributes render the configuration UI automatically.
 
 ## Making Changes
 
-- To add an action, create a class in the appropriate area folder that subclasses Rock's
-  `ActionComponent` and carries the standard `[Description]` / `[ActionCategory]` /
-  `[Export]` attributes; follow an existing sibling as a template.
-- Media actions require the `FFmpeg.NET` and `Magick*` assemblies to be present in `RockWeb/bin`
-  (handled by the PostBuildEvent).
-- `GetPersonFromFields` depends on [org.secc.PersonMatch](../org.secc.PersonMatch/README.md); person-matching changes may belong there.
+- Add new actions in the matching area folder (`Person/`, `Communication/`, …); follow an existing
+  sibling as a template.
+- Media actions require `FFmpeg.NET` and `Magick*` in `RockWeb/bin` (handled by the PostBuildEvent).
+- Person-matching behavior lives in [org.secc.PersonMatch](../org.secc.PersonMatch/README.md), not here.

--- a/Plugins/org.secc.WorkflowLauncher/README.md
+++ b/Plugins/org.secc.WorkflowLauncher/README.md
@@ -1,0 +1,112 @@
+# org.secc.WorkflowLauncher
+
+> Tools for launching and bulk-managing Rock workflows over groups, registrations, data views, and arbitrary SQL result sets.
+
+## Overview
+
+WorkflowLauncher is a small bag of Southeast's workflow-firing utilities: a scheduled **job** that
+launches a workflow for every row of a SQL query or every entity in a Data View, and a set of
+**blocks** for staff to launch workflows from the admin UI (pick a group / registration / data view,
+or pass an entity by querystring) and to bulk-select and bulk-update existing workflows. It is used
+to mass-start or mass-edit workflows without touching each one individually.
+
+## Project Info
+
+- **Project file:** `org.secc.WorkflowLauncher.csproj`
+- **Root namespace:** `org.secc.WorkflowLauncher`
+- **Target framework:** .NET Framework 4.7.2
+- **Deploys to:** `RockWeb/bin/` (assembly) and `RockWeb/Plugins/org_secc/` (block `.ascx` markup), via the PostBuildEvent `xcopy`
+
+## Project Layout
+
+```
+/                       WorkflowLauncher.cs — Quartz IJob (SQL/DataView row -> workflow launcher)
+/org_secc/Workflow/     UI blocks (.ascx + .ascx.cs):
+                          WorkflowLauncher      — launch from Group / RegistrationInstance / DataView
+                          WorkflowEntityLaunch  — launch one workflow for an entity passed by querystring
+                          WorkflowBulkSelect    — grid of a workflow type's instances -> EntitySet
+                          WorkflowBulkUpdate    — bulk attribute/status/activity edit over an EntitySet
+/Migrations/            Rock plugin migration (Workflow Launcher page + block)
+```
+
+## Components
+
+### Jobs
+
+A single Quartz `IJob` (`[DisallowConcurrentExecution]`). Note its namespace is `org.secc.Jobs`, not
+`org.secc.WorkflowLauncher`. Configuration is per-job via Rock job attributes (read from the `JobDataMap`).
+
+| Job (class) | Purpose | Key settings |
+|-------------|---------|--------------|
+| `WorkflowLauncher` | Launch the selected workflow once per SQL-query row (columns auto-mapped to workflow attributes by name) and/or once per entity in a Data View. | **SQLQuery**, **DataView**, **CommandTimeout**, **Workflow** |
+
+### Blocks
+
+Category in Rock: **SECC > Workflow** / **SECC > WorkFlow** (the bulk pair use the latter casing).
+
+| Block | Purpose | Key settings |
+|-------|---------|--------------|
+| Workflow Launcher | Launch a chosen workflow type for a Group's members, a Registration Instance's registrations (one or all), or a Person Data View's people. | (none — `WorkflowTypeField` is picked in the UI) |
+| Workflow Entity Launch | Launch one workflow for a single entity resolved from the `EntityId` querystring; group-member launches preset `Group`/`Person` attributes. | **EntityType**, **WorkflowType** |
+| Workflow Bulk Select | Filterable grid of one workflow type's instances (the type comes from the `WorkflowTypeId` page parameter; a picker is shown if absent); selected (or all filtered) rows are pushed into a 1-day `EntitySet` and handed to the update page. | **UpdatePage** (linked page); reads `WorkflowTypeId` page parameter |
+| Workflow Bulk Update | Over the `EntitySetId`'s workflows: set attribute values (Lava-resolved), reactivate/complete, set status, and activate a new activity, then re-process each. | (none — reads `EntitySetId` page parameter) |
+
+The `WorkflowEntityLaunch` block resolves the entity service/`Get`/`LaunchWorkflow` reflectively from
+the configured `EntityType`, so it works against any entity type that exposes a `LaunchWorkflow`
+extension. The `WorkflowLauncher` block restricts its entity-type dropdown to Group, Registration
+Instance, and Data View.
+
+## Dependencies & Integrations
+
+- **Rock:** Quartz job framework (`IJob`, `JobDataMap`), `RockContext` and Rock services
+  (`WorkflowService`, `DataViewService`, `RegistrationService`, `GroupMemberService`, `EntitySetService`,
+  `AttributeService`), `DbService.GetDataSet` (raw SQL), the workflow engine (`Workflow.Activate` /
+  `LaunchWorkflow` extensions), attribute/cache framework, `RockBlock` UI, plugin migrations.
+- **Third-party:** Newtonsoft.Json (bulk-select filter value (de)serialization), DotLiquid (Lava merge-field resolution in bulk update).
+- **Cross-plugin:** none required at build time.
+
+## Migrations
+
+Ships one Rock plugin migration under `/Migrations/`:
+
+- `20180630120000_InitialCreate` (`MigrationNumber 1`, `1.7.0`) — adds the **Workflow Launcher** page
+  under Rock RMS, registers the `WorkflowLauncher.ascx` block type, and places the block on the page.
+
+## Observations
+
+*Noticed while documenting — not a full audit.*
+
+- **Security (medium):** The `WorkflowLauncher` job runs an **operator-supplied SQL Query** verbatim
+  via `DbService.GetDataSet` with no parameterization or restriction. That's by design (the job
+  attribute is a SQL code editor), but it means anyone who can configure/edit this Rock Job can run
+  arbitrary SQL under Rock's DB credentials. Confirm Jobs admin is locked to trusted staff.
+- **Improvement:** Only the `WorkflowLauncher.ascx` block has a migration registering its block
+  type/page. `WorkflowEntityLaunch`, `WorkflowBulkSelect`, and `WorkflowBulkUpdate` ship `.ascx`
+  markup but have **no migration** — their block types/pages must be created by hand in Rock (or
+  installed by another plugin) or they're effectively dormant. Worth a migration if they're meant to
+  be deployed.
+- **Improvement:** The bulk-select/bulk-update blocks live in namespace
+  `RockWeb.Plugins.org_secc.WorkFlowUpdate` (note the capital `F` and the `Update` segment) while the
+  other two blocks use `...org_secc.Workflow`. Inconsistent namespacing/category casing
+  (`SECC > Workflow` vs `SECC > WorkFlow`) is easy to trip over when wiring pages.
+- **Improvement:** In the `WorkflowLauncher` block, `BindData()` opens an outer `RockContext` but then
+  news up a **second** `RockContext` inline for the `EntityTypeService` query — one context would do.
+- **Improvement:** `WorkflowBulkUpdate` re-processes each workflow on a **fresh `RockContext` per
+  workflow** inside the loop (`new WorkflowService( new RockContext() )`), separate from the context
+  that saved the changes. Fine for small sets, wasteful and inconsistent for large ones.
+
+## Making Changes
+
+- To change row-driven launching (SQL/DataView), edit `WorkflowLauncher.cs`; its config (query, data
+  view, workflow, timeout) is all Rock Job attributes — no code change to re-point it.
+- To change the admin launch UI (which entity types are offered, how attributes are seeded), edit
+  `org_secc/Workflow/WorkflowLauncher.ascx.cs` or `WorkflowEntityLaunch.ascx.cs`.
+- The bulk select/update flow keys off an `EntitySet`: `WorkflowBulkSelect` builds it and links to the
+  update page; `WorkflowBulkUpdate` reads `EntitySetId`. Edit the matching `.ascx.cs` and keep the
+  linked-page wiring intact.
+- New pages/blocks belong in a new numbered migration under `/Migrations/` — don't hand-edit the one
+  that has already run.
+- Related: [org.secc.Workflow](../org.secc.Workflow/README.md) (custom workflow actions) and the
+  workflow-closing jobs in [org.secc.Jobs](../org.secc.Jobs/README.md).
+</content>
+</invoke>


### PR DESCRIPTION
## ROCK-8615 — Document Rock Plugins in Markdown

Draft PR for **format review** before documenting all ~54 plugins. This pilot now shows **both documentation tiers** so reviewers can compare.

_(Supersedes #232, which was closed automatically when the branch was renamed.)_

### Tiers (agreed approach: tiered — deep where it pays, standard for the rest)
- **Standard tier** — Overview → Project Info → Project Layout → Components → Dependencies → Migrations → Observations → Making Changes. Used for the bulk of plugins.
  - `Plugins/org.secc.QRManager/README.md` — small (Lava filters + REST endpoint)
  - `Plugins/org.secc.PastoralCare/README.md` — medium (blocks + migrations)
- **Deep tier** — adds an execution data-flow (Mermaid) diagram, component contracts, per-item config-attribute reference, edge cases, and an extending guide. Reserved for high-traffic / complex / externally-facing plugins (e.g. Rest, Workflow, OAuth, payment plugins).
  - `Plugins/org.secc.Workflow/README.md` — large (29 workflow actions + 2 blocks) **← deep-tier sample**

> Note: the Mermaid diagram in the Workflow README renders natively in GitHub's file/PR view.

- **Audience:** internal SECC developers + AI coding agents.
- **Observations** sections capture security/improvement notes found while documenting (not a full audit). Notable example: the `Media/FFmpeg` workflow action interpolates Lava merge fields into a command string — worth a look.
- A top-level `Plugins/README.md` index (catalog grouped by inferred category) will be added with the full set.

### What we're asking reviewers
1. Is the **standard tier** the right depth for most plugins (dev opening a plugin cold + AI agents)?
2. Is the **deep tier** worth its extra effort/upkeep for the high-value plugins — and is the split right?
3. Keep the **Observations** section (security/improvement notes) inline, or split it out?
4. Any structure changes before we generate the remaining ~51 plugin READMEs?

### Not in scope (separate follow-up ticket)
Repo-root README, ARCHITECTURE.md, CONTRIBUTING.md, AGENTS.md/CLAUDE.md, CI link-checker.