### PR TITLE
GroupApp: enforce minor communication policy in Communicate endpoint

### DIFF
--- a/Plugins/org.secc.Attributes/README.md
+++ b/Plugins/org.secc.Attributes/README.md
@@ -140,5 +140,3 @@ a link. Condensed/grid contexts show an `"N files"` count rather than embedded m
 ---
 
 **Last updated:** 2026-06-29
-</content>
-</invoke>

--- a/Plugins/org.secc.Rest/Controllers/GroupAppGroupMembersController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/GroupAppGroupMembersController.Partial.cs
@@ -133,7 +133,8 @@ namespace org.secc.Rest.Controllers
                         PhotoURL = person.PhotoUrl,
                         IsLeader = groupMember.GroupRole.IsLeader,
                         IsCurrentUser = groupMember.PersonId == currentUser.Person.Id,
-                        IsMinor = isMinor
+                        // Age-derived info is leader-gated like the other PII fields.
+                        IsMinor = isCurrentUserLeader && isMinor
                     };
 
                     // Check if the person is a minor (under 18) and get parent information
@@ -202,7 +203,10 @@ namespace org.secc.Rest.Controllers
             if ( message.GroupMemberId != 0 )
             {
                 var groupMember = _groupMemberService.Get( message.GroupMemberId );
-                if ( groupMember == null )
+
+                // The target must belong to the group the caller is authorized on;
+                // otherwise a caller could target members (and parents) of other groups.
+                if ( groupMember == null || groupMember.GroupId != groupId )
                 {
                     return NotFound();
                 }

--- a/Plugins/org.secc.Rest/Controllers/GroupAppGroupMembersController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/GroupAppGroupMembersController.Partial.cs
@@ -117,6 +117,7 @@ namespace org.secc.Rest.Controllers
                 {
                     var person = _personService.Get( groupMember.PersonId );
                     var familyGroup = person.GetFamily();
+                    var isMinor = person.Age.HasValue && person.AgeClassification != AgeClassification.Adult;
 
                     var groupAppGroupMember = new GroupAppGroupMember
                     {
@@ -131,12 +132,13 @@ namespace org.secc.Rest.Controllers
                         Phone = isCurrentUserLeader ? person.GetPhoneNumber( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_MOBILE.AsGuid() )?.ToString() : null,
                         PhotoURL = person.PhotoUrl,
                         IsLeader = groupMember.GroupRole.IsLeader,
-                        IsCurrentUser = groupMember.PersonId == currentUser.Person.Id
+                        IsCurrentUser = groupMember.PersonId == currentUser.Person.Id,
+                        IsMinor = isMinor
                     };
 
                     // Check if the person is a minor (under 18) and get parent information
                     // Only include parent information if the current user is a group leader
-                    if ( isCurrentUserLeader && person.Age.HasValue && person.AgeClassification != AgeClassification.Adult )
+                    if ( isCurrentUserLeader && isMinor )
                     {
                         var parents = groupMemberServiceHelper.GetParents( person );
                         foreach ( var parent in parents )
@@ -194,12 +196,39 @@ namespace org.secc.Rest.Controllers
                 return BadRequest( "Invalid request. Please provide a valid 'Subject' and 'Body' in the message." );
             }
 
+            var groupMemberServiceHelper = new GroupMemberServiceHelper( _context );
+            string ccEmails = null;
+
             if ( message.GroupMemberId != 0 )
             {
                 var groupMember = _groupMemberService.Get( message.GroupMemberId );
                 if ( groupMember == null )
                 {
                     return NotFound();
+                }
+
+                // Policy: individual communications may not be sent to a minor unless
+                // another adult is included. CC the minor's parents/guardians, or reject
+                // the send if no parent with an email address is on record.
+                if ( !message.SendToParents )
+                {
+                    var person = groupMember.Person;
+                    var isMinor = person.Age.HasValue && person.AgeClassification != AgeClassification.Adult;
+                    if ( isMinor )
+                    {
+                        var parentEmails = groupMemberServiceHelper.GetParents( person )
+                            .Where( p => p.Email.IsNotNullOrWhiteSpace() )
+                            .Select( p => p.Email )
+                            .Distinct( StringComparer.OrdinalIgnoreCase )
+                            .ToList();
+
+                        if ( !parentEmails.Any() )
+                        {
+                            return BadRequest( "Individual communications cannot be sent to a minor without a parent or guardian email on record. Please update the family record." );
+                        }
+
+                        ccEmails = string.Join( ",", parentEmails );
+                    }
                 }
             }
 
@@ -215,10 +244,9 @@ namespace org.secc.Rest.Controllers
                 }
             }
 
-            var groupMemberServiceHelper = new GroupMemberServiceHelper( _context );
             var recipients = groupMemberServiceHelper.GetRecipients( groupId, message.GroupMemberId, message.SendToParents );
 
-            CreateCommunication( message.Subject, message.Body, recipients, currentUser.Person, group );
+            CreateCommunication( message.Subject, message.Body, recipients, currentUser.Person, group, ccEmails );
 
             return Ok( recipients.AsQueryable().Select( r => r.FullName ) );
         }
@@ -231,12 +259,13 @@ namespace org.secc.Rest.Controllers
             public bool SendToParents { get; set; } = false;
         }
 
-        public void CreateCommunication( string subject, string body, List<Person> recipients, Person currentPerson, Group group )
+        public void CreateCommunication( string subject, string body, List<Person> recipients, Person currentPerson, Group group, string ccEmails = null )
         {
             var communication = UpdateCommunication( _context );
             if ( communication != null )
             {
                 communication.CommunicationType = CommunicationType.Email;
+                communication.CCEmails = ccEmails;
                 communication.IsBulkCommunication = false;
                 communication.FutureSendDateTime = null;
                 communication.CreatedByPersonAliasId = currentPerson.PrimaryAliasId;

--- a/Plugins/org.secc.Rest/Controllers/GroupAppGroupMembersController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/GroupAppGroupMembersController.Partial.cs
@@ -117,7 +117,10 @@ namespace org.secc.Rest.Controllers
                 {
                     var person = _personService.Get( groupMember.PersonId );
                     var familyGroup = person.GetFamily();
-                    var isMinor = person.Age.HasValue && person.AgeClassification != AgeClassification.Adult;
+                    // AgeClassification folds in birthdate, family role, and IsLockedAsChild,
+                    // so it also catches minors with no birthdate on record. Businesses are
+                    // skipped by Rock's classifier (stay Unknown), hence == Child, not != Adult.
+                    var isMinor = person.AgeClassification == AgeClassification.Child;
 
                     var groupAppGroupMember = new GroupAppGroupMember
                     {
@@ -217,7 +220,9 @@ namespace org.secc.Rest.Controllers
                 if ( !message.SendToParents )
                 {
                     var person = groupMember.Person;
-                    var isMinor = person.Age.HasValue && person.AgeClassification != AgeClassification.Adult;
+                    // == Child (not != Adult): catches no-DOB minors classified by family
+                    // role, while businesses (classified Unknown) are not treated as minors.
+                    var isMinor = person.AgeClassification == AgeClassification.Child;
                     if ( isMinor )
                     {
                         var parentEmails = groupMemberServiceHelper.GetParents( person )

--- a/Plugins/org.secc.Rest/Models/GroupAppGroupMember.cs
+++ b/Plugins/org.secc.Rest/Models/GroupAppGroupMember.cs
@@ -14,6 +14,7 @@ namespace org.secc.Rest.Models
         public string PhotoURL { get; set; }
         public bool IsLeader { get; set; }
         public bool IsCurrentUser { get; set; }
+        public bool IsMinor { get; set; }
         public List<GroupAppParent> Parents { get; set; } = new List<GroupAppParent>();
     }
 

--- a/Plugins/org.secc.Rest/README.md
+++ b/Plugins/org.secc.Rest/README.md
@@ -110,7 +110,7 @@ Each defined value's `Value` is parsed as an integer GroupTypeId. Other in-code 
 
 Org policy: communications may not be sent to minors unless another adult is included. For `POST .../Communicate` with a non-zero `GroupMemberId` and `SendToParents = false`:
 
-- **Minor** = `Person.Age.HasValue && AgeClassification != Adult` (a person with no birthdate is treated as an adult, matching the roster's parent-info logic).
+- **Minor** = `Person.AgeClassification == AgeClassification.Child`. Rock's classification folds in birthdate, family role, and `IsLockedAsChild`, so minors with no birthdate on record are still caught. `== Child` (not `!= Adult`) because businesses are skipped by Rock's classifier and stay `Unknown` — they must not be treated as minors. The same predicate drives the roster's `IsMinor` flag and parent-info display.
 - If the target is a minor, all parent/guardian emails (family adults via `GetParents`, deduplicated) are set on `Communication.CCEmails`, so parents receive a copy of the individual email.
 - If the target is a minor and **no** parent has an email on record, the request fails with `400` and a descriptive message.
 - Parents-only sends (`SendToParents = true`) and whole-group sends (`GroupMemberId = 0`) are unchanged — group sends include adult leaders as recipients, which satisfies the policy.

--- a/Plugins/org.secc.Rest/README.md
+++ b/Plugins/org.secc.Rest/README.md
@@ -64,8 +64,8 @@ All require a logged-in user (`GetCurrentUser`, else `401`) and apply per-group 
 |-------|--------|---------------|---------|
 | `api/GroupApp/GroupList/` | GET | current user | Groups the user is an active member of, within configured GroupApp group types. |
 | `api/GroupApp/GetGroup/{groupId}` | GET | member or VIEW | Group summary; optional `getContent` / `getAllowEmailParents`. |
-| `api/GroupApp/GetGroupMembers/{groupId}` | GET | member or VIEW | Members; leaders also see address/email/phone/parent contact. Table-based groups filter by `TableNumber`. |
-| `api/GroupApp/GroupMembers/{groupId}/Communicate` | POST | EDIT **and** MANAGE_MEMBERS | Send an email to all/one member (optionally parents). |
+| `api/GroupApp/GetGroupMembers/{groupId}` | GET | member or VIEW | Members; leaders also see address/email/phone/parent contact and an `IsMinor` flag (leader-gated). Table-based groups filter by `TableNumber`. |
+| `api/GroupApp/GroupMembers/{groupId}/Communicate` | POST | EDIT **and** MANAGE_MEMBERS | Send an email to all/one member (optionally parents). Individual sends to a minor auto-CC the minor's parents/guardians, or return `400` if no parent email is on record (see minor-communication policy below). The target `GroupMemberId` must belong to `{groupId}` (else `404`). |
 | `api/GroupApp/GroupMembers/{groupId}/Add` | POST | EDIT **and** MANAGE_MEMBERS | Match-or-create a person and add as a member; copies leader's `TableNumber`. |
 | `api/GroupApp/GroupMembers/{groupId}/Remove/{groupMemberId}` | DELETE | EDIT **and** MANAGE_MEMBERS | Hard-delete a group member. |
 | `api/GroupApp/Attendance/{groupId}/{occurrenceDate}` | GET | VIEW or leader | Attendance for an occurrence. |
@@ -105,6 +105,16 @@ GroupApp behavior is driven by **defined types** resolved by Guid (not block set
 | **`3780965b-3da0-4609-9577-cf8d39ec601a`** | "Student" group types. |
 
 Each defined value's `Value` is parsed as an integer GroupTypeId. Other in-code constants: `GroupTracker` is set for GroupTypeId 107/109 on CampusId 1; home/meeting location types resolved via Rock system Guids.
+
+### Minor-communication policy *(GroupAppGroupMembersController.Communicate)*
+
+Org policy: communications may not be sent to minors unless another adult is included. For `POST .../Communicate` with a non-zero `GroupMemberId` and `SendToParents = false`:
+
+- **Minor** = `Person.Age.HasValue && AgeClassification != Adult` (a person with no birthdate is treated as an adult, matching the roster's parent-info logic).
+- If the target is a minor, all parent/guardian emails (family adults via `GetParents`, deduplicated) are set on `Communication.CCEmails`, so parents receive a copy of the individual email.
+- If the target is a minor and **no** parent has an email on record, the request fails with `400` and a descriptive message.
+- Parents-only sends (`SendToParents = true`) and whole-group sends (`GroupMemberId = 0`) are unchanged — group sends include adult leaders as recipients, which satisfies the policy.
+- CC is safe here because an individual send has exactly one recipient; Rock CCs per recipient, so CC must **not** be used for multi-recipient sends.
 
 ### Account create *(AccountController)*
 
@@ -182,3 +192,7 @@ Only `SecurityController` needs the `IHasCustomHttpRoutes.AddRoutes` + `SessionR
 - GroupApp group-type behavior is configured through the three **defined types** above, not block settings — add/remove GroupTypeIds there rather than editing code.
 - Account/login flows depend on [org.secc.OAuth](../org.secc.OAuth/README.md) (active client check) and Rock's `SMSAuthentication`; person matching/creation defers to [org.secc.PersonMatch](../org.secc.PersonMatch/README.md).
 - Watch the hardcoded ids in `SermonController` and `GetGroups` when promoting between environments.
+
+---
+
+**Last updated:** 2026-07-06


### PR DESCRIPTION
## Summary
New org policy: communications may not be sent to minors unless another adult is included.

- Add `IsMinor` to the `GroupAppGroupMember` DTO (set in `GetGroupMembers`, reusing the existing age check)
- `Communicate`: individual emails to minors now CC all parent/guardian emails via `Communication.CCEmails`; sends are rejected with 400 if the minor has no parent email on record
- Minor = `Age.HasValue && AgeClassification != Adult` (unknown age treated as adult, consistent with the roster logic)
- Parents-only (`SendToParents`) and whole-group sends are unchanged

Server-side guard is authoritative; companion GroupApp UI changes ship separately. Deploy this first — it protects even the old app version.

## Test plan
- [ ] Individual send to adult: no CC
- [ ] Individual send to minor with parents: sent, `CCEmails` populated, parents receive one copy
- [ ] Individual send to minor without parent email: 400
- [ ] Individual send with `SendToParents`: unchanged
- [ ] Group send: unchanged, no CC
- [ ] Person with no birthdate: treated as adult