### PR TITLE
ROCK-8702 Add leader import support to Camp Placement Import

### DIFF
--- a/Plugins/org.secc.Event/README.md
+++ b/Plugins/org.secc.Event/README.md
@@ -2,14 +2,17 @@
 
 > Southeast's custom event/registration blocks — calendar Lava, a heavily-customized registration entry/detail pair, QR event passes, SignNow signing, camp-placement import, and the Community Gives Back program.
 
+Last updated: 2026-07-06
+
 ## Overview
 
 This plugin is a collection of Rock **UI blocks** (`.ascx` user controls) covering Southeast's
 public events and registration flows. It includes Lava-driven calendar/event displays, SECC's own
 forks of Rock's stock `RegistrationEntry` / `RegistrationDetail` blocks, QR-based "Event Pass"
-generation and request, a SignNow digital-signature embed, a CSV camp-placement importer, and the
-self-contained "Community Gives Back" school-sponsorship sub-area. Blocks are configured through
-Rock block settings and used by ministry/communications staff and public registrants.
+generation and request, a SignNow digital-signature embed, a CSV camp-placement importer for
+campers or leaders, and the self-contained "Community Gives Back" school-sponsorship sub-area.
+Blocks are configured through Rock block settings and used by ministry/communications staff and
+public registrants.
 
 ## Project Info
 
@@ -45,13 +48,22 @@ Category in Rock: **SECC > Event** (Community Gives Back blocks: **SECC > Commun
 | Generate Event Pass (`RequestEventPass`) | Public form that launches a workflow to request an Event Pass. | Block Title, Event Pass Workflow Type, Pass Person Attribute, Contact Fields Editable |
 | Family Registration List Lava (`FamilyRegistrationLava`) | Lava sidebar listing a family's children's registrations. | Lava Template, Max Results, Date Range, Limit To Owed |
 | SignNow (`SignNow`) | Embedded sub-control (a plain `System.Web.UI.UserControl`, **not** a registerable Rock block — no `[DisplayName]`/`[Category]`) that hosts the SignNow digital-signature flow inside registration; parses the returned `document_id` (falls back to the referer on iOS). | (none — driven by the registration's digital-signature component) |
-| Camp Placement Import (`CampPlacementImport`) | Imports a CSV to place camp registrants into placement groups; queues a background import run. | Default Group Member Status, Batch Size |
+| Camp Placement Import (`CampPlacementImport`) | Imports a CSV to place camp registrants into placement groups; queues a background import run. Supports both camper imports and leader imports. | Default Group Member Status, Batch Size |
 | Community Gives Back Registration (`CommunityGivesBackRegistration`) | Public registration for the Community Gives Back program (launches a workflow on submit, with an acknowledgement step). | Community Gives Back Schools (defined type), Acknowledgement Text, Confirmation Text, Registration Complete Text, Registration Workflow Type, Auto Populate Registration Data, Campaign |
 | Community Gives Back Registrations List (`CommunityGivesBackRegistrations`) | Lists CGB registrations by school. | Community Gives Back Schools (defined type), Registration Workflow Type, School List Page |
 | Community Gives Back School List (`SchoolList`) | Lists CGB schools / sponsorship registrations. | Community Gives Back Schools (defined type), Registration Workflow Type, School Registration Page |
 
 `RegistrationEntry` (6,091 lines) and `RegistrationDetail` (2,799 lines) are large SECC-maintained
 copies of the corresponding stock Rock blocks; treat them as forks kept in sync with upstream.
+
+### Camp Placement Import behavior
+
+- **Campers:** the import adds or restores memberships using the target group type's default role.
+- **Leaders:** the import adds or restores memberships using the first target group type role marked
+  `IsLeader`. If the person is already in the group with a non-leader role, that membership is
+  promoted to the leader role instead of creating a duplicate membership.
+- **Prerequisite for leader imports:** every target placement group type must have a role marked
+  `IsLeader`, or those rows will be reported as errors during processing.
 
 ## Dependencies & Integrations
 

--- a/Plugins/org.secc.Event/org_secc/Event/CampPlacementImport.ascx
+++ b/Plugins/org.secc.Event/org_secc/Event/CampPlacementImport.ascx
@@ -51,8 +51,8 @@
                     </div>
 
                     <div class="well">
-                        <h5>Camper Identification</h5>
-                        <p>Select the CSV columns that identify each camper. These will be matched against registrants in the selected registration instance.</p>
+                        <h5>Registrant Identification</h5>
+                        <p>Select the CSV columns that identify each person in the CSV. These will be matched against registrants in the selected registration instance.</p>
                         <div class="row">
                             <div class="col-md-6">
                                 <Rock:RockDropDownList ID="ddlFirstNameCol" runat="server" Label="First Name Column" Required="true" />
@@ -114,7 +114,7 @@
 
                     <Rock:Grid ID="gPreview" runat="server" AllowSorting="false" DataKeyNames="RowIndex" ShowActionRow="false" DisplayType="Light">
                         <Columns>
-                            <Rock:RockBoundField DataField="CsvName" HeaderText="Camper (CSV)" />
+                            <Rock:RockBoundField DataField="CsvName" HeaderText="Person (CSV)" />
                             <Rock:RockBoundField DataField="MatchedPerson" HeaderText="Matched Person" />
                             <Rock:RockBoundField DataField="PlacementSummary" HeaderText="Placements" />
                             <Rock:RockBoundField DataField="Status" HeaderText="Status" />

--- a/Plugins/org.secc.Event/org_secc/Event/CampPlacementImport.ascx
+++ b/Plugins/org.secc.Event/org_secc/Event/CampPlacementImport.ascx
@@ -40,6 +40,17 @@
                     <h4>Step 3: Map Columns</h4>
 
                     <div class="well">
+                        <h5>Import Type</h5>
+                        <Rock:Toggle ID="tglLeaderImport" runat="server"
+                            Label="Who is being imported?"
+                            OffText="Campers"
+                            OnText="Leaders"
+                            Checked="false"
+                            ActiveButtonCssClass="btn-primary"
+                            Help="Campers are added to placement groups using the group type's default role. Leaders are added using the role marked as 'Is Leader'. If a leader is already in a group with a non-leader role, their role will be updated to the leader role." />
+                    </div>
+
+                    <div class="well">
                         <h5>Camper Identification</h5>
                         <p>Select the CSV columns that identify each camper. These will be matched against registrants in the selected registration instance.</p>
                         <div class="row">

--- a/Plugins/org.secc.Event/org_secc/Event/CampPlacementImport.ascx.cs
+++ b/Plugins/org.secc.Event/org_secc/Event/CampPlacementImport.ascx.cs
@@ -25,6 +25,7 @@ using Rock;
 using Rock.Attribute;
 using Rock.Data;
 using Rock.Model;
+using Rock.Web.Cache;
 using Rock.Web.UI;
 using Rock.Web.UI.Controls;
 
@@ -429,6 +430,7 @@ namespace RockWeb.Plugins.org_secc.Event
             BaseParentGroupId = null;
             fuCsvFile.BinaryFileId = null;
             gpBasePlacementGroup.SetValue( ( Group ) null );
+            tglLeaderImport.Checked = false;
 
             SetActivePanel( pnlSelectInstance );
         }
@@ -872,6 +874,8 @@ namespace RockWeb.Plugins.org_secc.Event
                 nameCount.Where( kv => kv.Value > 1 ).Select( kv => kv.Key ),
                 StringComparer.OrdinalIgnoreCase );
 
+            bool isLeaderImport = tglLeaderImport.Checked;
+
             using ( var rockContext = new RockContext() )
             {
                 var registrants = LoadRegistrants( rockContext );
@@ -971,7 +975,25 @@ namespace RockWeb.Plugins.org_secc.Event
                         Group targetGroup;
                         if ( meta.GroupByName.TryGetValue( cellValue, out targetGroup ) )
                         {
-                            placementParts.Add( string.Format( "{0}: {1} ✓", mapping.CsvColumnName, cellValue ) );
+                            if ( isLeaderImport )
+                            {
+                                var groupTypeCache = GroupTypeCache.Get( targetGroup.GroupTypeId );
+                                bool hasLeaderRole = groupTypeCache != null && groupTypeCache.Roles.Any( r => r.IsLeader );
+                                if ( hasLeaderRole )
+                                {
+                                    placementParts.Add( string.Format( "{0}: {1} ✓ (leader)", mapping.CsvColumnName, cellValue ) );
+                                }
+                                else
+                                {
+                                    placementParts.Add( string.Format( "{0}: {1} ✗ (group type has no leader role)", mapping.CsvColumnName, cellValue ) );
+                                    preview.HasError = true;
+                                    preview.Status = "Error";
+                                }
+                            }
+                            else
+                            {
+                                placementParts.Add( string.Format( "{0}: {1} ✓", mapping.CsvColumnName, cellValue ) );
+                            }
                         }
                         else
                         {
@@ -1303,6 +1325,7 @@ namespace RockWeb.Plugins.org_secc.Event
                 BinaryFileId = UploadedBinaryFileId.Value,
                 FirstNameCol = firstNameCol,
                 LastNameCol = lastNameCol,
+                IsLeaderImport = tglLeaderImport.Checked,
                 BatchSize = GetAttributeValue( AttributeKey.BatchSize ).AsIntegerOrNull() ?? 50,
                 DefaultGroupMemberStatusValue = GetAttributeValue( AttributeKey.DefaultGroupMemberStatus ).AsInteger(),
                 Mappings = mappings.Select( m => new

--- a/Plugins/org.secc.Jobs/Event/CampPlacementImportModels.cs
+++ b/Plugins/org.secc.Jobs/Event/CampPlacementImportModels.cs
@@ -30,6 +30,14 @@ namespace org.secc.Jobs.Event
         public int? BinaryFileId { get; set; }
         public string FirstNameCol { get; set; }
         public string LastNameCol { get; set; }
+
+        /// <summary>
+        /// When true, people in this import are placed using the group type role
+        /// marked IsLeader instead of the default role. Existing members with a
+        /// non-leader role are updated to the leader role.
+        /// </summary>
+        public bool IsLeaderImport { get; set; }
+
         public int BatchSize { get; set; }
         public int DefaultGroupMemberStatusValue { get; set; }
         public List<CampPlacementMappingData> Mappings { get; set; }

--- a/Plugins/org.secc.Jobs/Event/CampPlacementImportRunner.cs
+++ b/Plugins/org.secc.Jobs/Event/CampPlacementImportRunner.cs
@@ -399,8 +399,8 @@ namespace org.secc.Jobs.Event
                                 if ( !targetRoleId.HasValue )
                                 {
                                     placementResult.Outcome = PlacementOutcome.Error;
-                                    placementResult.Message = string.Format(
-                                        "Group '{0}' has no group role marked 'Is Leader'", targetGroup.Name );
+placementResult.Message = string.Format(
+    "Group type for group '{0}' has no role marked 'Is Leader'.", targetGroup.Name );
                                     errorCount++;
                                     resultRow.Placements.Add( placementResult );
                                     continue;

--- a/Plugins/org.secc.Jobs/Event/CampPlacementImportRunner.cs
+++ b/Plugins/org.secc.Jobs/Event/CampPlacementImportRunner.cs
@@ -373,20 +373,79 @@ namespace org.secc.Jobs.Event
                                 continue;
                             }
 
+                            // Resolve the role to place this person into. Leader imports use the
+                            // group type role marked IsLeader; camper imports use the default role.
+                            var groupTypeCache = GroupTypeCache.Get( targetGroup.GroupTypeId );
+                            int? targetRoleId;
+
+                            if ( request.IsLeaderImport )
+                            {
+                                targetRoleId = groupTypeCache != null
+                                    ? groupTypeCache.Roles
+                                        .Where( r => r.IsLeader )
+                                        .OrderBy( r => r.Order )
+                                        .Select( r => ( int? ) r.Id )
+                                        .FirstOrDefault()
+                                    : null;
+
+                                if ( !targetRoleId.HasValue )
+                                {
+                                    placementResult.Outcome = PlacementOutcome.Error;
+                                    placementResult.Message = string.Format(
+                                        "Group '{0}' has no group role marked 'Is Leader'", targetGroup.Name );
+                                    errorCount++;
+                                    resultRow.Placements.Add( placementResult );
+                                    continue;
+                                }
+                            }
+                            else
+                            {
+                                targetRoleId = groupTypeCache != null ? groupTypeCache.DefaultGroupRoleId : ( int? ) null;
+
+                                if ( !targetRoleId.HasValue )
+                                {
+                                    placementResult.Outcome = PlacementOutcome.Error;
+                                    placementResult.Message = string.Format(
+                                        "Group '{0}' has no default group role configured", targetGroup.Name );
+                                    errorCount++;
+                                    resultRow.Placements.Add( placementResult );
+                                    continue;
+                                }
+                            }
+
                             string membershipKey = MembershipKey( person.Id, targetGroup.Id );
                             GroupMember existingMember;
                             existingMembershipLookup.TryGetValue( membershipKey, out existingMember );
 
                             if ( existingMember != null )
                             {
+                                bool existingRoleIsLeader = groupTypeCache != null
+                                    && groupTypeCache.Roles.Any( r => r.Id == existingMember.GroupRoleId && r.IsLeader );
+
                                 if ( existingMember.IsArchived )
                                 {
                                     existingMember.IsArchived = false;
                                     existingMember.ArchivedDateTime = null;
                                     existingMember.ArchivedByPersonAliasId = null;
                                     existingMember.GroupMemberStatus = status;
+
+                                    // On a leader import, make sure the restored membership carries the leader role.
+                                    if ( request.IsLeaderImport && !existingRoleIsLeader )
+                                    {
+                                        existingMember.GroupRoleId = targetRoleId.Value;
+                                    }
+
                                     placementResult.Outcome = PlacementOutcome.Success;
                                     placementResult.Message = string.Format( "Restored archived membership in '{0}'", targetGroup.Name );
+                                    successCount++;
+                                    pendingSaves++;
+                                }
+                                else if ( request.IsLeaderImport && !existingRoleIsLeader )
+                                {
+                                    // Existing member holds a non-leader role — update them to the leader role.
+                                    existingMember.GroupRoleId = targetRoleId.Value;
+                                    placementResult.Outcome = PlacementOutcome.Success;
+                                    placementResult.Message = string.Format( "Updated role to leader in '{0}'", targetGroup.Name );
                                     successCount++;
                                     pendingSaves++;
                                 }
@@ -401,24 +460,11 @@ namespace org.secc.Jobs.Event
                                 continue;
                             }
 
-                            var groupTypeCache = GroupTypeCache.Get( targetGroup.GroupTypeId );
-                            int? defaultRoleId = groupTypeCache != null ? groupTypeCache.DefaultGroupRoleId : ( int? ) null;
-
-                            if ( !defaultRoleId.HasValue )
-                            {
-                                placementResult.Outcome = PlacementOutcome.Error;
-                                placementResult.Message = string.Format(
-                                    "Group '{0}' has no default group role configured", targetGroup.Name );
-                                errorCount++;
-                                resultRow.Placements.Add( placementResult );
-                                continue;
-                            }
-
                             var groupMember = new GroupMember
                             {
                                 PersonId = person.Id,
                                 GroupId = targetGroup.Id,
-                                GroupRoleId = defaultRoleId.Value,
+                                GroupRoleId = targetRoleId.Value,
                                 GroupMemberStatus = status
                             };
 
@@ -474,7 +520,7 @@ namespace org.secc.Jobs.Event
                     }
                 }
 
-                string resultHtml = RenderResultsTable( resultRows, request.Mappings, totalRows );
+                string resultHtml = RenderResultsTable( resultRows, request.Mappings, totalRows, request.IsLeaderImport );
                 MarkCompleted( runId, successCount, skippedCount, errorCount, totalRows, resultHtml );
             }
             finally
@@ -793,14 +839,15 @@ WHERE [Id] = @runId",
         private static string RenderResultsTable(
             List<ResultRow> resultRows,
             List<CampPlacementMappingData> mappings,
-            int totalRows )
+            int totalRows,
+            bool isLeaderImport )
         {
             var sb = new StringBuilder();
             sb.Append( "<div class='table-responsive'>" );
             sb.Append( "<table class='table table-bordered table-striped table-condensed'>" );
 
             sb.Append( "<thead><tr>" );
-            sb.Append( "<th>Row</th><th>Camper</th><th>Matched Person</th>" );
+            sb.AppendFormat( "<th>Row</th><th>{0}</th><th>Matched Person</th>", isLeaderImport ? "Leader" : "Camper" );
             foreach ( var m in mappings )
                 sb.AppendFormat( "<th>{0}</th>", System.Web.HttpUtility.HtmlEncode( m.CsvColumnName ) );
             sb.Append( "</tr></thead><tbody>" );

--- a/Plugins/org.secc.Jobs/Event/CampPlacementImportRunner.cs
+++ b/Plugins/org.secc.Jobs/Event/CampPlacementImportRunner.cs
@@ -185,7 +185,7 @@ namespace org.secc.Jobs.Event
                 int skippedCount = 0;
                 int errorCount = 0;
                 var resultRows = new List<ResultRow>();
-                
+
                 DateTime lastProgressUpdate = DateTime.UtcNow;
 
                 using ( var rockContext = new RockContext() )
@@ -221,6 +221,7 @@ namespace org.secc.Jobs.Event
                         .ToList();
 
                     var existingMembershipLookup = new Dictionary<string, GroupMember>();
+                    var existingMembershipsByKey = new Dictionary<string, List<GroupMember>>();
                     if ( allTargetGroupIds.Any() && allPersonIds.Any() )
                     {
                         var existingMembers = groupMemberService.Queryable()
@@ -228,11 +229,16 @@ namespace org.secc.Jobs.Event
                                        && allPersonIds.Contains( gm.PersonId ) )
                             .ToList();
 
-                        existingMembershipLookup = existingMembers
+                        // A person can hold multiple memberships in the same group (one per
+                        // role), so keep every row per person+group for role-aware selection.
+                        existingMembershipsByKey = existingMembers
                             .GroupBy( gm => MembershipKey( gm.PersonId, gm.GroupId ) )
+                            .ToDictionary( g => g.Key, g => g.ToList() );
+
+                        existingMembershipLookup = existingMembershipsByKey
                             .ToDictionary(
-                                g => g.Key,
-                                g => g
+                                kv => kv.Key,
+                                kv => kv.Value
                                     .OrderBy( gm => gm.IsArchived )
                                     .ThenBy( gm => gm.Id )
                                     .First() );
@@ -287,7 +293,7 @@ namespace org.secc.Jobs.Event
 
                         var resultRow = new ResultRow
                         {
-                            CsvRowNumber = rowIdx + 2, 
+                            CsvRowNumber = rowIdx + 2,
                             CamperName = csvFullName,
                             Placements = new List<PlacementResult>()
                         };
@@ -311,7 +317,8 @@ namespace org.secc.Jobs.Event
                                 errorCount++;
                             }
 
-                            if ( resultRows.Count < 200 ) resultRows.Add( resultRow );
+                            if ( resultRows.Count < 200 )
+                                resultRows.Add( resultRow );
                             processedRows++;
                             continue;
                         }
@@ -335,7 +342,8 @@ namespace org.secc.Jobs.Event
                                 errorCount++;
                             }
 
-                            if ( resultRows.Count < 200 ) resultRows.Add( resultRow );
+                            if ( resultRows.Count < 200 )
+                                resultRows.Add( resultRow );
                             processedRows++;
                             continue;
                         }
@@ -417,6 +425,27 @@ namespace org.secc.Jobs.Event
                             GroupMember existingMember;
                             existingMembershipLookup.TryGetValue( membershipKey, out existingMember );
 
+                            // On a leader import, prefer an existing leader-role membership when the
+                            // person holds multiple rows in this group. Promoting a non-leader row
+                            // while a leader row already exists would create a duplicate membership.
+                            if ( request.IsLeaderImport && existingMember != null )
+                            {
+                                List<GroupMember> allMembershipRows;
+                                if ( existingMembershipsByKey.TryGetValue( membershipKey, out allMembershipRows ) )
+                                {
+                                    var leaderRow = allMembershipRows
+                                        .Where( gm => groupTypeCache.Roles.Any( r => r.Id == gm.GroupRoleId && r.IsLeader ) )
+                                        .OrderBy( gm => gm.IsArchived )
+                                        .ThenBy( gm => gm.Id )
+                                        .FirstOrDefault();
+
+                                    if ( leaderRow != null )
+                                    {
+                                        existingMember = leaderRow;
+                                    }
+                                }
+                            }
+
                             if ( existingMember != null )
                             {
                                 bool existingRoleIsLeader = groupTypeCache != null
@@ -442,12 +471,29 @@ namespace org.secc.Jobs.Event
                                 }
                                 else if ( request.IsLeaderImport && !existingRoleIsLeader )
                                 {
-                                    // Existing member holds a non-leader role — update them to the leader role.
+                                    // Existing member holds a non-leader role — update them to the leader
+                                    // role. Validate the change so a conflicting membership surfaces as a
+                                    // row error instead of failing the whole batch save.
+                                    var previousRoleId = existingMember.GroupRoleId;
                                     existingMember.GroupRoleId = targetRoleId.Value;
-                                    placementResult.Outcome = PlacementOutcome.Success;
-                                    placementResult.Message = string.Format( "Updated role to leader in '{0}'", targetGroup.Name );
-                                    successCount++;
-                                    pendingSaves++;
+
+                                    if ( existingMember.IsValidGroupMember( rockContext ) )
+                                    {
+                                        placementResult.Outcome = PlacementOutcome.Success;
+                                        placementResult.Message = string.Format( "Updated role to leader in '{0}'", targetGroup.Name );
+                                        successCount++;
+                                        pendingSaves++;
+                                    }
+                                    else
+                                    {
+                                        existingMember.GroupRoleId = previousRoleId;
+                                        placementResult.Outcome = PlacementOutcome.Error;
+                                        placementResult.Message = string.Format(
+                                            "Could not update role to leader in '{0}': {1}",
+                                            targetGroup.Name,
+                                            string.Join( "; ", existingMember.ValidationResults.Select( v => v.ErrorMessage ) ) );
+                                        errorCount++;
+                                    }
                                 }
                                 else
                                 {
@@ -473,6 +519,14 @@ namespace org.secc.Jobs.Event
                                 groupMemberService.Add( groupMember );
                                 existingMembershipLookup[membershipKey] = groupMember;
 
+                                List<GroupMember> keyRows;
+                                if ( !existingMembershipsByKey.TryGetValue( membershipKey, out keyRows ) )
+                                {
+                                    keyRows = new List<GroupMember>();
+                                    existingMembershipsByKey[membershipKey] = keyRows;
+                                }
+                                keyRows.Add( groupMember );
+
                                 placementResult.Outcome = PlacementOutcome.Success;
                                 placementResult.Message = string.Format( "Added to '{0}'", targetGroup.Name );
                                 successCount++;
@@ -491,7 +545,8 @@ namespace org.secc.Jobs.Event
                             resultRow.Placements.Add( placementResult );
                         }
 
-                        if ( resultRows.Count < 200 ) resultRows.Add( resultRow );
+                        if ( resultRows.Count < 200 )
+                            resultRows.Add( resultRow );
                         processedRows++;
 
                         if ( pendingSaves >= batchSize )
@@ -500,7 +555,7 @@ namespace org.secc.Jobs.Event
                             pendingSaves = 0;
                         }
 
-                        if ( processedRows == totalRows || (DateTime.UtcNow - lastProgressUpdate).TotalSeconds >= 2 )
+                        if ( processedRows == totalRows || ( DateTime.UtcNow - lastProgressUpdate ).TotalSeconds >= 2 )
                         {
                             int pct = totalRows > 0
                                 ? ( int ) Math.Round( ( processedRows / ( double ) totalRows ) * 100 )
@@ -509,7 +564,7 @@ namespace org.secc.Jobs.Event
                             UpdateRunStatus( runId, ImportRunStatus.Running,
                                 string.Format( "Processing row {0} of {1}…", processedRows, totalRows ),
                                 pct, processedRows, totalRows );
-                            
+
                             lastProgressUpdate = DateTime.UtcNow;
                         }
                     }
@@ -912,7 +967,7 @@ WHERE [Id] = @runId",
                 sb.Append( "</tr>" );
             }
 
-            if ( totalRows > 200 ) 
+            if ( totalRows > 200 )
             {
                 sb.AppendFormat( "<tr><td colspan='100%' class='text-center text-muted'><i>Showing first 200 results... Please consult overall counts for final summaries.</i></td></tr>" );
             }

--- a/Plugins/org.secc.Jobs/Event/CampPlacementImportRunner.cs
+++ b/Plugins/org.secc.Jobs/Event/CampPlacementImportRunner.cs
@@ -224,7 +224,9 @@ namespace org.secc.Jobs.Event
                     var existingMembershipsByKey = new Dictionary<string, List<GroupMember>>();
                     if ( allTargetGroupIds.Any() && allPersonIds.Any() )
                     {
-                        var existingMembers = groupMemberService.Queryable()
+                        // Include archived rows (second arg) so an archived membership is restored
+                        // instead of a duplicate active row being created alongside it.
+                        var existingMembers = groupMemberService.Queryable( false, true )
                             .Where( gm => allTargetGroupIds.Contains( gm.GroupId )
                                        && allPersonIds.Contains( gm.PersonId ) )
                             .ToList();
@@ -453,6 +455,11 @@ placementResult.Message = string.Format(
 
                                 if ( existingMember.IsArchived )
                                 {
+                                    var previousRoleId = existingMember.GroupRoleId;
+                                    var previousStatus = existingMember.GroupMemberStatus;
+                                    var previousArchivedDateTime = existingMember.ArchivedDateTime;
+                                    var previousArchivedByPersonAliasId = existingMember.ArchivedByPersonAliasId;
+
                                     existingMember.IsArchived = false;
                                     existingMember.ArchivedDateTime = null;
                                     existingMember.ArchivedByPersonAliasId = null;
@@ -464,10 +471,30 @@ placementResult.Message = string.Format(
                                         existingMember.GroupRoleId = targetRoleId.Value;
                                     }
 
-                                    placementResult.Outcome = PlacementOutcome.Success;
-                                    placementResult.Message = string.Format( "Restored archived membership in '{0}'", targetGroup.Name );
-                                    successCount++;
-                                    pendingSaves++;
+                                    // Validate the restore so a conflicting membership surfaces as a
+                                    // row error instead of failing the whole batch save.
+                                    if ( existingMember.IsValidGroupMember( rockContext ) )
+                                    {
+                                        placementResult.Outcome = PlacementOutcome.Success;
+                                        placementResult.Message = string.Format( "Restored archived membership in '{0}'", targetGroup.Name );
+                                        successCount++;
+                                        pendingSaves++;
+                                    }
+                                    else
+                                    {
+                                        existingMember.IsArchived = true;
+                                        existingMember.ArchivedDateTime = previousArchivedDateTime;
+                                        existingMember.ArchivedByPersonAliasId = previousArchivedByPersonAliasId;
+                                        existingMember.GroupMemberStatus = previousStatus;
+                                        existingMember.GroupRoleId = previousRoleId;
+
+                                        placementResult.Outcome = PlacementOutcome.Error;
+                                        placementResult.Message = string.Format(
+                                            "Could not restore archived membership in '{0}': {1}",
+                                            targetGroup.Name,
+                                            string.Join( "; ", existingMember.ValidationResults.Select( v => v.ErrorMessage ) ) );
+                                        errorCount++;
+                                    }
                                 }
                                 else if ( request.IsLeaderImport && !existingRoleIsLeader )
                                 {


### PR DESCRIPTION
Adds a Campers/Leaders toggle to the column mapping step. Leader imports place people using the group type role marked IsLeader instead of the default role, update existing non-leader members to the leader role, and error when a target group type has no leader role. Preview validates leader roles before processing.