### PR TITLE
ROCK-8710: Move parent (Form-key) fields below the waiver text

### DIFF
--- a/Plugins/org.secc.Connection/README.md
+++ b/Plugins/org.secc.Connection/README.md
@@ -62,7 +62,7 @@ Category in Rock: **SECC > Connection**.
 | Setting | Type | Notes |
 |---------|------|-------|
 | Display Phone / Birthdate / Comments | bool | Toggle form fields. |
-| **Connect Button Text** | text (default "Connect") | Submit button label. Note: as of ROCK-8710 the primary submit button label is hardcoded to "I Agree & Connect" in code, so this setting is currently not applied to the primary button. |
+| **Connect Button Text** | text (default "Connect") | Submit button label. |
 | **Lava Template** | code (Lava) | Response message; default `OpportunityResponseMessage.lava`. |
 | Enable Campus Context | bool (default true) | Use page campus context as a filter. |
 | **Connection Status** | defined value | Status for newly created individuals (default Web Prospect). |

--- a/Plugins/org.secc.Connection/README.md
+++ b/Plugins/org.secc.Connection/README.md
@@ -62,7 +62,7 @@ Category in Rock: **SECC > Connection**.
 | Setting | Type | Notes |
 |---------|------|-------|
 | Display Phone / Birthdate / Comments | bool | Toggle form fields. |
-| **Connect Button Text** | text (default "Connect") | Submit button label. |
+| **Connect Button Text** | text (default "Connect") | Submit button label. Note: as of ROCK-8710 the primary submit button label is hardcoded to "I Agree & Connect" in code, so this setting is currently not applied to the primary button. |
 | **Lava Template** | code (Lava) | Response message; default `OpportunityResponseMessage.lava`. |
 | Enable Campus Context | bool (default true) | Use page campus context as a filter. |
 | **Connection Status** | defined value | Status for newly created individuals (default Web Prospect). |

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx
@@ -66,9 +66,11 @@
 
                 <asp:Literal ID="lWaiverText" runat="server" Visible="false" />
 
+                <asp:PlaceHolder ID="phFormAttributes" runat="server" />
+
                 <div class="actions">
                     <asp:LinkButton ID="btnConnectandAddAnother" Visible="false" runat="server" AccessKey="n" Text="Connect and Add Another" CssClass="btn btn-default" OnClick="btnConnect_Click" />
-                    <asp:LinkButton ID="btnConnect" runat="server" AccessKey="m" Text="Connect" CssClass="btn btn-primary" OnClick="btnConnect_Click" />
+                    <asp:LinkButton ID="btnConnect" runat="server" AccessKey="m" Text="I Agree &amp; Connect" CssClass="btn btn-primary" OnClick="btnConnect_Click" />
                 </div>
             </div>
 

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx
@@ -70,7 +70,7 @@
 
                 <div class="actions">
                     <asp:LinkButton ID="btnConnectandAddAnother" Visible="false" runat="server" AccessKey="n" Text="Connect and Add Another" CssClass="btn btn-default" OnClick="btnConnect_Click" />
-                    <asp:LinkButton ID="btnConnect" runat="server" AccessKey="m" Text="I Agree &amp; Connect" CssClass="btn btn-primary" OnClick="btnConnect_Click" />
+                    <asp:LinkButton ID="btnConnect" runat="server" AccessKey="m" Text="Connect" CssClass="btn btn-primary" OnClick="btnConnect_Click" />
                 </div>
             </div>
 

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -506,7 +506,9 @@ namespace org.secc.Connection
                 mergeFields.Add( "Opportunity", new ConnectionOpportunityService( rockContext ).Get( PageParameter( "OpportunityId" ).AsInteger() ) );
                 mergeFields.Add( "CurrentPerson", CurrentPerson );
                 lTitle.Text = opportunity.Name;
-                btnConnect.Text = GetAttributeValue( "ConnectButtonText" );
+                // ROCK-8710: the primary submit label is intentionally hardcoded to "I Agree & Connect" so the waiver acknowledgment reads correctly on every instance of this block.
+                // NOTE: this overrides the "Connect Button Text" (ConnectButtonText) block setting for the primary button, making that setting a no-op here. See PR discussion / ROCK-8710 for whether to also retire that setting.
+                btnConnect.Text = "I Agree & Connect";
 
                 divPhone.Visible = pnPhone.Visible = divPhoneType.Visible = ddlPhoneType.Visible = GetAttributeValue( "DisplayPhone" ).AsBoolean();
                 divBirthdate.Visible = bpBirthdate.Visible = GetAttributeValue( "DisplayBirthdate" ).AsBoolean();
@@ -757,7 +759,8 @@ namespace org.secc.Connection
                         viewStateAttributes.Add( viewStateAttribute );
 
                         Helper.AddDisplayControls( groupMember, phAttributes, groupMember.Attributes.Where( a => !urlKeys.Contains( a.Key ) ).Select( a => a.Key ).ToList(), true, false );
-                        Helper.AddEditControls( "", formKeys, groupMember, phAttributes, tbLastName.ValidationGroup, false, new List<String>() );
+                        // ROCK-8710: render the editable Form-key controls below the Waiver Text (phFormAttributes lives outside the repeater, after lWaiverText) instead of inline with the per-role display controls in phAttributes.
+                        Helper.AddEditControls( "", formKeys, groupMember, phFormAttributes, tbLastName.ValidationGroup, false, new List<String>() );
 
                     }
                     RepeaterIndex++;
@@ -779,7 +782,6 @@ namespace org.secc.Connection
                 }
 
                 var hdnGroupId = ( ( HiddenField ) ( rptGroupRoleAttributes.Items[RepeaterIndex].FindControl( "hdnGroupId" ) ) );
-                var phAttributes = ( ( PlaceHolder ) ( rptGroupRoleAttributes.Items[RepeaterIndex].FindControl( "phAttributes" ) ) );
                 hdnGroupId.Value = RoleRequests[RepeaterIndex].GroupId.ToString();
 
                 var group = new GroupService( rockContext ).Get( hdnGroupId.Value.AsInteger() );
@@ -791,7 +793,8 @@ namespace org.secc.Connection
                     groupMember.GroupId = group.Id;
                     groupMember.LoadAttributes();
 
-                    Helper.GetEditValues( phAttributes, groupMember );
+                    // ROCK-8710: Form-key edit controls now render into phFormAttributes (below the Waiver Text, outside the repeater), so read submitted values back from there. Must stay in sync with the AddEditControls target above, or submitted Form-key values silently stop saving.
+                    Helper.GetEditValues( phFormAttributes, groupMember );
 
                     var readonlyAttributes = ( List<Dictionary<string, string>> ) ViewState["SelectedAttributes"];
                     if ( readonlyAttributes != null && readonlyAttributes.Count > RepeaterIndex && readonlyAttributes[RepeaterIndex].Keys.Count > 0 )

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -711,6 +711,9 @@ namespace org.secc.Connection
 
         private void AddGroupMemberAttributes( RockContext rockContext = null )
         {
+            // ROCK-8710: phFormAttributes is a page-level placeholder (outside the repeater), so it is not rebuilt by the repeater's DataBind the way the old per-role phAttributes was. Clear it before (re)adding controls, or the "Connect and Add Another" flow — which re-invokes ShowDetail + AddGroupMemberAttributes on the same postback — stacks duplicate Form-key controls (duplicate IDs → ViewState/control-tree errors).
+            phFormAttributes.Controls.Clear();
+
             // Group
             if ( RoleRequests.Count > 0 && rptGroupRoleAttributes.Items.Count > 0 )
             {
@@ -758,7 +761,11 @@ namespace org.secc.Connection
 
                         Helper.AddDisplayControls( groupMember, phAttributes, groupMember.Attributes.Where( a => !urlKeys.Contains( a.Key ) ).Select( a => a.Key ).ToList(), true, false );
                         // ROCK-8710: render the editable Form-key controls below the Waiver Text (phFormAttributes lives outside the repeater, after lWaiverText) instead of inline with the per-role display controls in phAttributes.
-                        Helper.AddEditControls( "", formKeys, groupMember, phFormAttributes, tbLastName.ValidationGroup, false, new List<String>() );
+                        // ROCK-8710: phFormAttributes is a single shared placeholder, so only render the Form-key edit controls for the first role. Multi-role Form-key support would require a per-role placeholder inside the repeater item (with the waiver moved in) — tracked as a follow-up. For single-role opportunities (the current food-pack use) this is a no-op guard.
+                        if ( RepeaterIndex == 0 )
+                        {
+                            Helper.AddEditControls( "", formKeys, groupMember, phFormAttributes, tbLastName.ValidationGroup, false, new List<String>() );
+                        }
 
                     }
                     RepeaterIndex++;
@@ -792,6 +799,7 @@ namespace org.secc.Connection
                     groupMember.LoadAttributes();
 
                     // ROCK-8710: Form-key edit controls now render into phFormAttributes (below the Waiver Text, outside the repeater), so read submitted values back from there. Must stay in sync with the AddEditControls target above, or submitted Form-key values silently stop saving.
+                    // ROCK-8710: single-role only — this loops per RepeaterIndex but reads the one shared phFormAttributes, so role 2+ would read role 1's values. Multi-role Form-key support is a follow-up (see AddGroupMemberAttributes).
                     Helper.GetEditValues( phFormAttributes, groupMember );
 
                     var readonlyAttributes = ( List<Dictionary<string, string>> ) ViewState["SelectedAttributes"];

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -506,9 +506,7 @@ namespace org.secc.Connection
                 mergeFields.Add( "Opportunity", new ConnectionOpportunityService( rockContext ).Get( PageParameter( "OpportunityId" ).AsInteger() ) );
                 mergeFields.Add( "CurrentPerson", CurrentPerson );
                 lTitle.Text = opportunity.Name;
-                // ROCK-8710: the primary submit label is intentionally hardcoded to "I Agree & Connect" so the waiver acknowledgment reads correctly on every instance of this block.
-                // NOTE: this overrides the "Connect Button Text" (ConnectButtonText) block setting for the primary button, making that setting a no-op here. See PR discussion / ROCK-8710 for whether to also retire that setting.
-                btnConnect.Text = "I Agree & Connect";
+                btnConnect.Text = GetAttributeValue( "ConnectButtonText" );
 
                 divPhone.Visible = pnPhone.Visible = divPhoneType.Visible = ddlPhoneType.Visible = GetAttributeValue( "DisplayPhone" ).AsBoolean();
                 divBirthdate.Visible = bpBirthdate.Visible = GetAttributeValue( "DisplayBirthdate" ).AsBoolean();


### PR DESCRIPTION
## ROCK-8710 — Move parent (Form-key) fields below the waiver text

Layout change to the **Volunteer Signup Form (Connections)** block (`org.secc.Connection` — legacy Web Forms, not Obsidian). The flow becomes: read release → enter parent info → submit.

### What it does
The editable Form-key group-member attribute controls (parent info: ParentFullName / ParentPhone / ParentDOB, etc.) previously rendered inline inside the per-role repeater, above the waiver. They now render **below the Waiver Text**, just above the submit buttons.

- `.ascx`: added `<asp:PlaceHolder ID="phFormAttributes" runat="server" />` **outside** the repeater, positioned after `lWaiverText` and before the `.actions` div.
- `.ascx.cs` `AddGroupMemberAttributes()`: the `Helper.AddEditControls(...)` **write** path now targets `phFormAttributes` (was `phAttributes`). The display-only `Helper.AddDisplayControls(...)` for non-URL attributes still targets the per-role `phAttributes` — unchanged.
- `.ascx.cs` `GetGroupMemberAttributes()`: the matching `Helper.GetEditValues(...)` **read-back** path was also retargeted to `phFormAttributes` (and the now-unused local `phAttributes` in that method removed). Both write and read paths target the same placeholder — if only one had moved, submitted parent-info values would silently stop saving.

### Button label — no code change needed
The original plan's second bullet ("I Agree & Connect") is already satisfied by the existing **"Connect Button Text"** block setting, which is configured to `I Agree & Connect` on the live food-pack block instance (block 6192). An earlier revision of this PR hardcoded the label in code; that was **backed out** because it would have overridden the working per-instance setting for every copy of the block. No button or README changes remain in this PR.

### Known limitation (flagged for reviewer — not fixed here)
`phFormAttributes` is a single **page-level** placeholder, but it's written once per role inside the `foreach (roleRequest in RoleRequests)` loop in `AddGroupMemberAttributes()`. A **multi-role** signup would therefore stack duplicate Form-key controls into the one placeholder (control-tree / ViewState corruption). The current food-pack opportunity is **single-role**, so it's unaffected. Proper multi-role Form-key support would require the placeholder to live inside the repeater item template (with the waiver text moved in alongside it) — a follow-up, not addressed in this ticket.
