### PR TITLE
ROCK-8639 Fix IDOR view + PIN privilege-escalation findings

### DIFF
--- a/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/SuperCheckin.ascx.cs
+++ b/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/SuperCheckin.ascx.cs
@@ -1546,9 +1546,8 @@ try{{
                         {
                             maWarning.Show( "Unable to add PIN to person. This person is in a security role and cannot have a PIN added from this tool.", ModalAlertType.Warning );
                             mdPIN.Hide();
-                            // Must return: without it, execution falls through and a PIN UserLogin is
-                            // created for the security-role member anyway, defeating this guard and
-                            // letting an operator mint a PIN credential for a privileged account.
+                            // Without this return, execution falls through and mints the PIN anyway,
+                            // defeating the security-role guard (privilege escalation).
                             return;
                         }
 

--- a/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/SuperCheckin.ascx.cs
+++ b/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/SuperCheckin.ascx.cs
@@ -1546,6 +1546,10 @@ try{{
                         {
                             maWarning.Show( "Unable to add PIN to person. This person is in a security role and cannot have a PIN added from this tool.", ModalAlertType.Warning );
                             mdPIN.Hide();
+                            // Must return: without it, execution falls through and a PIN UserLogin is
+                            // created for the security-role member anyway, defeating this guard and
+                            // letting an operator mint a PIN credential for a privileged account.
+                            return;
                         }
 
                         var userLoginService = new UserLoginService( _rockContext );

--- a/Plugins/org.secc.Communication/org_secc/Communication/ManageCommunicationLists.ascx.cs
+++ b/Plugins/org.secc.Communication/org_secc/Communication/ManageCommunicationLists.ascx.cs
@@ -70,22 +70,14 @@ namespace RockWeb.Plugins.org_secc.Communication
                 var param = PageParameter( "p" );
                 if ( param.IsNotNullOrWhiteSpace() )
                 {
-                    // Resolve the acting person from a Rock impersonation token (high-entropy,
-                    // expiring, usage-limited), matching the secure pattern used by ContactGroupLeaders.
-                    // Previously this matched on a guessable GUID *suffix* (Guid.EndsWith with only a
-                    // length>=12 guard), which let an anonymous caller resolve an arbitrary person and
-                    // then overwrite their Email/EmailPreference and mobile number (account takeover via
-                    // password reset). A raw or partial Person GUID is NOT an access-control token.
-                    // Safe to change with no companion work: this ?p= path has no live generator — the
-                    // newsletter "manage subscriptions" link is a bare /s (no token), verified in both the
-                    // codebase and the Rock DB — so tightening it here breaks no existing link.
+                    // Resolve via a Rock impersonation token, not a guessable GUID suffix (the old
+                    // Guid.EndsWith match let an anonymous caller resolve any person and overwrite their
+                    // email/phone -> account takeover). Mirrors ContactGroupLeaders. Safe with no companion
+                    // change: the ?p= link has no live generator (the newsletter link is a bare /s).
                     RockContext rockContext = new RockContext();
                     PersonService personService = new PersonService( rockContext );
-                    // incrementUsage:false — OnInit re-runs on every postback and Person is not persisted
-                    // across them, so for the anonymous ?p= flow this resolves on each Subscribe/UpdateEmail
-                    // click. Counting usage here would burn a usage-limited token after a few clicks and lock
-                    // the visitor out mid-session. The token's entropy + expiry remain the protection; usage
-                    // limiting is incompatible with a page the person interacts with repeatedly.
+                    // incrementUsage:false: OnInit runs on every postback, so counting usage would burn a
+                    // usage-limited token mid-session; the token's entropy + expiry remain the protection.
                     Person = personService.GetByImpersonationToken( param, false, null );
                 }
             }

--- a/Plugins/org.secc.Communication/org_secc/Communication/ManageCommunicationLists.ascx.cs
+++ b/Plugins/org.secc.Communication/org_secc/Communication/ManageCommunicationLists.ascx.cs
@@ -68,16 +68,22 @@ namespace RockWeb.Plugins.org_secc.Communication
             if ( Person == null )
             {
                 var param = PageParameter( "p" );
-                if ( param.IsNotNullOrWhiteSpace() && param.Length >= 12 )
+                if ( param.IsNotNullOrWhiteSpace() )
                 {
+                    // Resolve the acting person from a Rock impersonation token (high-entropy,
+                    // expiring, usage-limited), matching the secure pattern used by ContactGroupLeaders.
+                    // Previously this matched on a guessable GUID *suffix* (Guid.EndsWith with only a
+                    // length>=12 guard), which let an anonymous caller resolve an arbitrary person and
+                    // then overwrite their Email/EmailPreference and mobile number (account takeover via
+                    // password reset). A raw or partial Person GUID is NOT an access-control token.
                     RockContext rockContext = new RockContext();
                     PersonService personService = new PersonService( rockContext );
-                    var people = personService.Queryable().Where( p => p.Guid.ToString().EndsWith( param ) ).ToList();
-                    if ( people.Count == 1 )
-                    {
-                        Person = people.FirstOrDefault();
-                    }
-
+                    // incrementUsage:false — OnInit re-runs on every postback and Person is not persisted
+                    // across them, so for the anonymous ?p= flow this resolves on each Subscribe/UpdateEmail
+                    // click. Counting usage here would burn a usage-limited token after a few clicks and lock
+                    // the visitor out mid-session. The token's entropy + expiry remain the protection; usage
+                    // limiting is incompatible with a page the person interacts with repeatedly.
+                    Person = personService.GetByImpersonationToken( param, false, null );
                 }
             }
 

--- a/Plugins/org.secc.Communication/org_secc/Communication/ManageCommunicationLists.ascx.cs
+++ b/Plugins/org.secc.Communication/org_secc/Communication/ManageCommunicationLists.ascx.cs
@@ -68,17 +68,16 @@ namespace RockWeb.Plugins.org_secc.Communication
             if ( Person == null )
             {
                 var param = PageParameter( "p" );
-                if ( param.IsNotNullOrWhiteSpace() )
+                if ( param.IsNotNullOrWhiteSpace() && param.Length >= 12 )
                 {
-                    // Resolve via a Rock impersonation token, not a guessable GUID suffix (the old
-                    // Guid.EndsWith match let an anonymous caller resolve any person and overwrite their
-                    // email/phone -> account takeover). Mirrors ContactGroupLeaders. Safe with no companion
-                    // change: the ?p= link has no live generator (the newsletter link is a bare /s).
                     RockContext rockContext = new RockContext();
                     PersonService personService = new PersonService( rockContext );
-                    // incrementUsage:false: OnInit runs on every postback, so counting usage would burn a
-                    // usage-limited token mid-session; the token's entropy + expiry remain the protection.
-                    Person = personService.GetByImpersonationToken( param, false, null );
+                    var people = personService.Queryable().Where( p => p.Guid.ToString().EndsWith( param ) ).ToList();
+                    if ( people.Count == 1 )
+                    {
+                        Person = people.FirstOrDefault();
+                    }
+
                 }
             }
 

--- a/Plugins/org.secc.Communication/org_secc/Communication/ManageCommunicationLists.ascx.cs
+++ b/Plugins/org.secc.Communication/org_secc/Communication/ManageCommunicationLists.ascx.cs
@@ -76,6 +76,9 @@ namespace RockWeb.Plugins.org_secc.Communication
                     // length>=12 guard), which let an anonymous caller resolve an arbitrary person and
                     // then overwrite their Email/EmailPreference and mobile number (account takeover via
                     // password reset). A raw or partial Person GUID is NOT an access-control token.
+                    // Safe to change with no companion work: this ?p= path has no live generator — the
+                    // newsletter "manage subscriptions" link is a bare /s (no token), verified in both the
+                    // codebase and the Rock DB — so tightening it here breaks no existing link.
                     RockContext rockContext = new RockContext();
                     PersonService personService = new PersonService( rockContext );
                     // incrementUsage:false — OnInit re-runs on every postback and Person is not persisted

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/RequisitionDetail.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/RequisitionDetail.ascx.cs
@@ -464,7 +464,7 @@ namespace RockWeb.Plugins.org_secc.Purchasing
                 {
                     isCreator = ( bool ) ViewState[BlockId + "_UserIsCreator"];
                 }
-                else if ( CurrentRequisition != null && CurrentRequisition.CreatedBy.PrimaryAliasId == CurrentPerson.PrimaryAliasId )
+                else if ( CurrentRequisition != null && CurrentRequisition.CreatedBy != null && CurrentRequisition.CreatedBy.PrimaryAliasId == CurrentPerson.PrimaryAliasId )
                 {
                     isCreator = true;
                     ViewState[BlockId + "_UserIsCreator"] = isCreator;
@@ -943,12 +943,22 @@ namespace RockWeb.Plugins.org_secc.Purchasing
 
         protected void ucAttachments_RefreshParent( object sender, EventArgs e )
         {
+            // Defense-in-depth: these child-control refresh handlers re-query the model outside the
+            // LoadRequisition gate, so re-check view authorization (see UserCanViewRequisition).
+            if ( !UserCanViewRequisition() )
+            {
+                return;
+            }
             CurrentRequisition.RefreshAttachments();
             LoadIcons();
         }
 
         protected void ucNotes_RefreshParent( object sender, EventArgs e )
         {
+            if ( !UserCanViewRequisition() )
+            {
+                return;
+            }
             CurrentRequisition.RefreshNotes();
             LoadIcons();
         }
@@ -1376,8 +1386,56 @@ namespace RockWeb.Plugins.org_secc.Purchasing
             }
         }
 
+        /// <summary>
+        /// Object-level view authorization (IDOR). RequisitionID is read from the querystring with no
+        /// ownership check (see the RequisitionID property), so without this gate any authenticated
+        /// user can view any requisition by changing the id. Mirrors the sibling
+        /// CapitalRequestDetail.UserCanView(). Edit gating (CanUserEditSummary / SetSummaryVisibility)
+        /// only disables inputs; it does NOT prevent the data from being loaded and displayed.
+        /// </summary>
+        private bool UserCanViewRequisition()
+        {
+            // A new requisition (no persisted id yet) is always viewable.
+            if ( RequisitionID <= 0 || CurrentRequisition == null || CurrentRequisition.RequisitionID != RequisitionID )
+            {
+                return true;
+            }
+
+            // Fail closed for a person-less session. This is a staff block (CurrentPerson is normally
+            // set), but the involvement helpers below dereference CurrentPerson / its PrimaryAliasId,
+            // so guard explicitly now that this runs for every authenticated viewer of every id.
+            if ( CurrentPerson == null || CurrentPerson.PrimaryAliasId == null )
+            {
+                return false;
+            }
+
+            // The requester themselves.
+            if ( CurrentPerson.PrimaryAliasId == CurrentRequisition.RequesterID )
+            {
+                return true;
+            }
+
+            // Creator, requester's/creator's ministry, an approver, or block edit/admin rights
+            // (the same relationships the block already uses to decide edit-ability).
+            if ( UserIsCreator || RequesterIsInMyMinitry || CreatorIsInMyMinistry || UserIsApprover || UserCanEdit )
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         private void LoadRequisition()
         {
+            // Object-level view authorization (IDOR): refuse to render a requisition the current user
+            // does not own / is not involved with. Return BEFORE any Load* call so no requisition data
+            // (summary, items, notes, attachments, approvals, charges) is ever populated.
+            if ( !UserCanViewRequisition() )
+            {
+                SetSummaryError( "You are not authorized to view this requisition. Click \"Return to List\" to continue." );
+                return;
+            }
+
             LoadIcons();
             LoadSummary();
             LoadItems();
@@ -1398,6 +1456,15 @@ namespace RockWeb.Plugins.org_secc.Purchasing
 
         private void LoadSummary()
         {
+            // Object-level view authorization (IDOR): LoadSummary is also reached directly from postback
+            // handlers, not just the gated LoadRequisition, so re-check here. UserCanViewRequisition()
+            // returns true for new requisitions and for anyone with view/edit involvement (edit rights
+            // are a subset of view rights), so legitimate flows are unaffected.
+            if ( !UserCanViewRequisition() )
+            {
+                return;
+            }
+
             ClearSummary();
             SetSummaryVisibility();
 
@@ -1446,6 +1513,12 @@ namespace RockWeb.Plugins.org_secc.Purchasing
 
         private void LoadItems()
         {
+            // Object-level view authorization (IDOR): LoadItems is reached directly from postback
+            // handlers too, so re-check (see LoadSummary). Safe for new requisitions / authorized users.
+            if ( !UserCanViewRequisition() )
+            {
+                return;
+            }
 
             ConfigureItemGrid();
 

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/RequisitionDetail.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/RequisitionDetail.ascx.cs
@@ -943,8 +943,7 @@ namespace RockWeb.Plugins.org_secc.Purchasing
 
         protected void ucAttachments_RefreshParent( object sender, EventArgs e )
         {
-            // Defense-in-depth: these child-control refresh handlers re-query the model outside the
-            // LoadRequisition gate, so re-check view authorization (see UserCanViewRequisition).
+            // IDOR re-check: refresh handlers re-query the model outside the LoadRequisition gate.
             if ( !UserCanViewRequisition() )
             {
                 return;
@@ -1387,36 +1386,31 @@ namespace RockWeb.Plugins.org_secc.Purchasing
         }
 
         /// <summary>
-        /// Object-level view authorization (IDOR). RequisitionID is read from the querystring with no
-        /// ownership check (see the RequisitionID property), so without this gate any authenticated
-        /// user can view any requisition by changing the id. Mirrors the sibling
-        /// CapitalRequestDetail.UserCanView(). Edit gating (CanUserEditSummary / SetSummaryVisibility)
-        /// only disables inputs; it does NOT prevent the data from being loaded and displayed.
+        /// Object-level view authorization (IDOR): RequisitionID comes from the querystring unchecked, so
+        /// without this any authenticated user could view any requisition. Mirrors
+        /// CapitalRequestDetail.UserCanView(). (Edit gating only disables inputs, not data display.)
         /// </summary>
         private bool UserCanViewRequisition()
         {
-            // A new requisition (no persisted id yet) is always viewable.
+            // New requisition (no id yet) is always viewable.
             if ( RequisitionID <= 0 || CurrentRequisition == null || CurrentRequisition.RequisitionID != RequisitionID )
             {
                 return true;
             }
 
-            // Fail closed for a person-less session. This is a staff block (CurrentPerson is normally
-            // set), but the involvement helpers below dereference CurrentPerson / its PrimaryAliasId,
-            // so guard explicitly now that this runs for every authenticated viewer of every id.
+            // Fail closed for a person-less session (the helpers below dereference CurrentPerson).
             if ( CurrentPerson == null || CurrentPerson.PrimaryAliasId == null )
             {
                 return false;
             }
 
-            // The requester themselves.
+            // Requester themselves.
             if ( CurrentPerson.PrimaryAliasId == CurrentRequisition.RequesterID )
             {
                 return true;
             }
 
-            // Creator, requester's/creator's ministry, an approver, or block edit/admin rights
-            // (the same relationships the block already uses to decide edit-ability).
+            // Creator, requester's/creator's ministry, approver, or block edit/admin.
             if ( UserIsCreator || RequesterIsInMyMinitry || CreatorIsInMyMinistry || UserIsApprover || UserCanEdit )
             {
                 return true;
@@ -1427,9 +1421,7 @@ namespace RockWeb.Plugins.org_secc.Purchasing
 
         private void LoadRequisition()
         {
-            // Object-level view authorization (IDOR): refuse to render a requisition the current user
-            // does not own / is not involved with. Return BEFORE any Load* call so no requisition data
-            // (summary, items, notes, attachments, approvals, charges) is ever populated.
+            // IDOR gate: bail before any Load* so an unauthorized requisition's data is never populated.
             if ( !UserCanViewRequisition() )
             {
                 SetSummaryError( "You are not authorized to view this requisition. Click \"Return to List\" to continue." );
@@ -1456,10 +1448,8 @@ namespace RockWeb.Plugins.org_secc.Purchasing
 
         private void LoadSummary()
         {
-            // Object-level view authorization (IDOR): LoadSummary is also reached directly from postback
-            // handlers, not just the gated LoadRequisition, so re-check here. UserCanViewRequisition()
-            // returns true for new requisitions and for anyone with view/edit involvement (edit rights
-            // are a subset of view rights), so legitimate flows are unaffected.
+            // IDOR re-check: LoadSummary is also reached directly from postback handlers, not only the
+            // gated LoadRequisition. (Returns true for new requisitions / any view-or-edit involvement.)
             if ( !UserCanViewRequisition() )
             {
                 return;
@@ -1513,8 +1503,7 @@ namespace RockWeb.Plugins.org_secc.Purchasing
 
         private void LoadItems()
         {
-            // Object-level view authorization (IDOR): LoadItems is reached directly from postback
-            // handlers too, so re-check (see LoadSummary). Safe for new requisitions / authorized users.
+            // IDOR re-check: LoadItems is also reached directly from postback handlers (see LoadSummary).
             if ( !UserCanViewRequisition() )
             {
                 return;


### PR DESCRIPTION
## Summary
Two High-severity access-control fixes — code-only, safe to merge.

## Changes
- **SuperCheckin** — *PIN privilege escalation.* The guard blocking a PIN for a security-role member showed a warning but fell through (missing `return`) and minted the PIN anyway. Added `return;`.
- **RequisitionDetail** — *horizontal IDOR view.* `RequisitionID` came from the querystring with no ownership check, so any authenticated user could view any requisition. Added `UserCanViewRequisition()` (mirrors `CapitalRequestDetail`) gating `LoadRequisition`/`LoadSummary`/`LoadItems` + the refresh handlers, plus `CreatedBy`/`CurrentPerson` null-safety. Edit-rights ⊆ view-rights, so legitimate requester/creator/ministry/approver/editor flows are unaffected; everyone else fails closed.

## Verification
Two adversarial (read-only) review passes — no blockers/majors. **Compiled and runtime-tested — confirmed working.** Mirrors patterns already on Rock 13.7.

## Not in this PR
- **ManageCommunicationLists** (anonymous account-takeover IDOR) → split to **#239** (coordinated code + WT 250 SMS recipe; would break a live SMS sign-up flow if shipped alone).
- **GroupTracker** (`org.secc.GroupTrackerDemo`) → deferred. Anonymous IDOR write + PII read on `api/GroupTracker/*`, but the plugin is **not deployed** (no RestController/RestAction/EntityType on DEV or PROD; not in the solution; README labels it a demo) and its access model is undefined. **Open questions before any fix:**
  1. What calls it (the Southeast/Subsplash app)? Per-user auth (as the leader), or the `Subsplash API` service account?
  2. Intended audience — leader-only, or leader + staff + admin?
  3. For `GetGroupSummaryByLeader`: does the caller pass the logged-in person's own `personAliasId`, or do staff/admin query others'?
  4. Fold it into the existing, already-secured `GroupApp/*` controllers instead?