### PR TITLE
ROCK-8654 Cap event promo image height on event detail page

### DIFF
--- a/Plugins/org.secc.Themes/Themes/SECC2024/Styles/_lib/_events.scss
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Styles/_lib/_events.scss
@@ -284,6 +284,7 @@ a.eventCardLink {
 
 // ROCK-8654: cap event promo image height (no .event-details in live DOM).
 .event-photo-container .event-photo {
+    max-height: 45vh;
     max-height: 45dvh;
     overflow: hidden;
 }

--- a/Plugins/org.secc.Themes/Themes/SECC2024/Styles/_lib/_events.scss
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Styles/_lib/_events.scss
@@ -282,10 +282,7 @@ a.eventCardLink {
 }
 
 
-// ROCK-8654: cap event promo image height. Scoped to the event-detail block via
-// its "CSS Class" field (event-photo-cap on Block 7325) so it only affects the
-// event detail page, not the shared .event-photo-container markup elsewhere.
-// NOTE: requires the event-photo-cap CSS Class set on the block per environment.
+// ROCK-8654: cap event promo image height (scoped via block CSS class event-photo-cap).
 .event-photo-cap .event-photo-container .event-photo {
     max-height: 45vh;
     overflow: hidden;

--- a/Plugins/org.secc.Themes/Themes/SECC2024/Styles/_lib/_events.scss
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Styles/_lib/_events.scss
@@ -282,10 +282,12 @@ a.eventCardLink {
 }
 
 
-// ROCK-8654: cap event promo image height (no .event-details in live DOM).
-.event-photo-container .event-photo {
+// ROCK-8654: cap event promo image height. Scoped to the event-detail block via
+// its "CSS Class" field (event-photo-cap on Block 7325) so it only affects the
+// event detail page, not the shared .event-photo-container markup elsewhere.
+// NOTE: requires the event-photo-cap CSS Class set on the block per environment.
+.event-photo-cap .event-photo-container .event-photo {
     max-height: 45vh;
-    max-height: 45dvh;
     overflow: hidden;
 }
 

--- a/Plugins/org.secc.Themes/Themes/SECC2024/Styles/_lib/_events.scss
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Styles/_lib/_events.scss
@@ -282,6 +282,12 @@ a.eventCardLink {
 }
 
 
+// ROCK-8654: cap event promo image height (no .event-details in live DOM).
+.event-photo-container .event-photo {
+    max-height: 45dvh;
+    overflow: hidden;
+}
+
 .event-details {
     padding: 25px;
     border-radius: 5px;

--- a/Plugins/org.secc.Themes/Themes/SECC2024/Styles/_lib/_events.scss
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Styles/_lib/_events.scss
@@ -286,6 +286,9 @@ a.eventCardLink {
 .event-photo-cap .event-photo-container .event-photo {
     max-height: 45vh;
     overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .event-details {


### PR DESCRIPTION
## What

Caps the event promo image on the public **event detail page** (SECC2024 theme) so it no longer fills the viewport and pushes event copy below the fold on desktop.

```scss
.event-photo-cap .event-photo-container .event-photo {
    max-height: 45dvh;
    overflow: hidden;
    display: flex;
    justify-content: center;
    align-items: center;
}
```

## Why

`Events/Details.lava` emits the promo image as a full-width `<img style="width:100%">` with no height constraint. On tall/landscape photos this dominates the screen — the reported issue (Freshservice SR-12871). `45dvh` caps the banner to ~45% of viewport height (responsive: ~486px on 1080p, ~345px on a laptop), `overflow:hidden` clips the remainder.

## Scope / blast radius (verified)

- Affects **only** the event details page promo photo on Site 30 (SECC2024). Confirmed against the live DOM.
- The selector intentionally drops the `.event-details` prefix — the live detail-page DOM has **no** `.event-details` wrapper, so the pre-existing `.event-details .event-photo-container .event-photo` rule never matched (which is why the photo was uncapped).
- **Not** group pages: old `groups/oncampus/details` is retired (redirects → 404); new `/allgroups` pages don't use this markup.
- **Not** the SECC2014 (old site) or SECC2019 themes that reuse the class name — each loads its own compiled CSS bundle.
- DB checks: 0 HtmlContent hits; the 8 inline-Lava hits are all on Site 3 (SECC - 2014 - OLD), a separate theme/CSS.

## Deploy note

This is the source-of-truth change. A matching rule was hand-added to the live `main.css` for the immediate fix; this PR ensures the next theme recompile regenerates it instead of wiping the live edit.