### PR TITLE
ROCK-8756: Dev SMS capture transport (Papercut for SMS)

### DIFF
--- a/Plugins/org.secc.SmsCapture/Data/SmsCaptureContext.cs
+++ b/Plugins/org.secc.SmsCapture/Data/SmsCaptureContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SmsCapture/Data/SmsCaptureContext.cs
+++ b/Plugins/org.secc.SmsCapture/Data/SmsCaptureContext.cs
@@ -1,0 +1,52 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Data.Entity;
+using org.secc.SmsCapture.Model;
+
+namespace org.secc.SmsCapture.Data
+{
+    public class SmsCaptureContext : Rock.Data.DbContext
+    {
+        #region Models
+        public DbSet<CapturedSms> CapturedSmsMessages { get; set; }
+        #endregion
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SmsCaptureContext"/> class.
+        /// </summary>
+        public SmsCaptureContext()
+            : base( "RockContext" )
+        {
+            //intentionally left blank
+        }
+
+        /// <summary>
+        /// This method is called when the model for a derived context has been initialized, but
+        /// before the model has been locked down and used to initialize the context.  The default
+        /// implementation of this method does nothing, but it can be overridden in a derived class
+        /// such that the model can be further configured before it is locked down.
+        /// </summary>
+        /// <param name="modelBuilder">The builder that defines the model for the context being created.</param>
+        protected override void OnModelCreating( DbModelBuilder modelBuilder )
+        {
+            // we don't want this context to create a database or look for EF Migrations, do set the Initializer to null
+            Database.SetInitializer<SmsCaptureContext>( new NullDatabaseInitializer<SmsCaptureContext>() );
+
+            Rock.Data.ContextHelper.AddConfigurations( modelBuilder );
+            modelBuilder.Configurations.AddFromAssembly( System.Reflection.Assembly.GetExecutingAssembly() );
+        }
+
+    }
+}

--- a/Plugins/org.secc.SmsCapture/Data/SmsCaptureDataService.cs
+++ b/Plugins/org.secc.SmsCapture/Data/SmsCaptureDataService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SmsCapture/Data/SmsCaptureDataService.cs
+++ b/Plugins/org.secc.SmsCapture/Data/SmsCaptureDataService.cs
@@ -1,0 +1,42 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+
+using Rock.Data;
+
+namespace org.secc.SmsCapture.Data
+{
+    public class SmsCaptureDataService<T> : Rock.Data.Service<T> where T : Rock.Data.Entity<T>, new()
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SmsCaptureDataService{T}"/> class.
+        /// </summary>
+        public SmsCaptureDataService( RockContext context )
+            : base( context )
+        {
+        }
+
+        /// <summary>
+        /// Determines whether this instance can delete the specified item.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <param name="errorMessage">The error message.</param>
+        /// <returns></returns>
+        public virtual bool CanDelete( T item, out string errorMessage )
+        {
+            errorMessage = string.Empty;
+            return true;
+        }
+    }
+}

--- a/Plugins/org.secc.SmsCapture/Migrations/001_Init.cs
+++ b/Plugins/org.secc.SmsCapture/Migrations/001_Init.cs
@@ -1,0 +1,49 @@
+namespace org.secc.SmsCapture.Migrations
+{
+    using Rock.Plugin;
+
+    [MigrationNumber( 1, "1.13.0" )]
+    public partial class Init : Migration
+    {
+        public override void Up()
+        {
+            AddTable(
+                "dbo._org_secc_SmsCapture_CapturedSms",
+                c => new
+                {
+                    Id = c.Int( nullable: false, identity: true ),
+                    FromNumber = c.String( maxLength: 20 ),
+                    ToNumber = c.String( maxLength: 20 ),
+                    RecipientPersonAliasId = c.Int(),
+                    Body = c.String(),
+                    AttachmentBinaryFileIds = c.String(),
+                    CommunicationId = c.Int(),
+                    CommunicationRecipientId = c.Int(),
+                    Source = c.String( maxLength: 100 ),
+                    CreatedDateTime = c.DateTime(),
+                    ModifiedDateTime = c.DateTime(),
+                    CreatedByPersonAliasId = c.Int(),
+                    ModifiedByPersonAliasId = c.Int(),
+                    Guid = c.Guid( nullable: false ),
+                    ForeignId = c.Int(),
+                    ForeignGuid = c.Guid(),
+                    ForeignKey = c.String( maxLength: 100 ),
+                } );
+            AddPrimaryKey( "dbo._org_secc_SmsCapture_CapturedSms", "Id" );
+            AddForeignKey( "dbo._org_secc_SmsCapture_CapturedSms", "RecipientPersonAliasId", "dbo.PersonAlias", "Id" );
+            AddForeignKey( "dbo._org_secc_SmsCapture_CapturedSms", "CreatedByPersonAliasId", "dbo.PersonAlias", "Id" );
+            AddForeignKey( "dbo._org_secc_SmsCapture_CapturedSms", "ModifiedByPersonAliasId", "dbo.PersonAlias", "Id" );
+            AddIndex( "dbo._org_secc_SmsCapture_CapturedSms", "RecipientPersonAliasId" );
+            AddIndex( "dbo._org_secc_SmsCapture_CapturedSms", "CreatedByPersonAliasId" );
+            AddIndex( "dbo._org_secc_SmsCapture_CapturedSms", "ModifiedByPersonAliasId" );
+            AddIndex( "dbo._org_secc_SmsCapture_CapturedSms", "Guid", unique: true );
+            AddIndex( "dbo._org_secc_SmsCapture_CapturedSms", "ToNumber" );
+            AddIndex( "dbo._org_secc_SmsCapture_CapturedSms", "CreatedDateTime" );
+        }
+
+        public override void Down()
+        {
+            DropTable( "dbo._org_secc_SmsCapture_CapturedSms" );
+        }
+    }
+}

--- a/Plugins/org.secc.SmsCapture/Migrations/Configuration.cs
+++ b/Plugins/org.secc.SmsCapture/Migrations/Configuration.cs
@@ -1,0 +1,17 @@
+namespace org.secc.SmsCapture.Migrations
+{
+    using System.Data.Entity.Migrations;
+
+    internal sealed class Configuration : DbMigrationsConfiguration<org.secc.SmsCapture.Data.SmsCaptureContext>
+    {
+        public Configuration()
+        {
+            AutomaticMigrationsEnabled = false;
+        }
+
+        protected override void Seed( org.secc.SmsCapture.Data.SmsCaptureContext context )
+        {
+            //  This method will be called after migrating to the latest version.
+        }
+    }
+}

--- a/Plugins/org.secc.SmsCapture/Model/CapturedSms.cs
+++ b/Plugins/org.secc.SmsCapture/Model/CapturedSms.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SmsCapture/Model/CapturedSms.cs
+++ b/Plugins/org.secc.SmsCapture/Model/CapturedSms.cs
@@ -1,0 +1,79 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity.ModelConfiguration;
+using System.Runtime.Serialization;
+
+namespace org.secc.SmsCapture.Model
+{
+    [Table( "_org_secc_SmsCapture_CapturedSms" )]
+    [DataContract]
+    public partial class CapturedSms : Rock.Data.Model<CapturedSms>, Rock.Security.ISecured, Rock.Data.IRockEntity
+    {
+        [DataMember]
+        [MaxLength( 20 )]
+        public string FromNumber { get; set; }
+
+        [DataMember]
+        [Index]
+        [MaxLength( 20 )]
+        public string ToNumber { get; set; }
+
+        [DataMember]
+        public int? RecipientPersonAliasId { get; set; }
+
+        [DataMember]
+        public string Body { get; set; }
+
+        /// <summary>
+        /// Comma-delimited BinaryFile ids of the SMS attachments (references only; media is not downloaded).
+        /// </summary>
+        [DataMember]
+        public string AttachmentBinaryFileIds { get; set; }
+
+        /// <summary>
+        /// Id of the Rock Communication this message came from, when applicable.
+        /// Stored without a foreign key so communication cleanup jobs can delete
+        /// old communications without being blocked by capture rows.
+        /// </summary>
+        [DataMember]
+        public int? CommunicationId { get; set; }
+
+        [DataMember]
+        public int? CommunicationRecipientId { get; set; }
+
+        /// <summary>
+        /// Which transport Send() overload produced the capture, e.g. "Communication" or "RockMessage".
+        /// </summary>
+        [DataMember]
+        [MaxLength( 100 )]
+        public string Source { get; set; }
+
+        public virtual Rock.Model.PersonAlias RecipientPersonAlias { get; set; }
+    }
+
+    public partial class CapturedSmsConfiguration : EntityTypeConfiguration<CapturedSms>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CapturedSmsConfiguration"/> class.
+        /// </summary>
+        public CapturedSmsConfiguration()
+        {
+            this.HasOptional( c => c.RecipientPersonAlias ).WithMany().HasForeignKey( c => c.RecipientPersonAliasId ).WillCascadeOnDelete( false );
+            this.HasEntitySetName( "CapturedSmsMessages" );
+        }
+    }
+}

--- a/Plugins/org.secc.SmsCapture/Model/CapturedSmsService.cs
+++ b/Plugins/org.secc.SmsCapture/Model/CapturedSmsService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SmsCapture/Model/CapturedSmsService.cs
+++ b/Plugins/org.secc.SmsCapture/Model/CapturedSmsService.cs
@@ -1,0 +1,24 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using org.secc.SmsCapture.Data;
+using Rock.Data;
+
+namespace org.secc.SmsCapture.Model
+{
+    public class CapturedSmsService : SmsCaptureDataService<CapturedSms>
+    {
+        public CapturedSmsService( RockContext context ) : base( context ) { }
+    }
+}

--- a/Plugins/org.secc.SmsCapture/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.SmsCapture/Properties/AssemblyInfo.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle( "org.secc.SmsCapture" )]
+[assembly: AssemblyDescription( "DEV-only SMS capture transport for Rock RMS. Captures outbound SMS to a table instead of sending." )]
+[assembly: AssemblyConfiguration( "" )]
+[assembly: AssemblyCompany( "Southeast Christian Church" )]
+[assembly: AssemblyProduct( "org.secc.SmsCapture" )]
+[assembly: AssemblyCopyright( "Copyright © Southeast Christian Church 2026" )]
+[assembly: AssemblyTrademark( "" )]
+[assembly: AssemblyCulture( "" )]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible( false )]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid( "04c883e4-020f-444a-9b21-4b29fca9eaf6" )]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion( "1.0.0.0" )]
+[assembly: AssemblyFileVersion( "1.0.0.0" )]

--- a/Plugins/org.secc.SmsCapture/README.md
+++ b/Plugins/org.secc.SmsCapture/README.md
@@ -1,0 +1,72 @@
+# org.secc.SmsCapture — Dev SMS Capture Transport ("Papercut for SMS")
+
+A Rock RMS **SMS transport plugin** that captures fully rendered outbound SMS messages to a
+database table instead of sending them — the SMS equivalent of Papercut SMTP. The transport
+reports success to Rock's communication pipeline so recipient statuses advance to
+Delivered/Sent exactly as they would in production, and a Papercut-style "SMS Capture Inbox"
+block shows everything that would have been sent.
+
+> **DEV / TESTING ONLY.** This transport never delivers a message. It contains no Twilio SDK
+> calls and no outbound HTTP whatsoever. It is deliberately kept in its own assembly
+> (`org.secc.SmsCapture.dll`) so it can be deployed to DEV without ever shipping to production.
+> Fail-closed: if it *is* accidentally deployed and selected on production, messages are
+> captured, not sent — annoying, but safe in the right direction.
+
+## What gets captured
+
+Every SMS Rock attempts to send through the SMS medium — bulk communications, system
+communications, SMS conversation replies, workflow SMS actions, and nightly jobs — is written
+to `_org_secc_SmsCapture_CapturedSms` with:
+
+| Field | Notes |
+|---|---|
+| FromNumber / ToNumber | as they would have gone to Twilio |
+| RecipientPersonAliasId | FK to PersonAlias when resolvable |
+| Body | fully rendered message (Lava already resolved) |
+| AttachmentBinaryFileIds | comma-delimited BinaryFile ids (references only; media is not downloaded) |
+| CommunicationId / CommunicationRecipientId | when applicable (plain ids, no FK, so communication cleanup jobs are never blocked) |
+| Source | which `Send()` overload produced it: `Communication` (bulk/queued path) or `RockMessage` (immediate path) |
+| CreatedDateTime | capture time |
+
+The transport is sync-only (it does not implement `IAsyncTransport`); Rock's
+`MediumComponent` automatically falls back to the synchronous `Send` overloads on every
+pipeline path, so nothing is missed.
+
+Component attributes:
+
+- **Enable Logging** (default: true) — writes a compact line to the Rock log
+  (`COMMUNICATIONS` domain) per captured message.
+- **Max Captured Messages** (default: 5000) — after each send, the oldest rows beyond this
+  cap are trimmed. Set to 0 to disable trimming.
+
+## Manual wiring steps (DEV ONLY)
+
+1. Deploy the plugin to all DEV web farm nodes: `org.secc.SmsCapture.dll` (+ `.pdb`) to
+   `RockWeb\bin`, and `org_secc\SmsCapture\` block files to `RockWeb\Plugins\org_secc\SmsCapture\`.
+   The plugin migration creates the capture table automatically on startup.
+2. **Admin Tools → Communications → Communication Transports** → confirm **SMS Capture**
+   appears; set its attributes and mark it **Active**.
+3. **Admin Tools → Communications → Communication Mediums → SMS** → set the Transport
+   Container selection to **SMS Capture**.
+   ⚠️ **DEV ONLY — never make this change on production.** ⚠️
+4. Create an internal admin page (e.g., under Admin Tools → Communications) and add the
+   **SMS Capture Inbox** block (category *SECC > Communication*).
+5. **Post-clone checklist:** after any prod→DEV database restore, re-verify the SMS medium's
+   transport is **SMS Capture** *before* enabling any jobs. The medium's transport setting
+   lives in the database (`Attribute`/`AttributeValue`) and **will revert to Twilio on
+   clone** — same class of problem as the OAuth Acceptable Domain setting that carried over
+   after a previous clone. Add this to the existing post-clone sanitization checklist doc.
+   Blanking the Twilio SID/Auth Token attribute values on DEV is a good belt-and-suspenders
+   measure while you're in there.
+
+## Verifying no Twilio traffic
+
+- The `org.secc.SmsCapture` project has **no** Twilio package reference, no `HttpClient`,
+  and no outbound calls of any kind — capture rows and log lines are the only side effects.
+- On DEV, blank the Twilio transport's SID/Auth Token attributes; test sends still succeed
+  (they never touch Twilio).
+
+## Phase 2 (not built)
+
+An inbound simulator (POSTing a synthetic Twilio webhook payload to Rock's SMS pipeline to
+test keyword responses and two-way conversations) was deliberately left out of scope.

--- a/Plugins/org.secc.SmsCapture/README.md
+++ b/Plugins/org.secc.SmsCapture/README.md
@@ -70,3 +70,7 @@ Component attributes:
 
 An inbound simulator (POSTing a synthetic Twilio webhook payload to Rock's SMS pipeline to
 test keyword responses and two-way conversations) was deliberately left out of scope.
+
+---
+
+**Last updated:** 2026-07-06

--- a/Plugins/org.secc.SmsCapture/Transport/SmsCapture.cs
+++ b/Plugins/org.secc.SmsCapture/Transport/SmsCapture.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SmsCapture/Transport/SmsCapture.cs
+++ b/Plugins/org.secc.SmsCapture/Transport/SmsCapture.cs
@@ -72,6 +72,11 @@ namespace org.secc.SmsCapture.Transport
         {
             errorMessages = new List<string>();
 
+            // Component attribute values are an in-memory snapshot loaded when the component
+            // singleton was constructed; reload so cap/logging changes made in the admin UI
+            // take effect without an app restart (including on other web farm nodes).
+            this.LoadAttributes();
+
             var smsMessage = rockMessage as RockSMSMessage;
             if ( smsMessage == null )
             {
@@ -198,6 +203,11 @@ namespace org.secc.SmsCapture.Transport
         /// <param name="mediumAttributes">The medium attributes.</param>
         public override void Send( Rock.Model.Communication communication, int mediumEntityTypeId, Dictionary<string, string> mediumAttributes )
         {
+            // Component attribute values are an in-memory snapshot loaded when the component
+            // singleton was constructed; reload so cap/logging changes made in the admin UI
+            // take effect without an app restart (including on other web farm nodes).
+            this.LoadAttributes();
+
             string fromPhone;
             var unprocessedRecipientCount = 0;
             var mergeFields = new Dictionary<string, object>();
@@ -388,6 +398,13 @@ namespace org.secc.SmsCapture.Transport
                     {
                         capturedSmsService.DeleteRange( excess );
                         rockContext.SaveChanges();
+
+                        if ( GetAttributeValue( AttributeKey.EnableLogging ).AsBooleanOrNull() ?? true )
+                        {
+                            RockLogger.Log.Information( RockLogDomains.Communications,
+                                "SMS Capture: trimmed {trimmedCount} captured messages over cap of {maxMessages}",
+                                excess.Count, maxMessages );
+                        }
                     }
                 }
             }

--- a/Plugins/org.secc.SmsCapture/Transport/SmsCapture.cs
+++ b/Plugins/org.secc.SmsCapture/Transport/SmsCapture.cs
@@ -289,6 +289,13 @@ namespace org.secc.SmsCapture.Transport
                 try
                 {
                     recipient = new CommunicationRecipientService( rockContext ).Get( recipient.Id );
+                    if ( recipient == null )
+                    {
+                        // Recipient no longer exists (e.g., deleted by another worker); nothing to
+                        // capture, and a null here would otherwise throw again from the catch below.
+                        return;
+                    }
+
                     var smsNumber = recipient.PersonAlias.Person.PhoneNumbers.GetFirstSmsNumber();
                     if ( !string.IsNullOrWhiteSpace( smsNumber ) )
                     {

--- a/Plugins/org.secc.SmsCapture/Transport/SmsCapture.cs
+++ b/Plugins/org.secc.SmsCapture/Transport/SmsCapture.cs
@@ -1,0 +1,410 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+using org.secc.SmsCapture.Model;
+using Rock;
+using Rock.Attribute;
+using Rock.Communication;
+using Rock.Data;
+using Rock.Logging;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace org.secc.SmsCapture.Transport
+{
+    /// <summary>
+    /// DEV/testing SMS transport that captures fully rendered outbound messages to a local
+    /// table instead of sending them, then reports success to the communication pipeline so
+    /// recipient statuses advance exactly as they would in production. Contains no Twilio SDK
+    /// calls and no outbound HTTP whatsoever.
+    /// </summary>
+    [Description( "Captures SMS to a local table instead of sending. DEV/testing only." )]
+    [Export( typeof( TransportComponent ) )]
+    [ExportMetadata( "ComponentName", "SMS Capture" )]
+    [BooleanField( "Enable Logging",
+        Description = "Write a compact line to the Rock log for each captured message.",
+        DefaultBooleanValue = true,
+        Order = 0,
+        Key = AttributeKey.EnableLogging )]
+    [IntegerField( "Max Captured Messages",
+        Description = "After each send the oldest captured messages beyond this cap are trimmed. Set to 0 to disable trimming.",
+        IsRequired = false,
+        DefaultIntegerValue = 5000,
+        Order = 1,
+        Key = AttributeKey.MaxCapturedMessages )]
+    public class SmsCapture : TransportComponent
+    {
+        /// <summary>
+        /// Keys to use for Component Attributes
+        /// </summary>
+        public static class AttributeKey
+        {
+            public const string EnableLogging = "EnableLogging";
+            public const string MaxCapturedMessages = "MaxCapturedMessages";
+        }
+
+        /// <summary>
+        /// Sends the specified rock message. This is the immediate path used by system
+        /// communications, workflow SMS actions and SMS conversation replies.
+        /// </summary>
+        /// <param name="rockMessage">The rock message.</param>
+        /// <param name="mediumEntityTypeId">The medium entity type identifier.</param>
+        /// <param name="mediumAttributes">The medium attributes.</param>
+        /// <param name="errorMessages">The error messages.</param>
+        /// <returns></returns>
+        public override bool Send( RockMessage rockMessage, int mediumEntityTypeId, Dictionary<string, string> mediumAttributes, out List<string> errorMessages )
+        {
+            errorMessages = new List<string>();
+
+            var smsMessage = rockMessage as RockSMSMessage;
+            if ( smsMessage == null )
+            {
+                errorMessages.Add( "The message was not a valid RockSMSMessage." );
+                return false;
+            }
+
+            // Validate From Number
+            if ( smsMessage.FromNumber == null )
+            {
+                errorMessages.Add( "A From Number was not provided." );
+                return false;
+            }
+
+            // Common Merge Fields
+            var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( null, rockMessage.CurrentPerson );
+            foreach ( var mergeField in rockMessage.AdditionalMergeFields )
+            {
+                mergeFields.AddOrReplace( mergeField.Key, mergeField.Value );
+            }
+
+            var attachmentBinaryFileIds = rockMessage.Attachments.Select( a => a.Id ).ToList().AsDelimited( "," );
+
+            foreach ( var recipient in rockMessage.GetRecipients() )
+            {
+                try
+                {
+                    foreach ( var mergeField in mergeFields )
+                    {
+                        recipient.MergeFields.AddOrIgnore( mergeField.Key, mergeField.Value );
+                    }
+
+                    using ( var rockContext = new RockContext() )
+                    {
+                        CommunicationRecipient communicationRecipient = null;
+                        if ( recipient.CommunicationRecipientId.HasValue )
+                        {
+                            communicationRecipient = new CommunicationRecipientService( rockContext ).Get( recipient.CommunicationRecipientId.Value );
+                        }
+
+                        string message = ResolveText( smsMessage.Message, smsMessage.CurrentPerson, communicationRecipient, smsMessage.EnabledLavaCommands, recipient.MergeFields, smsMessage.AppRoot, smsMessage.ThemeRoot );
+                        Person recipientPerson = ( Person ) recipient.MergeFields.GetValueOrNull( "Person" );
+
+                        // Create the communication record and capture using that if we have a person since a
+                        // communication record requires a valid person (mirrors the Twilio transport structure).
+                        if ( smsMessage.CreateCommunicationRecord && recipientPerson != null )
+                        {
+                            var communicationService = new CommunicationService( rockContext );
+
+                            var createSMSCommunicationArgs = new CommunicationService.CreateSMSCommunicationArgs
+                            {
+                                FromPerson = smsMessage.CurrentPerson,
+                                ToPersonAliasId = recipientPerson?.PrimaryAliasId,
+                                Message = message,
+                                FromPhone = smsMessage.FromNumber,
+                                CommunicationName = smsMessage.CommunicationName,
+                                ResponseCode = string.Empty,
+                                SystemCommunicationId = smsMessage.SystemCommunicationId
+                            };
+
+                            Rock.Model.Communication communication = communicationService.CreateSMSCommunication( createSMSCommunicationArgs );
+
+                            if ( smsMessage.CurrentPerson != null )
+                            {
+                                communication.CreatedByPersonAliasId = smsMessage.CurrentPerson.PrimaryAliasId;
+                                communication.ModifiedByPersonAliasId = smsMessage.CurrentPerson.PrimaryAliasId;
+                            }
+
+                            // Since we just created a new communication record, we need to move any attachments from the rockMessage
+                            // to the communication's attachments since the Send method below will be handling the capture.
+                            if ( smsMessage.Attachments.Any() )
+                            {
+                                foreach ( var attachment in smsMessage.Attachments )
+                                {
+                                    communication.AddAttachment( new CommunicationAttachment { BinaryFileId = attachment.Id }, CommunicationType.SMS );
+                                }
+                            }
+
+                            rockContext.SaveChanges();
+                            Send( communication, mediumEntityTypeId, mediumAttributes );
+
+                            communication.SendDateTime = RockDateTime.Now;
+                            rockContext.SaveChanges();
+                        }
+                        else
+                        {
+                            var capture = new CapturedSms
+                            {
+                                FromNumber = smsMessage.FromNumber.Value,
+                                ToNumber = recipient.To,
+                                RecipientPersonAliasId = recipientPerson?.PrimaryAliasId,
+                                Body = message,
+                                AttachmentBinaryFileIds = attachmentBinaryFileIds,
+                                CommunicationId = communicationRecipient?.CommunicationId,
+                                CommunicationRecipientId = recipient.CommunicationRecipientId,
+                                Source = "RockMessage"
+                            };
+                            new CapturedSmsService( rockContext ).Add( capture );
+
+                            // ResolveText set communicationRecipient.SentMessage (when there is one); this persists it too.
+                            rockContext.SaveChanges();
+                            LogCapture( capture );
+                        }
+                    }
+                }
+                catch ( Exception ex )
+                {
+                    errorMessages.Add( ex.Message );
+                    ExceptionLogService.LogException( ex );
+                }
+            }
+
+            TrimCapturedMessages();
+
+            return !errorMessages.Any();
+        }
+
+        /// <summary>
+        /// Sends the specified communication. This is the bulk/queued path used by the
+        /// communication wizard and the Send Communications job.
+        /// </summary>
+        /// <param name="communication">The communication.</param>
+        /// <param name="mediumEntityTypeId">The medium entity type identifier.</param>
+        /// <param name="mediumAttributes">The medium attributes.</param>
+        public override void Send( Rock.Model.Communication communication, int mediumEntityTypeId, Dictionary<string, string> mediumAttributes )
+        {
+            string fromPhone;
+            var unprocessedRecipientCount = 0;
+            var mergeFields = new Dictionary<string, object>();
+            Person currentPerson = null;
+            var personEntityTypeId = 0;
+            var communicationCategoryId = 0;
+            var communicationEntityTypeId = 0;
+            string attachmentBinaryFileIds = null;
+
+            using ( var rockContext = new RockContext() )
+            {
+                // Requery the Communication
+                communication = new CommunicationService( rockContext ).Get( communication.Id );
+
+                if ( communication != null &&
+                    communication.Status == CommunicationStatus.Approved &&
+                    ( !communication.FutureSendDateTime.HasValue || communication.FutureSendDateTime.Value.CompareTo( RockDateTime.Now ) <= 0 ) )
+                {
+                    unprocessedRecipientCount = new CommunicationRecipientService( rockContext ).Queryable()
+                        .Where( r =>
+                            r.CommunicationId == communication.Id &&
+                            r.Status == CommunicationRecipientStatus.Pending &&
+                            r.MediumEntityTypeId.HasValue &&
+                            r.MediumEntityTypeId.Value == mediumEntityTypeId )
+                        .Count();
+                }
+
+                if ( unprocessedRecipientCount == 0 )
+                {
+                    return;
+                }
+
+                fromPhone = communication.SMSFromDefinedValue?.Value;
+                if ( string.IsNullOrWhiteSpace( fromPhone ) )
+                {
+                    // just in case we got this far without a From Number, throw an exception
+                    throw new Exception( "A From Number was not provided for communication: " + communication.Id.ToString() );
+                }
+
+                currentPerson = communication.CreatedByPersonAlias?.Person;
+                mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( null, currentPerson );
+
+                personEntityTypeId = EntityTypeCache.Get<Person>().Id;
+                communicationEntityTypeId = EntityTypeCache.Get<Rock.Model.Communication>().Id;
+                communicationCategoryId = CategoryCache.Get( Rock.SystemGuid.Category.HISTORY_PERSON_COMMUNICATIONS.AsGuid(), rockContext ).Id;
+                attachmentBinaryFileIds = communication.GetAttachmentBinaryFileIds( CommunicationType.SMS ).AsDelimited( "," );
+            }
+
+            var publicAppRoot = GlobalAttributesCache.Get().GetValue( "PublicApplicationRoot" );
+
+            var recipientFound = true;
+            while ( recipientFound )
+            {
+                // make a new rockContext per recipient
+                var recipient = GetNextPending( communication.Id, mediumEntityTypeId, communication.IsBulkCommunication );
+
+                // This means we are done, break the loop
+                if ( recipient == null )
+                {
+                    recipientFound = false;
+                    continue;
+                }
+
+                CaptureCommunicationRecipient( communication, fromPhone, mergeFields, currentPerson, attachmentBinaryFileIds, personEntityTypeId, communicationCategoryId, communicationEntityTypeId, publicAppRoot, recipient );
+            }
+
+            TrimCapturedMessages();
+        }
+
+        /// <summary>
+        /// Captures a single communication recipient's message and advances their status,
+        /// mirroring the per-recipient structure of the Twilio transport (new RockContext per
+        /// recipient, same status/History side effects) minus the API call.
+        /// </summary>
+        private void CaptureCommunicationRecipient( Rock.Model.Communication communication, string fromPhone, Dictionary<string, object> mergeFields, Person currentPerson, string attachmentBinaryFileIds, int personEntityTypeId, int communicationCategoryId, int communicationEntityTypeId, string publicAppRoot, CommunicationRecipient recipient )
+        {
+            using ( var rockContext = new RockContext() )
+            {
+                try
+                {
+                    recipient = new CommunicationRecipientService( rockContext ).Get( recipient.Id );
+                    var smsNumber = recipient.PersonAlias.Person.PhoneNumbers.GetFirstSmsNumber();
+                    if ( !string.IsNullOrWhiteSpace( smsNumber ) )
+                    {
+                        // Create merge field dictionary
+                        var mergeObjects = recipient.CommunicationMergeValues( mergeFields );
+
+                        string message = ResolveText( communication.SMSMessage, currentPerson, recipient, communication.EnabledLavaCommands, mergeObjects, publicAppRoot );
+
+                        var capture = new CapturedSms
+                        {
+                            FromNumber = fromPhone,
+                            ToNumber = smsNumber,
+                            RecipientPersonAliasId = recipient.PersonAliasId,
+                            Body = message,
+                            AttachmentBinaryFileIds = attachmentBinaryFileIds,
+                            CommunicationId = communication.Id,
+                            CommunicationRecipientId = recipient.Id,
+                            Source = "Communication"
+                        };
+                        new CapturedSmsService( rockContext ).Add( capture );
+
+                        recipient.Status = CommunicationRecipientStatus.Delivered;
+                        recipient.StatusNote = "Captured by SMS Capture transport";
+                        recipient.SendDateTime = RockDateTime.Now;
+                        recipient.TransportEntityTypeName = this.GetType().FullName;
+                        recipient.UniqueMessageId = capture.Guid.ToString();
+
+                        try
+                        {
+                            var historyService = new HistoryService( rockContext );
+                            historyService.Add( new History
+                            {
+                                CreatedByPersonAliasId = communication.SenderPersonAliasId,
+                                EntityTypeId = personEntityTypeId,
+                                CategoryId = communicationCategoryId,
+                                EntityId = recipient.PersonAlias.PersonId,
+                                Verb = History.HistoryVerb.Sent.ConvertToString().ToUpper(),
+                                ChangeType = History.HistoryChangeType.Record.ToString(),
+                                ValueName = "SMS message",
+                                Caption = message.Truncate( 200 ),
+                                RelatedEntityTypeId = communicationEntityTypeId,
+                                RelatedEntityId = communication.Id
+                            } );
+                        }
+                        catch ( Exception ex )
+                        {
+                            ExceptionLogService.LogException( ex, null );
+                        }
+
+                        LogCapture( capture );
+                    }
+                    else
+                    {
+                        recipient.Status = CommunicationRecipientStatus.Failed;
+                        recipient.StatusNote = "No Phone Number with Messaging Enabled";
+                    }
+                }
+                catch ( Exception ex )
+                {
+                    recipient.Status = CommunicationRecipientStatus.Failed;
+                    recipient.StatusNote = "SMS Capture Exception: " + ex.Message;
+                }
+
+                rockContext.SaveChanges();
+            }
+        }
+
+        private CommunicationRecipient GetNextPending( int communicationId, int mediumEntityId, bool isBulkCommunication )
+        {
+            using ( var rockContext = new RockContext() )
+            {
+                var recipient = Rock.Model.Communication.GetNextPending( communicationId, mediumEntityId, rockContext );
+                if ( ValidRecipient( recipient, isBulkCommunication ) )
+                {
+                    return recipient;
+                }
+                else
+                {
+                    rockContext.SaveChanges();
+                    return GetNextPending( communicationId, mediumEntityId, isBulkCommunication );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Opportunistically trims the oldest captured messages beyond the Max Captured Messages cap.
+        /// </summary>
+        private void TrimCapturedMessages()
+        {
+            var maxMessages = GetAttributeValue( AttributeKey.MaxCapturedMessages ).AsIntegerOrNull() ?? 5000;
+            if ( maxMessages <= 0 )
+            {
+                return;
+            }
+
+            try
+            {
+                using ( var rockContext = new RockContext() )
+                {
+                    var capturedSmsService = new CapturedSmsService( rockContext );
+                    var excess = capturedSmsService.Queryable()
+                        .OrderByDescending( c => c.Id )
+                        .Skip( maxMessages )
+                        .ToList();
+
+                    if ( excess.Any() )
+                    {
+                        capturedSmsService.DeleteRange( excess );
+                        rockContext.SaveChanges();
+                    }
+                }
+            }
+            catch ( Exception ex )
+            {
+                ExceptionLogService.LogException( ex );
+            }
+        }
+
+        private void LogCapture( CapturedSms capture )
+        {
+            if ( GetAttributeValue( AttributeKey.EnableLogging ).AsBooleanOrNull() ?? true )
+            {
+                RockLogger.Log.Information( RockLogDomains.Communications,
+                    "SMS Capture: To={toNumber} From={fromNumber} CommunicationId={communicationId} Source={source} Guid={guid}",
+                    capture.ToNumber, capture.FromNumber, capture.CommunicationId, capture.Source, capture.Guid );
+            }
+        }
+    }
+}

--- a/Plugins/org.secc.SmsCapture/Transport/SmsCapture.cs
+++ b/Plugins/org.secc.SmsCapture/Transport/SmsCapture.cs
@@ -395,23 +395,22 @@ namespace org.secc.SmsCapture.Transport
             {
                 using ( var rockContext = new RockContext() )
                 {
-                    var capturedSmsService = new CapturedSmsService( rockContext );
-                    var excess = capturedSmsService.Queryable()
-                        .OrderByDescending( c => c.Id )
-                        .Skip( maxMessages )
-                        .ToList();
+                    // Delete beyond-cap rows entirely in SQL so their (potentially large) bodies
+                    // are never materialized into EF.
+                    var sql = @"
+;WITH cte AS (
+    SELECT [Id], ROW_NUMBER() OVER ( ORDER BY [Id] DESC ) AS [rn]
+    FROM [dbo].[_org_secc_SmsCapture_CapturedSms]
+)
+DELETE FROM cte WHERE [rn] > @p0";
 
-                    if ( excess.Any() )
+                    var trimmedCount = rockContext.Database.ExecuteSqlCommand( sql, maxMessages );
+
+                    if ( trimmedCount > 0 && ( GetAttributeValue( AttributeKey.EnableLogging ).AsBooleanOrNull() ?? true ) )
                     {
-                        capturedSmsService.DeleteRange( excess );
-                        rockContext.SaveChanges();
-
-                        if ( GetAttributeValue( AttributeKey.EnableLogging ).AsBooleanOrNull() ?? true )
-                        {
-                            RockLogger.Log.Information( RockLogDomains.Communications,
-                                "SMS Capture: trimmed {trimmedCount} captured messages over cap of {maxMessages}",
-                                excess.Count, maxMessages );
-                        }
+                        RockLogger.Log.Information( RockLogDomains.Communications,
+                            "SMS Capture: trimmed {trimmedCount} captured messages over cap of {maxMessages}",
+                            trimmedCount, maxMessages );
                     }
                 }
             }

--- a/Plugins/org.secc.SmsCapture/app.config
+++ b/Plugins/org.secc.SmsCapture/app.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/Plugins/org.secc.SmsCapture/org.secc.SmsCapture.csproj
+++ b/Plugins/org.secc.SmsCapture/org.secc.SmsCapture.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Model\CapturedSms.cs" />
     <Compile Include="Model\CapturedSmsService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Transport\SmsCapture.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)\DotLiquid\DotLiquid.csproj">

--- a/Plugins/org.secc.SmsCapture/org.secc.SmsCapture.csproj
+++ b/Plugins/org.secc.SmsCapture/org.secc.SmsCapture.csproj
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{04C883E4-020F-444A-9B21-4B29FCA9EAF6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>org.secc.SmsCapture</RootNamespace>
+    <AssemblyName>org.secc.SmsCapture</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Data\SmsCaptureContext.cs" />
+    <Compile Include="Data\SmsCaptureDataService.cs" />
+    <Compile Include="Migrations\001_Init.cs" />
+    <Compile Include="Migrations\Configuration.cs" />
+    <Compile Include="Model\CapturedSms.cs" />
+    <Compile Include="Model\CapturedSmsService.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)\DotLiquid\DotLiquid.csproj">
+      <Project>{00EDCB8D-EF33-459C-AD62-02876BD24DFF}</Project>
+      <Name>DotLiquid</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Rock\Rock.csproj">
+      <Project>{185a31d7-3037-4dae-8797-0459849a84bd}</Project>
+      <Name>Rock</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Rock.Common\Rock.Common.csproj">
+      <Project>{13568622-324e-4493-b605-c9896e725d30}</Project>
+      <Name>Rock.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Rock.Lava.Shared\Rock.Lava.Shared.csproj">
+      <Project>{8820cd93-70ee-496d-b17b-0c4c68dd4957}</Project>
+      <Name>Rock.Lava.Shared</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /R /E /I "$(ProjectDir)org_secc" "$(SolutionDir)RockWeb\Plugins\org_secc"
+xcopy /Y /R "$(ProjectDir)bin\Debug\org.secc.SmsCapture.dll" "$(SolutionDir)RockWeb\bin"
+xcopy /Y /R "$(ProjectDir)bin\Debug\org.secc.SmsCapture.pdb" "$(SolutionDir)RockWeb\bin"</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/Plugins/org.secc.SmsCapture/org_secc/SmsCapture/SmsCaptureInbox.ascx
+++ b/Plugins/org.secc.SmsCapture/org_secc/SmsCapture/SmsCaptureInbox.ascx
@@ -1,0 +1,57 @@
+<%@ Control Language="C#" AutoEventWireup="true" CodeFile="SmsCaptureInbox.ascx.cs" Inherits="RockWeb.Plugins.org_secc.SmsCapture.SmsCaptureInbox" %>
+<asp:UpdatePanel ID="upnlContent" runat="server">
+    <ContentTemplate>
+        <Rock:ModalAlert ID="mdGridWarning" runat="server" />
+        <asp:Panel ID="pnlList" runat="server" CssClass="panel panel-block">
+            <div class="panel-heading">
+                <h1 class="panel-title"><i class="fa fa-comment-dots"></i> SMS Capture Inbox</h1>
+                <div class="panel-labels">
+                    <asp:LinkButton ID="btnClearAll" runat="server" CssClass="btn btn-danger btn-xs" OnClick="btnClearAll_Click" OnClientClick="return confirm('Are you sure you want to delete ALL captured messages?');" CausesValidation="false"><i class="fa fa-trash"></i> Clear All</asp:LinkButton>
+                </div>
+            </div>
+            <div class="panel-body">
+                <div class="grid grid-panel">
+                    <Rock:GridFilter ID="gfFilter" runat="server" OnApplyFilterClick="gfFilter_ApplyFilterClick" OnDisplayFilterValue="gfFilter_DisplayFilterValue" OnClearFilterClick="gfFilter_ClearFilterClick">
+                        <Rock:DateRangePicker ID="drpDates" runat="server" Label="Date Range" />
+                        <Rock:RockTextBox ID="tbToNumber" runat="server" Label="To Number Contains" />
+                        <Rock:RockTextBox ID="tbBody" runat="server" Label="Body Contains" />
+                    </Rock:GridFilter>
+                    <Rock:Grid ID="gMessages" runat="server" AllowSorting="true" RowItemText="Message" DataKeyNames="Id" OnRowSelected="gMessages_RowSelected" OnGridRebind="gMessages_GridRebind" OnRowDataBound="gMessages_RowDataBound">
+                        <Columns>
+                            <Rock:DateTimeField DataField="CreatedDateTime" HeaderText="Captured" SortExpression="CreatedDateTime" />
+                            <Rock:RockBoundField DataField="FromNumber" HeaderText="From" SortExpression="FromNumber" />
+                            <Rock:RockBoundField DataField="ToNumber" HeaderText="To" SortExpression="ToNumber" />
+                            <Rock:RockTemplateField HeaderText="Person">
+                                <ItemTemplate><asp:Literal ID="lPerson" runat="server" /></ItemTemplate>
+                            </Rock:RockTemplateField>
+                            <Rock:RockBoundField DataField="BodyPreview" HeaderText="Message" />
+                            <Rock:RockBoundField DataField="Source" HeaderText="Source" SortExpression="Source" />
+                            <Rock:RockTemplateField HeaderText="Communication">
+                                <ItemTemplate><asp:Literal ID="lCommunication" runat="server" /></ItemTemplate>
+                            </Rock:RockTemplateField>
+                            <Rock:DeleteField OnClick="gMessages_Delete" />
+                        </Columns>
+                    </Rock:Grid>
+                </div>
+            </div>
+        </asp:Panel>
+        <Rock:ModalDialog ID="mdDetail" runat="server" Title="Captured SMS">
+            <Content>
+                <div class="row">
+                    <div class="col-md-6">
+                        <Rock:RockLiteral ID="lDetailFrom" runat="server" Label="From" />
+                        <Rock:RockLiteral ID="lDetailTo" runat="server" Label="To" />
+                        <Rock:RockLiteral ID="lDetailPerson" runat="server" Label="Person" />
+                    </div>
+                    <div class="col-md-6">
+                        <Rock:RockLiteral ID="lDetailCaptured" runat="server" Label="Captured" />
+                        <Rock:RockLiteral ID="lDetailSource" runat="server" Label="Source" />
+                        <Rock:RockLiteral ID="lDetailCommunication" runat="server" Label="Communication" />
+                    </div>
+                </div>
+                <Rock:RockLiteral ID="lDetailBody" runat="server" Label="Message" />
+                <Rock:RockLiteral ID="lDetailAttachments" runat="server" Label="Attachments" />
+            </Content>
+        </Rock:ModalDialog>
+    </ContentTemplate>
+</asp:UpdatePanel>

--- a/Plugins/org.secc.SmsCapture/org_secc/SmsCapture/SmsCaptureInbox.ascx.cs
+++ b/Plugins/org.secc.SmsCapture/org_secc/SmsCapture/SmsCaptureInbox.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SmsCapture/org_secc/SmsCapture/SmsCaptureInbox.ascx.cs
+++ b/Plugins/org.secc.SmsCapture/org_secc/SmsCapture/SmsCaptureInbox.ascx.cs
@@ -1,0 +1,314 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data.Entity;
+using System.Linq;
+using System.Web;
+using System.Web.UI.WebControls;
+using org.secc.SmsCapture.Model;
+using Rock;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.UI;
+using Rock.Web.UI.Controls;
+
+namespace RockWeb.Plugins.org_secc.SmsCapture
+{
+    [DisplayName( "SMS Capture Inbox" )]
+    [Category( "SECC > Communication" )]
+    [Description( "Papercut-style inbox for SMS messages captured by the SMS Capture transport. DEV/testing only." )]
+    public partial class SmsCaptureInbox : RockBlock
+    {
+        #region Filter Keys
+
+        private static class FilterKey
+        {
+            public const string DateRange = "Date Range";
+            public const string ToNumber = "To Number";
+            public const string Body = "Body";
+        }
+
+        #endregion
+
+        #region Base Control Methods
+
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            gMessages.DataKeyNames = new string[] { "Id" };
+            gMessages.Actions.ShowAdd = false;
+            gMessages.IsDeleteEnabled = true;
+        }
+
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
+
+            if ( !Page.IsPostBack )
+            {
+                BindFilter();
+                BindGrid();
+            }
+        }
+
+        #endregion
+
+        #region Events
+
+        protected void gfFilter_ApplyFilterClick( object sender, EventArgs e )
+        {
+            gfFilter.SaveUserPreference( FilterKey.DateRange, drpDates.DelimitedValues );
+            gfFilter.SaveUserPreference( FilterKey.ToNumber, tbToNumber.Text );
+            gfFilter.SaveUserPreference( FilterKey.Body, tbBody.Text );
+            BindGrid();
+        }
+
+        protected void gfFilter_DisplayFilterValue( object sender, GridFilter.DisplayFilterValueArgs e )
+        {
+            switch ( e.Key )
+            {
+                case FilterKey.DateRange:
+                    e.Value = DateRangePicker.FormatDelimitedValues( e.Value );
+                    break;
+                case FilterKey.ToNumber:
+                case FilterKey.Body:
+                    break;
+                default:
+                    e.Value = string.Empty;
+                    break;
+            }
+        }
+
+        protected void gfFilter_ClearFilterClick( object sender, EventArgs e )
+        {
+            gfFilter.DeleteUserPreferences();
+            BindFilter();
+            BindGrid();
+        }
+
+        protected void gMessages_GridRebind( object sender, EventArgs e )
+        {
+            BindGrid();
+        }
+
+        protected void gMessages_RowDataBound( object sender, GridViewRowEventArgs e )
+        {
+            var row = e.Row.DataItem as CapturedSmsRow;
+            if ( row == null )
+            {
+                return;
+            }
+
+            var lPerson = e.Row.FindControl( "lPerson" ) as Literal;
+            if ( lPerson != null && row.PersonId.HasValue )
+            {
+                lPerson.Text = string.Format( "<a href='{0}'>{1}</a>",
+                    ResolveRockUrl( "~/Person/" + row.PersonId.Value ),
+                    HttpUtility.HtmlEncode( row.PersonName ) );
+            }
+
+            var lCommunication = e.Row.FindControl( "lCommunication" ) as Literal;
+            if ( lCommunication != null && row.CommunicationId.HasValue )
+            {
+                lCommunication.Text = string.Format( "<a href='{0}'>#{1}</a>",
+                    ResolveRockUrl( "~/Communication/" + row.CommunicationId.Value ),
+                    row.CommunicationId.Value );
+            }
+        }
+
+        protected void gMessages_RowSelected( object sender, RowEventArgs e )
+        {
+            using ( var rockContext = new RockContext() )
+            {
+                var capture = new CapturedSmsService( rockContext ).Get( e.RowKeyId );
+                if ( capture == null )
+                {
+                    return;
+                }
+
+                lDetailFrom.Text = HttpUtility.HtmlEncode( capture.FromNumber );
+                lDetailTo.Text = HttpUtility.HtmlEncode( capture.ToNumber );
+                lDetailCaptured.Text = capture.CreatedDateTime.HasValue ? capture.CreatedDateTime.Value.ToString( "g" ) : string.Empty;
+                lDetailSource.Text = HttpUtility.HtmlEncode( capture.Source );
+
+                if ( capture.RecipientPersonAlias != null )
+                {
+                    lDetailPerson.Text = string.Format( "<a href='{0}'>{1}</a>",
+                        ResolveRockUrl( "~/Person/" + capture.RecipientPersonAlias.PersonId ),
+                        HttpUtility.HtmlEncode( capture.RecipientPersonAlias.Person.FullName ) );
+                }
+                else
+                {
+                    lDetailPerson.Text = string.Empty;
+                }
+
+                if ( capture.CommunicationId.HasValue )
+                {
+                    lDetailCommunication.Text = string.Format( "<a href='{0}'>#{1}</a>",
+                        ResolveRockUrl( "~/Communication/" + capture.CommunicationId.Value ),
+                        capture.CommunicationId.Value );
+                }
+                else
+                {
+                    lDetailCommunication.Text = string.Empty;
+                }
+
+                lDetailBody.Text = string.Format( "<pre style='white-space: pre-wrap;'>{0}</pre>", HttpUtility.HtmlEncode( capture.Body ) );
+
+                var attachmentLinks = new List<string>();
+                foreach ( var binaryFileId in ( capture.AttachmentBinaryFileIds ?? string.Empty ).SplitDelimitedValues().AsIntegerList() )
+                {
+                    attachmentLinks.Add( string.Format( "<a href='{0}' target='_blank'>File {1}</a>",
+                        ResolveRockUrl( "~/GetFile.ashx?id=" + binaryFileId ),
+                        binaryFileId ) );
+                }
+
+                lDetailAttachments.Text = attachmentLinks.Any() ? string.Join( "<br />", attachmentLinks ) : "<em>None</em>";
+            }
+
+            mdDetail.Show();
+        }
+
+        protected void gMessages_Delete( object sender, RowEventArgs e )
+        {
+            using ( var rockContext = new RockContext() )
+            {
+                var capturedSmsService = new CapturedSmsService( rockContext );
+                var capture = capturedSmsService.Get( e.RowKeyId );
+                if ( capture != null )
+                {
+                    capturedSmsService.Delete( capture );
+                    rockContext.SaveChanges();
+                }
+            }
+
+            BindGrid();
+        }
+
+        protected void btnClearAll_Click( object sender, EventArgs e )
+        {
+            using ( var rockContext = new RockContext() )
+            {
+                rockContext.Database.ExecuteSqlCommand( "DELETE FROM [dbo].[_org_secc_SmsCapture_CapturedSms]" );
+            }
+
+            BindGrid();
+        }
+
+        #endregion
+
+        #region Methods
+
+        private void BindFilter()
+        {
+            drpDates.DelimitedValues = gfFilter.GetUserPreference( FilterKey.DateRange );
+            tbToNumber.Text = gfFilter.GetUserPreference( FilterKey.ToNumber );
+            tbBody.Text = gfFilter.GetUserPreference( FilterKey.Body );
+        }
+
+        private void BindGrid()
+        {
+            using ( var rockContext = new RockContext() )
+            {
+                var qry = new CapturedSmsService( rockContext ).Queryable().AsNoTracking();
+
+                var dateRange = DateRangePicker.CalculateDateRangeFromDelimitedValues( gfFilter.GetUserPreference( FilterKey.DateRange ) );
+                if ( dateRange.Start.HasValue )
+                {
+                    qry = qry.Where( c => c.CreatedDateTime >= dateRange.Start.Value );
+                }
+
+                if ( dateRange.End.HasValue )
+                {
+                    qry = qry.Where( c => c.CreatedDateTime < dateRange.End.Value );
+                }
+
+                var toNumber = gfFilter.GetUserPreference( FilterKey.ToNumber );
+                if ( toNumber.IsNotNullOrWhiteSpace() )
+                {
+                    qry = qry.Where( c => c.ToNumber.Contains( toNumber ) );
+                }
+
+                var body = gfFilter.GetUserPreference( FilterKey.Body );
+                if ( body.IsNotNullOrWhiteSpace() )
+                {
+                    qry = qry.Where( c => c.Body.Contains( body ) );
+                }
+
+                var sortProperty = gMessages.SortProperty;
+                if ( sortProperty != null )
+                {
+                    qry = qry.Sort( sortProperty );
+                }
+                else
+                {
+                    qry = qry.OrderByDescending( c => c.Id );
+                }
+
+                gMessages.DataSource = qry
+                    .Select( c => new
+                    {
+                        c.Id,
+                        c.CreatedDateTime,
+                        c.FromNumber,
+                        c.ToNumber,
+                        c.Body,
+                        c.Source,
+                        c.CommunicationId,
+                        PersonId = ( int? ) c.RecipientPersonAlias.PersonId,
+                        PersonNickName = c.RecipientPersonAlias.Person.NickName,
+                        PersonLastName = c.RecipientPersonAlias.Person.LastName
+                    } )
+                    .ToList()
+                    .Select( c => new CapturedSmsRow
+                    {
+                        Id = c.Id,
+                        CreatedDateTime = c.CreatedDateTime,
+                        FromNumber = c.FromNumber,
+                        ToNumber = c.ToNumber,
+                        BodyPreview = c.Body.Truncate( 80 ),
+                        Source = c.Source,
+                        CommunicationId = c.CommunicationId,
+                        PersonId = c.PersonId,
+                        PersonName = string.Format( "{0} {1}", c.PersonNickName, c.PersonLastName ).Trim()
+                    } )
+                    .ToList();
+                gMessages.DataBind();
+            }
+        }
+
+        #endregion
+
+        #region Helper Classes
+
+        private class CapturedSmsRow
+        {
+            public int Id { get; set; }
+            public DateTime? CreatedDateTime { get; set; }
+            public string FromNumber { get; set; }
+            public string ToNumber { get; set; }
+            public string BodyPreview { get; set; }
+            public string Source { get; set; }
+            public int? CommunicationId { get; set; }
+            public int? PersonId { get; set; }
+            public string PersonName { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/Plugins/org.secc.SmsCapture/org_secc/SmsCapture/SmsCaptureInbox.ascx.cs
+++ b/Plugins/org.secc.SmsCapture/org_secc/SmsCapture/SmsCaptureInbox.ascx.cs
@@ -235,7 +235,10 @@ namespace RockWeb.Plugins.org_secc.SmsCapture
 
                 if ( dateRange.End.HasValue )
                 {
-                    qry = qry.Where( c => c.CreatedDateTime < dateRange.End.Value );
+                    // DateRangePicker is date-only and parses the end date to midnight;
+                    // add a day so the selected end date is inclusive.
+                    var endExclusive = dateRange.End.Value.AddDays( 1 );
+                    qry = qry.Where( c => c.CreatedDateTime < endExclusive );
                 }
 
                 var toNumber = gfFilter.GetUserPreference( FilterKey.ToNumber );

--- a/Plugins/org.secc.SmsCapture/packages.config
+++ b/Plugins/org.secc.SmsCapture/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.1.3" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
## Summary

New plugin project `org.secc.SmsCapture` — a DEV/testing SMS transport that captures fully rendered outbound messages to a database table instead of sending them (the SMS equivalent of Papercut SMTP), plus a Papercut-style **SMS Capture Inbox** block to browse them.

- **Transport** (`org.secc.SmsCapture.Transport.SmsCapture`) mirrors the Rock v13 Twilio transport structure exactly — both `Send` overloads, per-recipient `RockContext` cadence, identical recipient status / History side effects — but writes a capture row instead of calling the Twilio API. Recipients advance to **Delivered** with status note "Captured by SMS Capture transport", so downstream jobs/workflows behave as in production.
- **Zero delivery risk**: no Twilio SDK reference, no `HttpClient`, no outbound calls of any kind. Fail-closed: if ever selected on the wrong environment, messages are captured, not sent.
- Sync-only on purpose: `MediumComponent` falls back to the sync `Send` overloads for non-`IAsyncTransport` components on every pipeline path (bulk/queued, system communications, workflow SMS actions, conversation replies).
- **Entity + plugin migration**: `_org_secc_SmsCapture_CapturedSms` (from/to numbers, recipient PersonAlias, rendered body, attachment BinaryFile ids, communication ids, source, capture time). `CommunicationId`/`CommunicationRecipientId` stored without FK constraints so communication cleanup jobs are never blocked.
- **Inbox block**: grid (newest first) with date range / to number / body filters, detail modal with full pre-wrapped body and attachment links, per-row delete, confirmed Clear All.
- Component attributes: **Enable Logging** (compact Rock log line per capture, COMMUNICATIONS domain) and **Max Captured Messages** (default 5000; oldest trimmed after each send).

Kept in its own assembly per the ROCK-8756 plan so it can be excluded from a prod deploy if we ever want to; note our CI/CD currently ships the whole repo together — on prod the plugin is inert (empty table, transport listed but inactive) until an admin explicitly activates it and switches the SMS medium's transport.

No existing plugin or Rock core files were modified.

## Manual wiring (DEV only — see plugin README)

1. Confirm **SMS Capture** appears under Communication Transports; set attributes; mark Active.
2. Point the SMS medium's transport selection at **SMS Capture** (DEV ONLY).
3. Create an admin page for the **SMS Capture Inbox** block (SECC > Communication).
4. Post-clone checklist: after any prod→DEV restore, re-verify the SMS medium's transport before enabling jobs (setting lives in the DB and reverts to Twilio on clone).

## Test plan

- [x] Builds clean against Rock 13.7 (rock-13 solution), zero new warnings
- [x] Block code-behind compile-checked against RockWeb bin assemblies
- [x] DEV: Communication Wizard test SMS → capture row, recipient Delivered, no Twilio traffic (Twilio creds blanked)
- [x] DEV: workflow Send SMS action captures with Lava resolved
- [x] DEV: SMS Conversations reply captures
- [x] DEV: 100+ recipient bulk send via Send Communications job — all recipients advance, one row per recipient
- [x] DEV: inbox renders, filters, deletes, clears; row cap trims oldest

🤖 Generated with [Claude Code](https://claude.com/claude-code)