### PR TITLE
ROCK-8647: embed multi-file media in FormatValue (+AsHtml); clean exports via text path

### DIFF
--- a/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
+++ b/Plugins/org.secc.Attributes/FieldTypes/MultiFileFieldType.cs
@@ -327,9 +327,15 @@ namespace org.secc.Attributes.FieldTypes
         #region Formatting
 
         /// <summary>
-        /// Link-only formatting. This output also feeds non-HTML consumers — CSV/grid exports
-        /// and Lava merge fields (including emails) — so it must never emit &lt;video&gt;/&lt;img&gt;
-        /// markup. Rich media embedding lives in <see cref="FormatValueAsHtml"/>.
+        /// Embeds media for display: video files render as a native &lt;video&gt; player and images as
+        /// an &lt;img&gt; thumbnail, each with its download link beneath; other types render as a plain
+        /// link. Condensed (grids/summaries) returns an "N files" count.
+        ///
+        /// Rock does not route all attribute display through <see cref="FormatValueAsHtml"/>: the
+        /// Workflow Entry form and Lava attribute rendering ({{ Entity | Attribute:'Key' }}) resolve
+        /// the displayed value through FormatValue. We therefore embed here, mirroring Rock core
+        /// (ImageFieldType embeds via FormatValue; MediaElement/MediaWatch override both). Exports and
+        /// plain-text merge stay markup-free via <see cref="GetTextValue"/> / <see cref="GetCondensedTextValue"/>.
         /// </summary>
         public override string FormatValue( Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues, bool condensed )
         {
@@ -339,41 +345,72 @@ namespace org.secc.Attributes.FieldTypes
                 return string.Empty;
             }
 
-            if ( condensed )
-            {
-                return files.Count == 1 ? "1 file" : ( files.Count + " files" );
-            }
-
-            return string.Join( string.Empty, files.Select( f => BuildFileLinkHtml( f.Guid, f.FileName ) ) );
+            return condensed ? FormatCount( files ) : RenderMediaHtml( files );
         }
 
         /// <summary>
-        /// Full HTML display embeds media: video files render as a native &lt;video&gt; player and
-        /// images as an &lt;img&gt; thumbnail, each with its download link beneath; other types render
-        /// as a plain link. Condensed (grids/summaries) and empty cases defer to <see cref="FormatValue"/>
-        /// so non-HTML consumers keep the link-only / count output. (Matches Rock's MediaElementFieldType
-        /// convention of putting rich rendering in FormatValueAsHtml.)
+        /// Identical embed to <see cref="FormatValue"/>. Both render media on purpose — Rock resolves
+        /// attribute display via FormatValue on some surfaces (workflow entry forms, Lava) and via
+        /// FormatValueAsHtml on others (detail blocks, ChangeManager managed-values). Overriding this
+        /// explicitly (rather than relying on the base delegating to FormatValue) guarantees the embed
+        /// regardless of any base-class encoding/condensing behavior, matching core's MediaElementFieldType.
         /// </summary>
         public override string FormatValueAsHtml( Control parentControl, string value, Dictionary<string, ConfigurationValue> configurationValues, bool condensed = false )
         {
-            if ( condensed )
-            {
-                return FormatValue( parentControl, value, configurationValues, true );
-            }
+            return FormatValue( parentControl, value, configurationValues, condensed );
+        }
 
+        /// <summary>
+        /// Plain-text channel for exports and non-HTML merge: a comma-separated filename list with no
+        /// &lt;video&gt;/&lt;img&gt; markup. This is the value-agnostic text path Rock v13 uses for
+        /// CSV/grid exports and plain-text Lava merge, so it must never emit media markup.
+        ///
+        /// (v13 has no <c>FormatValueAsText</c> override point — <c>GetTextValue</c>/
+        /// <c>GetCondensedTextValue</c> are its successors; see the Rock-rendering note in the commit.)
+        /// </summary>
+        public override string GetTextValue( string value, Dictionary<string, string> configurationValues )
+        {
             var files = GetOrderedFiles( value );
             if ( files == null || !files.Any() )
             {
                 return string.Empty;
             }
 
-            return string.Join( string.Empty, files.Select( f => BuildFileHtml( f.Guid, f.FileName, f.MimeType ) ) );
+            return string.Join( ", ", files.Select( f => f.FileName ) );
         }
 
         /// <summary>
+        /// Condensed plain text (grids/summaries): the "N files" count, never media markup.
+        /// </summary>
+        public override string GetCondensedTextValue( string value, Dictionary<string, string> configurationValues )
+        {
+            var files = GetOrderedFiles( value );
+            if ( files == null || !files.Any() )
+            {
+                return string.Empty;
+            }
+
+            return FormatCount( files );
+        }
+
+        /// <summary>
+        /// Renders the full media embed for a resolved file list (one &lt;video&gt;/&lt;img&gt;/link
+        /// per file). Shared by <see cref="FormatValue"/> and <see cref="FormatValueAsHtml"/>.
+        /// </summary>
+        private static string RenderMediaHtml( List<MultiFileInfo> files ) =>
+            string.Join( string.Empty, files.Select( f => BuildFileHtml( f.Guid, f.FileName, f.MimeType ) ) );
+
+        /// <summary>
+        /// The condensed/grid representation: "1 file" / "N files".
+        /// </summary>
+        private static string FormatCount( List<MultiFileInfo> files ) =>
+            files.Count == 1 ? "1 file" : ( files.Count + " files" );
+
+        /// <summary>
         /// Resolves a stored AttributeMatrix Guid to its files in display order, each with the
-        /// FileName and MimeType needed for media detection. Shared by <see cref="FormatValue"/>
-        /// (links) and <see cref="FormatValueAsHtml"/> (media) so the two can't drift.
+        /// FileName and MimeType needed for media detection. Shared by all format methods
+        /// (<see cref="FormatValue"/>, <see cref="FormatValueAsHtml"/>, <see cref="GetTextValue"/>,
+        /// <see cref="GetCondensedTextValue"/>) so they can't drift.
         /// </summary>
         private static List<MultiFileInfo> GetOrderedFiles( string value )
         {

--- a/Plugins/org.secc.Attributes/README.md
+++ b/Plugins/org.secc.Attributes/README.md
@@ -55,14 +55,17 @@ defined-value Id back to its label (e.g. `Mobile: 555-1234`).
 is the Guid of an `AttributeMatrix` whose items each hold one file in a `File` column. On first use it
 auto-provisions a single shared `AttributeMatrixTemplate` (well-known Guid `D95683B6-…-F48A79340175`,
 cached in a static field). `GetEditValue` reconciles rows against the picker's current file Ids
-(adds new, deletes removed). Display is split across two overrides so rich markup only reaches HTML
-surfaces: `FormatValue` is **link-only** (a list of `GetFile.ashx` download links, or an `"N files"`
-count when condensed) — this feeds CSV/grid exports and Lava merge fields, which must not receive
-embedded media. `FormatValueAsHtml` does the inline embedding for on-page HTML display: video files
-embed as a native `<video>` player and images as an `<img>` thumbnail, each with its download link
-directly beneath; non-media files render as a plain link. SVG is **never** embedded (it can carry
-inline script) and falls back to a link. Condensed/grid contexts still show an `"N files"` count
-rather than embedded media. Config attributes:
+(adds new, deletes removed). Media embeds render from **both `FormatValue` and `FormatValueAsHtml`**:
+video files embed as a native `<video>` player and images as an `<img>` thumbnail, each with its
+`GetFile.ashx` download link directly beneath; non-media files render as a plain link. Both paths
+embed because Rock resolves attribute display through `FormatValue` on some surfaces (Workflow Entry
+forms, Lava `{{ Entity | Attribute:'Key' }}`) and through `FormatValueAsHtml` on others (detail
+blocks, ChangeManager managed-values) — this mirrors Rock core (`ImageFieldType` embeds via
+`FormatValue`; `MediaElementFieldType`/`MediaWatchFieldType` override both). To keep exports and
+plain-text merge markup-free, **`GetTextValue`** (v13's value-agnostic text channel, used by CSV/grid
+exports and non-HTML Lava merge) returns a comma-separated filename list, and **`GetCondensedTextValue`**
+returns the `"N files"` count. SVG is **never** embedded (it can carry inline script) and falls back to
+a link. Condensed/grid contexts show an `"N files"` count rather than embedded media. Config attributes:
 
 | Setting | Type | Notes |
 |---------|------|-------|


### PR DESCRIPTION
## Summary

Renders multi-file attribute media (`<video>`/`<img>`, with a download link beneath each) inline from **both `FormatValue` and `FormatValueAsHtml`**, restoring inline media on Workflow Entry forms and Lava output. Follow-up to #249 (ROCK-8647).

## Why `FormatValue` embeds media (alongside `FormatValueAsHtml`)

Rock does not route all attribute display through `FormatValueAsHtml`. The Workflow Entry form and Lava attribute rendering (`{{ Entity | Attribute:'Key' }}`) resolve the displayed value through `FormatValue`. Confining the embed to `FormatValueAsHtml` (as #249 did) therefore made workflow forms fall back to plain links. Rock's own media field types render media from `FormatValue`: `ImageFieldType` overrides only `FormatValue`, and `MediaElementFieldType`/`MediaWatchFieldType` override both `FormatValue` and `FormatValueAsHtml`. We mirror that here.

To keep the earlier reviewer's concern addressed, raw markup is kept out of exports/plain-text merge via the value-agnostic text channel (see deviation below), and condensed/grid contexts still return the `"N files"` count.

## ⚠️ Deviation from the implementation plan: no `FormatValueAsText` in this Rock v13

The plan specified a `FormatValueAsText` override to keep exports/plain-text merge markup-free. **That override point does not exist in this Rock v13 base `FieldType`** — verified directly against the bundled `Rock.dll` (the `FormatValueAsText` symbol is absent; `FormatValueAsHtml`, `GetTextValue`, and `GetCondensedTextValue` are present). Adding `override FormatValueAsText` would fail to compile (CS0115).

The plan's intent — a clean, markup-free plain-text channel — is implemented via v13's actual successors:

- **`GetTextValue`** → comma-separated filename list (the channel CSV/grid export and plain-text Lava merge use)
- **`GetCondensedTextValue`** → `"N files"`

## Behavior matrix

| Method | Non-condensed | Condensed |
|--------|---------------|-----------|
| `FormatValue` | embed (`<video>`/`<img>` + link) | `"N files"` |
| `FormatValueAsHtml` | embed (delegates to `FormatValue`) | `"N files"` |
| `GetTextValue` / `GetCondensedTextValue` | filename list (no markup) | `"N files"` |

- SVG always renders as a plain link in the embed paths (inline-script XSS guard).
- Files render in `AttributeMatrixItem.Order`.

## Verification

A full MSBuild isn't possible in the plugins-only checkout (the project `ProjectReference`s a Rock source tree not present locally), so the **entire `org.secc.Attributes` assembly was compiled with Roslyn (`langversion:latest`) against the in-repo reference assemblies** — clean build (exit 0). This confirms the `GetTextValue`/`GetCondensedTextValue` overrides bind to real virtual base methods and the assembly type-checks. Runtime checks (workflow form embed, export output, SVG link, ordering) still need a live Rock environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
