### PR TITLE
ROCK-8647: render MultiFile attribute media inline (native video/image)

### DIFF
--- a/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
+++ b/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
@@ -365,15 +365,65 @@ namespace org.secc.Attributes.FieldTypes
 
                 var files = new BinaryFileService( rockContext ).Queryable()
                     .Where( bf => fileGuids.Contains( bf.Guid ) )
-                    .Select( bf => new { bf.Guid, bf.FileName } )
+                    .Select( bf => new { bf.Guid, bf.FileName, bf.MimeType } )
+                    .ToList()
+                    // The GUID-IN query doesn't guarantee order; restore the matrix/display order.
+                    .OrderBy( f => fileGuids.IndexOf( f.Guid ) )
                     .ToList();
 
-                var links = files
-                    .Select( f => string.Format( "<a href=\"/GetFile.ashx?guid={0}\">{1}</a>", f.Guid, HttpUtility.HtmlEncode( f.FileName ?? string.Empty ) ) )
-                    .ToList();
+                var blocks = files.Select( f => BuildFileHtml( f.Guid, f.FileName, f.MimeType ) );
 
-                return string.Join( "<br />", links );
+                return string.Join( string.Empty, blocks );
             }
+        }
+
+        private static readonly System.Text.RegularExpressions.Regex _videoExt =
+            new System.Text.RegularExpressions.Regex( @"\.(mp4|webm|ogg|ogv|mov|m4v)$",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled );
+
+        private static readonly System.Text.RegularExpressions.Regex _imageExt =
+            new System.Text.RegularExpressions.Regex( @"\.(png|jpe?g|gif|webp|svg|bmp)$",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled );
+
+        private static bool IsVideo( string fileName, string mimeType ) =>
+            ( !string.IsNullOrWhiteSpace( mimeType ) && mimeType.StartsWith( "video/", StringComparison.OrdinalIgnoreCase ) )
+            || ( !string.IsNullOrWhiteSpace( fileName ) && _videoExt.IsMatch( fileName ) );
+
+        private static bool IsImage( string fileName, string mimeType ) =>
+            ( !string.IsNullOrWhiteSpace( mimeType ) && mimeType.StartsWith( "image/", StringComparison.OrdinalIgnoreCase ) )
+            || ( !string.IsNullOrWhiteSpace( fileName ) && _imageExt.IsMatch( fileName ) );
+
+        /// <summary>
+        /// Builds the display markup for one stored file: an inline &lt;video&gt; or &lt;img&gt;
+        /// for media types (with the download link beneath), or a plain link otherwise.
+        /// </summary>
+        private static string BuildFileHtml( Guid guid, string fileName, string mimeType )
+        {
+            var url = "/GetFile.ashx?guid=" + guid;
+            var encodedName = HttpUtility.HtmlEncode( fileName ?? string.Empty );
+            var link = string.Format( "<a href=\"{0}\">{1}</a>", url, encodedName );
+
+            if ( IsVideo( fileName, mimeType ) )
+            {
+                return string.Format(
+                    "<div class=\"multifile-item multifile-video\">" +
+                    "<video controls preload=\"metadata\" src=\"{0}\" " +
+                    "style=\"display:block;width:100%;max-width:560px;margin:.5rem 0;background:#000;border-radius:4px;\"></video>" +
+                    "{1}</div>",
+                    url, link );
+            }
+
+            if ( IsImage( fileName, mimeType ) )
+            {
+                return string.Format(
+                    "<div class=\"multifile-item multifile-image\">" +
+                    "<img src=\"{0}\" alt=\"{1}\" " +
+                    "style=\"display:block;max-width:240px;max-height:240px;margin:.5rem 0;border:1px solid #ddd;border-radius:4px;\" />" +
+                    "{2}</div>",
+                    url, encodedName, link );
+            }
+
+            return string.Format( "<div class=\"multifile-item\">{0}</div>", link );
         }
 
         #endregion

--- a/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
+++ b/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
@@ -326,12 +326,61 @@ namespace org.secc.Attributes.FieldTypes
 
         #region Formatting
 
+        /// <summary>
+        /// Link-only formatting. This output also feeds non-HTML consumers — CSV/grid exports
+        /// and Lava merge fields (including emails) — so it must never emit &lt;video&gt;/&lt;img&gt;
+        /// markup. Rich media embedding lives in <see cref="FormatValueAsHtml"/>.
+        /// </summary>
         public override string FormatValue( Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues, bool condensed )
+        {
+            var files = GetOrderedFiles( value );
+            if ( files == null || !files.Any() )
+            {
+                return string.Empty;
+            }
+
+            if ( condensed )
+            {
+                return files.Count == 1 ? "1 file" : ( files.Count + " files" );
+            }
+
+            return string.Join( string.Empty, files.Select( f => BuildFileLinkHtml( f.Guid, f.FileName ) ) );
+        }
+
+        /// <summary>
+        /// Full HTML display embeds media: video files render as a native &lt;video&gt; player and
+        /// images as an &lt;img&gt; thumbnail, each with its download link beneath; other types render
+        /// as a plain link. Condensed (grids/summaries) and empty cases defer to <see cref="FormatValue"/>
+        /// so non-HTML consumers keep the link-only / count output. (Matches Rock's MediaElementFieldType
+        /// convention of putting rich rendering in FormatValueAsHtml.)
+        /// </summary>
+        public override string FormatValueAsHtml( Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues, bool condensed = false )
+        {
+            if ( condensed )
+            {
+                return FormatValue( parentControl, value, configurationValues, true );
+            }
+
+            var files = GetOrderedFiles( value );
+            if ( files == null || !files.Any() )
+            {
+                return string.Empty;
+            }
+
+            return string.Join( string.Empty, files.Select( f => BuildFileHtml( f.Guid, f.FileName, f.MimeType ) ) );
+        }
+
+        /// <summary>
+        /// Resolves a stored AttributeMatrix Guid to its files in display order, each with the
+        /// FileName and MimeType needed for media detection. Shared by <see cref="FormatValue"/>
+        /// (links) and <see cref="FormatValueAsHtml"/> (media) so the two can't drift.
+        /// </summary>
+        private static List<MultiFileInfo> GetOrderedFiles( string value )
         {
             var matrixGuid = value.AsGuidOrNull();
             if ( !matrixGuid.HasValue )
             {
-                return string.Empty;
+                return new List<MultiFileInfo>();
             }
 
             using ( var rockContext = new RockContext() )
@@ -339,7 +388,7 @@ namespace org.secc.Attributes.FieldTypes
                 var matrix = new AttributeMatrixService( rockContext ).Get( matrixGuid.Value );
                 if ( matrix == null || matrix.AttributeMatrixItems == null || !matrix.AttributeMatrixItems.Any() )
                 {
-                    return string.Empty;
+                    return new List<MultiFileInfo>();
                 }
 
                 var fileGuids = new List<Guid>();
@@ -355,12 +404,7 @@ namespace org.secc.Attributes.FieldTypes
 
                 if ( !fileGuids.Any() )
                 {
-                    return string.Empty;
-                }
-
-                if ( condensed )
-                {
-                    return fileGuids.Count == 1 ? "1 file" : ( fileGuids.Count + " files" );
+                    return new List<MultiFileInfo>();
                 }
 
                 // The GUID-IN query doesn't guarantee order; key by Guid so we can emit in matrix order.
@@ -371,16 +415,22 @@ namespace org.secc.Attributes.FieldTypes
                     .ToDictionary( bf => bf.Guid );
 
                 // fileGuids is already in matrix/display order; iterate it to preserve that order (O(n)).
-                var blocks = fileGuids
+                return fileGuids
                     .Where( filesByGuid.ContainsKey )
                     .Select( g =>
                     {
                         var f = filesByGuid[g];
-                        return BuildFileHtml( f.Guid, f.FileName, f.MimeType );
-                    } );
-
-                return string.Join( string.Empty, blocks );
+                        return new MultiFileInfo { Guid = f.Guid, FileName = f.FileName, MimeType = f.MimeType };
+                    } )
+                    .ToList();
             }
+        }
+
+        private class MultiFileInfo
+        {
+            public Guid Guid { get; set; }
+            public string FileName { get; set; }
+            public string MimeType { get; set; }
         }
 
         private static readonly System.Text.RegularExpressions.Regex _videoExt =
@@ -388,16 +438,42 @@ namespace org.secc.Attributes.FieldTypes
                 System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled );
 
         private static readonly System.Text.RegularExpressions.Regex _imageExt =
-            new System.Text.RegularExpressions.Regex( @"\.(png|jpe?g|gif|webp|svg|bmp)$",
+            new System.Text.RegularExpressions.Regex( @"\.(png|jpe?g|gif|webp|bmp)$",
                 System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled );
 
         private static bool IsVideo( string fileName, string mimeType ) =>
             ( !string.IsNullOrWhiteSpace( mimeType ) && mimeType.StartsWith( "video/", StringComparison.OrdinalIgnoreCase ) )
             || ( !string.IsNullOrWhiteSpace( fileName ) && _videoExt.IsMatch( fileName ) );
 
-        private static bool IsImage( string fileName, string mimeType ) =>
-            ( !string.IsNullOrWhiteSpace( mimeType ) && mimeType.StartsWith( "image/", StringComparison.OrdinalIgnoreCase ) )
-            || ( !string.IsNullOrWhiteSpace( fileName ) && _imageExt.IsMatch( fileName ) );
+        private static bool IsImage( string fileName, string mimeType )
+        {
+            // SVG can carry inline script; never embed it. The image/ MIME prefix below would
+            // otherwise match image/svg+xml, so guard the MIME type and the extension explicitly.
+            // It falls through to a plain download link instead.
+            if ( !string.IsNullOrWhiteSpace( mimeType ) && mimeType.IndexOf( "svg", StringComparison.OrdinalIgnoreCase ) >= 0 )
+            {
+                return false;
+            }
+            if ( !string.IsNullOrWhiteSpace( fileName ) && fileName.EndsWith( ".svg", StringComparison.OrdinalIgnoreCase ) )
+            {
+                return false;
+            }
+
+            return ( !string.IsNullOrWhiteSpace( mimeType ) && mimeType.StartsWith( "image/", StringComparison.OrdinalIgnoreCase ) )
+                || ( !string.IsNullOrWhiteSpace( fileName ) && _imageExt.IsMatch( fileName ) );
+        }
+
+        /// <summary>
+        /// Builds the link-only markup for one stored file (a download &lt;a&gt; wrapped in the
+        /// shared item container). Used by <see cref="FormatValue"/> and as the non-media
+        /// fallback inside <see cref="BuildFileHtml"/>.
+        /// </summary>
+        private static string BuildFileLinkHtml( Guid guid, string fileName )
+        {
+            var url = "/GetFile.ashx?guid=" + guid;
+            var encodedName = HttpUtility.HtmlEncode( fileName ?? string.Empty );
+            return string.Format( "<div class=\"multifile-item\"><a href=\"{0}\">{1}</a></div>", url, encodedName );
+        }
 
         /// <summary>
         /// Builds the display markup for one stored file: an inline &lt;video&gt; or &lt;img&gt;
@@ -430,7 +506,7 @@ namespace org.secc.Attributes.FieldTypes
                     url, encodedName, link );
             }
 
-            return string.Format( "<div class=\"multifile-item\">{0}</div>", link );
+            return BuildFileLinkHtml( guid, fileName );
         }
 
         #endregion

--- a/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
+++ b/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
@@ -363,15 +363,21 @@ namespace org.secc.Attributes.FieldTypes
                     return fileGuids.Count == 1 ? "1 file" : ( fileGuids.Count + " files" );
                 }
 
-                var files = new BinaryFileService( rockContext ).Queryable()
+                // The GUID-IN query doesn't guarantee order; key by Guid so we can emit in matrix order.
+                var filesByGuid = new BinaryFileService( rockContext ).Queryable()
                     .Where( bf => fileGuids.Contains( bf.Guid ) )
                     .Select( bf => new { bf.Guid, bf.FileName, bf.MimeType } )
                     .ToList()
-                    // The GUID-IN query doesn't guarantee order; restore the matrix/display order.
-                    .OrderBy( f => fileGuids.IndexOf( f.Guid ) )
-                    .ToList();
+                    .ToDictionary( bf => bf.Guid );
 
-                var blocks = files.Select( f => BuildFileHtml( f.Guid, f.FileName, f.MimeType ) );
+                // fileGuids is already in matrix/display order; iterate it to preserve that order (O(n)).
+                var blocks = fileGuids
+                    .Where( filesByGuid.ContainsKey )
+                    .Select( g =>
+                    {
+                        var f = filesByGuid[g];
+                        return BuildFileHtml( f.Guid, f.FileName, f.MimeType );
+                    } );
 
                 return string.Join( string.Empty, blocks );
             }
@@ -407,17 +413,18 @@ namespace org.secc.Attributes.FieldTypes
             {
                 return string.Format(
                     "<div class=\"multifile-item multifile-video\">" +
-                    "<video controls preload=\"metadata\" src=\"{0}\" " +
-                    "style=\"display:block;width:100%;max-width:560px;margin:.5rem 0;background:#000;border-radius:4px;\"></video>" +
-                    "{1}</div>",
-                    url, link );
+                    "<video controls playsinline preload=\"metadata\" src=\"{0}\" aria-label=\"{1}\" " +
+                    "style=\"display:block;width:100%;max-width:560px;margin:.5rem 0;background:#000;border-radius:4px;\">" +
+                    "Your browser does not support the video tag.</video>" +
+                    "{2}</div>",
+                    url, encodedName, link );
             }
 
             if ( IsImage( fileName, mimeType ) )
             {
                 return string.Format(
                     "<div class=\"multifile-item multifile-image\">" +
-                    "<img src=\"{0}\" alt=\"{1}\" " +
+                    "<img src=\"{0}\" alt=\"{1}\" loading=\"lazy\" decoding=\"async\" " +
                     "style=\"display:block;max-width:240px;max-height:240px;margin:.5rem 0;border:1px solid #ddd;border-radius:4px;\" />" +
                     "{2}</div>",
                     url, encodedName, link );

--- a/Plugins/org.secc.Attributes/README.md
+++ b/Plugins/org.secc.Attributes/README.md
@@ -55,10 +55,14 @@ defined-value Id back to its label (e.g. `Mobile: 555-1234`).
 is the Guid of an `AttributeMatrix` whose items each hold one file in a `File` column. On first use it
 auto-provisions a single shared `AttributeMatrixTemplate` (well-known Guid `D95683B6-…-F48A79340175`,
 cached in a static field). `GetEditValue` reconciles rows against the picker's current file Ids
-(adds new, deletes removed). When a saved value is **displayed**, `FormatValue` renders each file
-inline: video files embed as a native `<video>` player and images as an `<img>` thumbnail, each
-with its `GetFile.ashx` download link directly beneath; non-media files render as a plain link.
-Condensed/grid contexts still show an `"N files"` count rather than embedded media. Config attributes:
+(adds new, deletes removed). Display is split across two overrides so rich markup only reaches HTML
+surfaces: `FormatValue` is **link-only** (a list of `GetFile.ashx` download links, or an `"N files"`
+count when condensed) — this feeds CSV/grid exports and Lava merge fields, which must not receive
+embedded media. `FormatValueAsHtml` does the inline embedding for on-page HTML display: video files
+embed as a native `<video>` player and images as an `<img>` thumbnail, each with its download link
+directly beneath; non-media files render as a plain link. SVG is **never** embedded (it can carry
+inline script) and falls back to a link. Condensed/grid contexts still show an `"N files"` count
+rather than embedded media. Config attributes:
 
 | Setting | Type | Notes |
 |---------|------|-------|

--- a/Plugins/org.secc.Attributes/README.md
+++ b/Plugins/org.secc.Attributes/README.md
@@ -55,7 +55,10 @@ defined-value Id back to its label (e.g. `Mobile: 555-1234`).
 is the Guid of an `AttributeMatrix` whose items each hold one file in a `File` column. On first use it
 auto-provisions a single shared `AttributeMatrixTemplate` (well-known Guid `D95683B6-…-F48A79340175`,
 cached in a static field). `GetEditValue` reconciles rows against the picker's current file Ids
-(adds new, deletes removed). Config attributes:
+(adds new, deletes removed). When a saved value is **displayed**, `FormatValue` renders each file
+inline: video files embed as a native `<video>` player and images as an `<img>` thumbnail, each
+with its `GetFile.ashx` download link directly beneath; non-media files render as a plain link.
+Condensed/grid contexts still show an `"N files"` count rather than embedded media. Config attributes:
 
 | Setting | Type | Notes |
 |---------|------|-------|
@@ -126,5 +129,9 @@ cached in a static field). `GetEditValue` reconciles rows against the picker's c
 - The multi-file template provisioning and row reconciliation live in `MultiFileFieldType`
   (`EnsureSharedTemplate`, `GetEditValue`); the client-side upload/remove behavior is the inline JS in
   `Controls/MultiFileUpload.cs` (`RegisterClientScript`).
+
+---
+
+**Last updated:** 2026-06-29
 </content>
 </invoke>


### PR DESCRIPTION
Replace the plain-link display of the MultiFileFieldType with server-side markup that embeds <video>/<img> for media files, keeping the download link directly beneath each. Type detection uses BinaryFile.MimeType with a filename-extension fallback. The condensed branch (grids/summaries) still returns the 'N files' count, and FormatValueAsText still degrades to filenames via the retained anchors. This removes the need for the downstream page-level <script> that previously enhanced the links.