### PR TITLE
ROCK-8650 Sync OnePoint portal search icon into repo

### DIFF
--- a/Plugins/org.secc.Themes/Themes/SECC2019Portal/Assets/Lava/Site/PrimaryHeaderNav.lava
+++ b/Plugins/org.secc.Themes/Themes/SECC2019Portal/Assets/Lava/Site/PrimaryHeaderNav.lava
@@ -1,3 +1,16 @@
+<style>
+  .cd-header-buttons .cd-search-trigger {
+    width: auto; height: auto; overflow: visible;
+    color: inherit !important;
+    padding: 9px;
+    line-height: 1;
+  }
+  .cd-header-buttons .cd-search-trigger::before,
+  .cd-header-buttons .cd-search-trigger::after { content: none; }
+  .cd-header-buttons .cd-search-trigger i {
+    font-size: 16px;
+  }
+</style>
 <!--========== HEADER ==========-->
 <header class="cd-main-header transparent-menu-enabled transparent-header">
   <a class="cd-logo" href="/">
@@ -14,7 +27,7 @@
         <a href="/?logout=true" class="cd-nav-logout" title="Log Out" rel="nofollow"><i class="fas fa-sign-out"></i><span class="sr-only">Log Out</span></a>
     </li>
     {% endcomment %}
-	<li><a class="cd-search-trigger" href="#cd-search" title="Search">Search<span></span></a></li>
+    <li><a class="cd-search-trigger" href="#cd-search" title="Search" aria-label="Search" style="color:#000 !important;width:auto;height:auto;overflow:visible;padding:9px;line-height:1;margin-top:4px;"><i class="fas fa-search"></i></a></li>
   {% endif %}
 
   {% unless personGuid != null %}


### PR DESCRIPTION
Brings the `SECC2019Portal` (OnePoint) `PrimaryHeaderNav.lava` repo file back in sync with prod. The header search trigger now renders as a Font Awesome magnifying-glass icon styled to match the news bell, instead of the old plain-text "Search" link.

**Already live.** This change was applied, tested, and confirmed working on prod via Rock File Manager. The repo had drifted from prod — the trigger was commented out on the live file while the repo still carried the old plain-text version — so this PR realigns the repo with what's deployed.

**FA5, not FA6.** The OnePoint kit is Font Awesome 5 Pro, so the icon is `fa-search`. The FA6 name `fa-magnifying-glass` renders blank here — do not "modernize" it.

**Mirrors prod exactly.** The fix is captured as an inline `<style>` block plus an inline `style` attribute, matching the live file byte-for-byte.

**Scope:** desktop header only, and only for logged-in users (the trigger lives inside `{% if CurrentPerson.Guid %}`).