### PR TITLE
ROCK-8637 Fix IDOR / broken access control findings

### DIFF
--- a/Plugins/org.secc.Cms/org_secc/Cms/LinkListEditUsers.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/LinkListEditUsers.ascx.cs
@@ -262,40 +262,78 @@ namespace RockWeb.Plugins.org_secc.Cms
             }
         }
 
+        /// <summary>
+        /// Re-resolves and re-authorizes the editors security group for a mutating postback.
+        /// The security group must NEVER be trusted from the hfSecurityGroupId hidden field: an
+        /// attacker can tamper it to an arbitrary security role (e.g. RSR - Rock Administration) and
+        /// escalate privileges. Instead re-derive the group from the content channel item and re-run
+        /// the same EDIT authorization check LoadLinkList performs, so the gate runs on every state
+        /// change rather than only on the initial (non-postback) load. Returns null (and shows a
+        /// notification) when the current person is not authorized to edit this list.
+        /// </summary>
+        private int? GetAuthorizedEditorsGroupId()
+        {
+            var contentChannelItemId = hfContentChannelItemId.Value.AsInteger();
+            using (var rockContext = new RockContext())
+            {
+                var contentItem = new ContentChannelItemService( rockContext ).Get( contentChannelItemId );
+                if (contentItem == null
+                    || !contentItem.IsAuthorized( Rock.Security.Authorization.EDIT, CurrentPerson ))
+                {
+                    ShowNotification( NotificationBoxType.Danger,
+                        "<strong><i class=\"fas fa-exclamation-triangle\"></i> Not Authorized</strong><br /> You do not have edit rights to this Link List." );
+                    return null;
+                }
+
+                return GetListEditorsGroup( contentItem ).Id;
+            }
+        }
+
         private void GroupMemberAdd( int personId )
         {
-            var groupId = hfSecurityGroupId.Value.AsInteger();
+            var groupId = GetAuthorizedEditorsGroupId();
+            if (groupId == null)
+            {
+                return;
+            }
 
             using (var rockContext = new RockContext())
             {
                 var defaultRoleId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_SECURITY_ROLE )
                     .DefaultGroupRoleId;
                 var groupService = new GroupService( rockContext );
-                var group = groupService.Get( groupId );
+                var group = groupService.Get( groupId.Value );
                 var groupMemberService = new GroupMemberService( rockContext );
                 groupMemberService.AddOrRestoreGroupMember( group, personId, defaultRoleId.Value );
                 rockContext.SaveChanges();
             }
 
-            LoadEditorList( groupId );
+            LoadEditorList( groupId.Value );
 
         }
 
         private void GroupMemberRemove( int groupMemberId )
         {
-            var groupId = hfSecurityGroupId.Value.AsInteger();
+            var groupId = GetAuthorizedEditorsGroupId();
+            if (groupId == null)
+            {
+                return;
+            }
+
             using (var rockContext = new RockContext())
             {
                 var groupMemberService = new GroupMemberService( rockContext );
                 var groupMember = groupMemberService.Get( groupMemberId );
 
-                if (groupMember.GroupId == groupId)
+                // Guard against a missing/stale groupMemberId, and only allow removal from the
+                // authorized editors group (never a member of some other group via a tampered id).
+                if (groupMember != null && groupMember.GroupId == groupId.Value)
                 {
                     groupMemberService.Delete( groupMember );
                     rockContext.SaveChanges();
                 }
 
-                LoadEditorList( groupId );
+                LoadEditorList( groupId.Value );
 
             }
         }

--- a/Plugins/org.secc.Cms/org_secc/Cms/PublicProfileEdit.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/PublicProfileEdit.ascx.cs
@@ -327,6 +327,21 @@ namespace RockWeb.Plugins.org_secc.Cms
                 var group = new GroupService( rockContext ).Get( ddlGroup.SelectedValueAsId().Value );
                 if ( group != null )
                 {
+                    // Ownership gate (IDOR write): ddlGroup and hfPersonId are both client-controlled
+                    // postback values. Validate them against the current person server-side before any
+                    // write: the posted group must be one of the current person's families (ddlGroup is
+                    // populated from CurrentPerson.GetFamilies()), and an existing person being edited
+                    // must be the current person or a member of that family. Reject tampered values.
+                    var allowedFamilyIds = CurrentPerson.GetFamilies().Select( f => f.Id ).ToList();
+                    var postedPersonId = hfPersonId.Value.AsInteger();
+                    if ( !allowedFamilyIds.Contains( group.Id )
+                        || ( postedPersonId != 0
+                            && postedPersonId != CurrentPerson.Id
+                            && !group.Members.Any( m => m.PersonId == postedPersonId ) ) )
+                    {
+                        return;
+                    }
+
                     rockContext.WrapTransaction( () =>
                     {
                         var personService = new PersonService( rockContext );

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupDetailLava.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupDetailLava.ascx.cs
@@ -38,6 +38,24 @@ namespace RockWeb.Plugins.org_secc.GroupManager
                 NavigateToHomePage();
                 return;
             }
+
+            // Object-level authorization (IDOR): the base block loads CurrentGroup straight from the
+            // GroupId request parameter with no authorization. The sibling blocks (GroupRoster,
+            // GroupManagerAttendance, etc.) each enforce their own check; this display block did not,
+            // so an authenticated user could swap GroupId to render an arbitrary group (incl. member
+            // PII) via the Lava template. Follow the same per-block pattern here. The condition is
+            // intentionally permissive (VIEW, EDIT, or MANAGE_MEMBERS, or active membership) so that,
+            // e.g., a coach with EDIT-but-not-VIEW on a group they oversee is not bounced; it only
+            // fails closed for users with no relationship to the group at all.
+            if ( CurrentGroupMember == null
+                && !CurrentGroup.IsAuthorized( Rock.Security.Authorization.VIEW, CurrentPerson )
+                && !CurrentGroup.IsAuthorized( Rock.Security.Authorization.EDIT, CurrentPerson )
+                && !CurrentGroup.IsAuthorized( Rock.Security.Authorization.MANAGE_MEMBERS, CurrentPerson ) )
+            {
+                NavigateToHomePage();
+                return;
+            }
+
             Dictionary<string, object> MergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( RockPage, CurrentPerson );
             MergeFields.Add( "Group", CurrentGroup );
 


### PR DESCRIPTION
## Summary

  Closes a set of IDOR / broken-access-control issues where these blocks trusted a client-supplied id (query-string or hidden field) to pick which record to read/write without checking the user was authorized on that specific object now each action re-derives the target server-side and re-authorizes it.

| Row | File | Finding | Resolution |
|-----|------|---------|------------|
| 6 | `GroupManagerBlock.cs` (base) | Base loads `CurrentGroup` from `GroupId` with no authz | Covered by row 10 — base stays unauth by design; all derived blocks self-guard |
| 7 | `FinancialTransactionsExtensionsController` | REST action returns contribution PII | **No action** — POST→`[Secured]` Edit, Staff-only, non-staff get 401; accepted internal risk |
| 8 | `PublicProfileEdit.ascx.cs` | IDOR write — trusts `hfPersonId` on save | **Fixed** — server-side ownership gate against `CurrentPerson.GetFamilies()` |
| 9 | `LinkListEditUsers.ascx.cs` | Privilege escalation — trusts `hfSecurityGroupId` on postback | **Fixed** — re-resolve group + re-run `IsAuthorized(EDIT)` per mutating postback |
| 10 | `GroupDetailLava.ascx.cs` | IDOR read — swap `GroupId` to view arbitrary group PII | **Fixed** — object-level VIEW/EDIT/MANAGE_MEMBERS-or-membership check in `OnLoad` |

## Notes

- Authorization conditions are intentionally **permissive** (VIEW *or* EDIT *or* MANAGE_MEMBERS *or* active membership) so oversight roles (e.g. a coach with EDIT-but-not-VIEW) aren't bounced — they fail closed only for users with no relationship to the group.
- Behavior is unchanged for legitimate users; these add deny-path gates only.


<img width="1840" height="1900" alt="ROCK-8637-PR235-board" src="https://github.com/user-attachments/assets/40b9decf-8566-474c-a343-0efc3308b2f7" />