### PR TITLE
ROCK-8706: Fix Sports & Fitness guest check-in LoadHosts 10-15s hang

### DIFF
--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
@@ -375,15 +375,27 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
                     .Select(a => a.EntityId);
 
 
-                var hostsQry = attendanceService.Queryable()
-                    .GroupJoin(hostsGuests, a => a.PersonAlias.PersonId, h => h.PersonId,
-                        (a, h) => new {Attendance = a, GuestCount = h.Select(h1 => h1.GuestCount).DefaultIfEmpty()})
-                    .Where( a => occurrenceIds.Contains( a.Attendance.OccurrenceId ) )
-                    .Where( a => a.Attendance.DidAttend == true )
-                    .Where( a => a.Attendance.EndDateTime == null )
-                    .Where(a => a.Attendance.PersonAlias.Person.ConnectionStatusValueId == memberConnectionStatus.Id ||
-                        employees.Contains(a.Attendance.PersonAlias.PersonId))
-                    .Where( a => a.Attendance.Note == null || !a.Attendance.Note.StartsWith( "Guest" ) )
+                // ROCK-8706: Narrow the Attendance set with the active-occurrence filter (and the
+                // other Attendance predicates) BEFORE joining guest counts, so SQL Server applies
+                // "OccurrenceId IN (...)" against the base Attendance table first instead of scanning
+                // the full 9.4M-row table. Previously these Where clauses were applied AFTER the
+                // GroupJoin (against the projected anonymous type), which let EF6 defer the occurrence
+                // filter and run the member/employee predicate over the whole table (the 10-15s hang).
+                // The GroupJoin/DefaultIfEmpty guest-count join is preserved unchanged so the guest
+                // count is still computed once as a hash LEFT JOIN (do NOT switch it to a correlated
+                // subquery: hostsGuests resolves ValueAsPersonId via a scalar UDF, so a per-row
+                // subquery re-runs that UDF for every attendance row and is far slower).
+                var attendanceQry = attendanceService.Queryable()
+                    .Where( a => occurrenceIds.Contains( a.OccurrenceId ) )
+                    .Where( a => a.DidAttend == true )
+                    .Where( a => a.EndDateTime == null )
+                    .Where( a => a.PersonAlias.Person.ConnectionStatusValueId == memberConnectionStatus.Id ||
+                        employees.Contains( a.PersonAlias.PersonId ) )
+                    .Where( a => a.Note == null || !a.Note.StartsWith( "Guest" ) );
+
+                var hostsQry = attendanceQry
+                    .GroupJoin( hostsGuests, a => a.PersonAlias.PersonId, h => h.PersonId,
+                        ( a, h ) => new { Attendance = a, GuestCount = h.Select( h1 => h1.GuestCount ).DefaultIfEmpty() } )
                     .Select( a => new SportsAndFitnessHost
                     {
                         AttendanceId = a.Attendance.Id,

--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
@@ -385,7 +385,7 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
                 // count is still computed once as a hash LEFT JOIN (do NOT switch it to a correlated
                 // subquery: hostsGuests resolves ValueAsPersonId via a scalar UDF, so a per-row
                 // subquery re-runs that UDF for every attendance row and is far slower).
-                var attendanceQry = attendanceService.Queryable()
+                var attendanceQry = attendanceService.Queryable().AsNoTracking()
                     .Where( a => occurrenceIds.Contains( a.OccurrenceId ) )
                     .Where( a => a.DidAttend == true )
                     .Where( a => a.EndDateTime == null )


### PR DESCRIPTION
Fixes the 10-15s hang on the Sports & Fitness guest sign-in "load hosts" screen (`GuestCheckin.ascx.cs`, `LoadHosts()`).

### Root cause
`hostsQry` built a `GroupJoin` against the guest-count subquery first, then applied the `OccurrenceId` / `DidAttend` / `EndDateTime` / member-or-employee / `Note` `Where` clauses against the joined projection. EF6 generated a plan that ran the member-ConnectionStatus-OR-employee-subquery predicate over the **full ~9.4M-row `Attendance` table** before narrowing by occurrence — that's the hang.

### Fix
Move those five `Where` clauses onto `attendanceService.Queryable()` directly, applied **before** the `GroupJoin`, so SQL Server narrows by occurrence first. The `GroupJoin`/`DefaultIfEmpty` guest-count join itself is unchanged — a correlated-subquery alternative was tried and rejected (it re-runs the `ValueAsPersonId` scalar UDF per row, measured at 58s).

### Verification (DEV, sample day 2026-01-05, occurrences 648643/45/46/47/50/67/81/85)
- **Row-set equivalence**: old vs. new shape return identical rows — 458/458, 0 mismatches either direction, guest-count sum 1159=1159.
- **Perf**: new shape (narrowed + GroupJoin) = 310ms. Reproducing the pre-fix effective plan (OR predicate + guest join over the full table, no occurrence narrowing) = 16,454ms over 2.87M rows — in the reported hang range. ~53x improvement.
- Adversarial verifier pass (semantic-equivalence + EF6 lens): clean — no blockers/majors/minors. One pre-existing nit noted (missing `AsNoTracking()` at L388, not introduced by this change).

### Scope
Single file, single private method in one block (Block 7417, Sports & Fitness site only). No schema/attribute/index changes.