### PR TITLE
ROCK-8625: Add optional per-instance Lava Waiver Text to Volunteer Signup Form

### DIFF
--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx
@@ -64,6 +64,8 @@
                 
                 <Rock:RockTextBox ID="tbComments" runat="server" Label="Comments"  TextMode="MultiLine" Rows="4" />
 
+                <asp:Literal ID="lWaiverText" runat="server" Visible="false" />
+
                 <div class="actions">
                     <asp:LinkButton ID="btnConnectandAddAnother" Visible="false" runat="server" AccessKey="n" Text="Connect and Add Another" CssClass="btn btn-default" OnClick="btnConnect_Click" />
                     <asp:LinkButton ID="btnConnect" runat="server" AccessKey="m" Text="Connect" CssClass="btn btn-primary" OnClick="btnConnect_Click" />

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -67,6 +67,7 @@ namespace org.secc.Connection
     [BooleanField( "Display Add Another", "Whether to display the \"Connect and Add Another\" button", false, "", 11 )]
     [TextField( "Comment label text", "The wording that should be used for the comment box title", true, "Comments", "", 12 )]
     [BooleanField( "Comments Required", "Whether the comment are required", true, "", 13 )]
+    [CodeEditorField( "Waiver Text", "Optional waiver/legal text (supports Lava) shown directly above the Connect button. Leave blank to display nothing.", CodeEditorMode.Lava, CodeEditorTheme.Rock, 200, false, "", "", 14 )]
 
     public partial class VolunteerSignupFormConnections : RockBlock
     {
@@ -515,6 +516,17 @@ namespace org.secc.Connection
                 {
                     tbComments.Label = GetAttributeValue( "Commentlabeltext" ).ResolveMergeFields( mergeFields );
                     tbComments.Required = GetAttributeValue( "CommentsRequired" ).AsBoolean();
+                }
+
+                var waiverText = GetAttributeValue( "WaiverText" );
+                if ( !string.IsNullOrWhiteSpace( waiverText ) )
+                {
+                    lWaiverText.Text = waiverText.ResolveMergeFields( mergeFields );
+                    lWaiverText.Visible = true;
+                }
+                else
+                {
+                    lWaiverText.Visible = false;
                 }
 
                 // If any of these aren't showing then set the width to be a bit wider on the columns


### PR DESCRIPTION
## Summary

- Adds an optional **Waiver Text** block setting to the Volunteer Signup Form — Connections block (`org.secc.Connection`)
- When non-empty, the waiver text renders directly above the Connect button using Lava
- Defaults to blank, so all existing ~30 signup form instances are unaffected

## Files changed

- `VolunteerSignupFormConnections.ascx` — renders waiver text block above Connect button
- `VolunteerSignupFormConnections.ascx.cs` — adds `WaiverText` block attribute definition

## Config follow-up (at go-live, July 19)

On Page 2742 "Food Pack Sign Up", Block 6192: paste legal's waiver wording into the new **Waiver Text** block setting. Optionally change Connect Button Text from "Connect" → "I Agree and Submit". No further code changes needed.

## JIRA

[ROCK-8625](https://secc.atlassian.net/browse/ROCK-8625)

[ROCK-8625]: https://seccdev.atlassian.net/browse/ROCK-8625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ