### PR TITLE
ROCK-8675: send Messaging API function key via x-functions-key header

### DIFF
--- a/Plugins/org.secc.Communication/MessagingClient.cs
+++ b/Plugins/org.secc.Communication/MessagingClient.cs
@@ -35,11 +35,12 @@ namespace org.secc.Communication
         public List<TwilioPhoneNumber> GetTwilioNumbers( bool clearCache = false )
         {
 
-            var url = $"{settings.MessagingUrl}twiliophonenumbers?code={settings.MessagingKey}{(clearCache ? "&nocache=1" : String.Empty)}";
+            var url = $"{settings.MessagingUrl}twiliophonenumbers{(clearCache ? "?nocache=1" : String.Empty)}";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.GET );
             request.RequestFormat = DataFormat.Json;
             request.AddHeader( "Accept", "application/json" );
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
 
             var response = restClient.Execute( request );
 
@@ -57,11 +58,12 @@ namespace org.secc.Communication
 
         public MessagingPhoneNumber AddPhoneNumber( MessagingPhoneNumber number )
         {
-            var url = $"{settings.MessagingUrl}phonenumbers?code={settings.MessagingKey}";
+            var url = $"{settings.MessagingUrl}phonenumbers";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.POST );
             request.RequestFormat = DataFormat.Json;
             request.AddHeader( "Accept", "application/json" );
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
             request.AddParameter( "application/json", JsonConvert.SerializeObject( number ), ParameterType.RequestBody );
             var response = restClient.Execute( request );
 
@@ -76,20 +78,22 @@ namespace org.secc.Communication
 
         public void DeletePhoneNumber( string id )
         {
-            var url = $"{settings.MessagingUrl}phonenumbers/{id}?code={settings.MessagingKey}";
+            var url = $"{settings.MessagingUrl}phonenumbers/{id}";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.DELETE );
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
             restClient.Execute( request );
 
         }
 
         public MessagingPhoneNumber GetPhoneNumber( string id )
         {
-            var url = $"{settings.MessagingUrl}phonenumbers/{id}?code={settings.MessagingKey}";
+            var url = $"{settings.MessagingUrl}phonenumbers/{id}";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.GET );
             request.RequestFormat = DataFormat.Json;
-            request.AddHeader( "Accept", "applicaiton/json" );
+            request.AddHeader( "Accept", "application/json" );
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
             var response = restClient.Execute( request );
 
             if (response.StatusCode == HttpStatusCode.OK)
@@ -102,11 +106,12 @@ namespace org.secc.Communication
 
         public List<MessagingPhoneNumber> GetPhoneNumbers()
         {
-            var url = $"{settings.MessagingUrl}phonenumbers?code={settings.MessagingKey}";
+            var url = $"{settings.MessagingUrl}phonenumbers";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.GET );
             request.RequestFormat = DataFormat.Json;
             request.AddHeader( "Accept", "application/json" );
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
             var response = restClient.Execute( request );
 
             if (response.StatusCode == HttpStatusCode.OK)
@@ -120,11 +125,12 @@ namespace org.secc.Communication
 
         public MessagingPhoneNumber UpdatePhoneNumber( MessagingPhoneNumber number )
         {
-            var url = $"{settings.MessagingUrl}phonenumbers?code={settings.MessagingKey}";
+            var url = $"{settings.MessagingUrl}phonenumbers";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.PUT );
             request.RequestFormat = DataFormat.Json;
             request.AddHeader( "Accept", "application/json" );
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
             request.AddParameter( "application/json", JsonConvert.SerializeObject( number ), ParameterType.RequestBody );
             var response = restClient.Execute( request );
 
@@ -143,11 +149,12 @@ namespace org.secc.Communication
 
         public void AddKeyword( string phoneId, Keyword k )
         {
-            var url = $"{settings.MessagingUrl}phonenumbers/{phoneId}/keywords?code={settings.MessagingKey}";
+            var url = $"{settings.MessagingUrl}phonenumbers/{phoneId}/keywords";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.POST );
             request.RequestFormat = DataFormat.Json;
             request.AddHeader( "Accept", "application/json" );
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
             request.AddParameter( "application/json", JsonConvert.SerializeObject( k ), ParameterType.RequestBody );
 
             var response = restClient.Execute( request );
@@ -160,10 +167,11 @@ namespace org.secc.Communication
 
         public void DeleteKeyword( string phoneId, string keywordId )
         {
-            var url = $"{settings.MessagingUrl}phonenumbers/{phoneId}/keywords/{keywordId}?code={settings.MessagingKey}";
+            var url = $"{settings.MessagingUrl}phonenumbers/{phoneId}/keywords/{keywordId}";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.DELETE );
             request.RequestFormat = DataFormat.Json;
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
             var response = restClient.Execute( request );
 
             if (response.StatusCode != HttpStatusCode.Gone)
@@ -175,11 +183,12 @@ namespace org.secc.Communication
 
         public Keyword GetKeyword( string phoneId, string keywordId )
         {
-            var url = $"{settings.MessagingUrl}phonenumbers/{phoneId}/keywords/{keywordId}?code={settings.MessagingKey}";
+            var url = $"{settings.MessagingUrl}phonenumbers/{phoneId}/keywords/{keywordId}";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.GET );
             request.RequestFormat = DataFormat.Json;
             request.AddHeader( "Accept", "application/json" );
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
             var response = restClient.Execute( request );
 
             if (response.StatusCode == HttpStatusCode.NotFound)
@@ -193,11 +202,12 @@ namespace org.secc.Communication
 
         public void ReorderKeyword( KeywordReorderItem item, string phoneId )
         {
-            var url = $"{settings.MessagingUrl}phonenumbers/{phoneId}/keywords/reorder?code={settings.MessagingKey}";
+            var url = $"{settings.MessagingUrl}phonenumbers/{phoneId}/keywords/reorder";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.PATCH );
             request.RequestFormat = DataFormat.Json;
             request.AddHeader( "Accept", "application/json" );
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
             request.AddParameter( "application/json", JsonConvert.SerializeObject( item ), ParameterType.RequestBody );
             var response = restClient.Execute( request );
 
@@ -210,11 +220,12 @@ namespace org.secc.Communication
 
         public void UpdateKeyword( string phoneId, Keyword k )
         {
-            var url = $"{settings.MessagingUrl}phonenumbers/{phoneId}/keywords?code={settings.MessagingKey}";
+            var url = $"{settings.MessagingUrl}phonenumbers/{phoneId}/keywords";
             var restClient = new RestClient( url );
             var request = new RestRequest( Method.PUT );
             request.RequestFormat = DataFormat.Json;
             request.AddHeader( "Accept", "application/json" );
+            request.AddHeader( "x-functions-key", settings.MessagingKey );
             request.AddParameter( "application/json", JsonConvert.SerializeObject( k ), ParameterType.RequestBody );
             var response = restClient.Execute( request );
 

--- a/Plugins/org.secc.Communication/README.md
+++ b/Plugins/org.secc.Communication/README.md
@@ -97,10 +97,11 @@ Twilio SDK enums aren't needed to read the data.
 
 *Noticed while documenting — not a full audit.*
 
-- **Security (low):** `MessagingClient` passes the decrypted Messaging API function key as a `code`
-  query-string parameter on every request (`?code={MessagingKey}`). Query-string secrets can land
-  in proxy/server logs; worth confirming the API can't accept the key via header instead, and that
-  the configured URL is HTTPS.
+- **Security (resolved, ROCK-8675):** `MessagingClient` now sends the decrypted Messaging API
+  function key via the `x-functions-key` request header instead of a `?code={MessagingKey}`
+  query-string parameter, so the secret no longer travels in request URLs (proxy/server logs,
+  Function access logs, App Insights). Still worth confirming the configured `MessagingUrl` is
+  HTTPS.
 - **Improvement:** The job class is misspelled `SycnTwilioHistory` (typo for "Sync") — renaming the
   class would break the existing scheduled-job registration in the database, so review before
   changing.


### PR DESCRIPTION
Move the decrypted Messaging API function key out of the ?code= query string and into the x-functions-key request header across all MessagingClient methods, so the secret no longer travels in request URLs (captured in Function access logs, App Insights, and proxies). Behavior is otherwise unchanged. Also fixes an Accept-header typo in GetPhoneNumber (applicaiton/json -> application/json).