### PR TITLE
ROCK-8706 follow-up: remove the three LoadHosts hot operators (guest counts, occurrence N+1, employee scan)

### DIFF
--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
@@ -365,11 +365,16 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
                 var occurrenceIds = new List<int>();
                 if (activeTriples.Count > 0)
                 {
+                    // EF6 reliably translates List<T>.Contains (-> SQL IN) but NOT HashSet<T>.Contains
+                    // (throws NotSupportedException at query time), so hand the IN-lists to the query as lists.
+                    var groupIdList = activeGroupIds.ToList();
+                    var locationIdList = activeLocationIds.ToList();
+                    var scheduleIdList = activeScheduleIds.ToList();
                     occurrenceIds = occurrenceService.Queryable().AsNoTracking()
                         .Where( o => o.OccurrenceDate == occurrenceDate )
-                        .Where( o => o.GroupId.HasValue && activeGroupIds.Contains( o.GroupId.Value ) )
-                        .Where( o => o.LocationId.HasValue && activeLocationIds.Contains( o.LocationId.Value ) )
-                        .Where( o => o.ScheduleId.HasValue && activeScheduleIds.Contains( o.ScheduleId.Value ) )
+                        .Where( o => o.GroupId.HasValue && groupIdList.Contains( o.GroupId.Value ) )
+                        .Where( o => o.LocationId.HasValue && locationIdList.Contains( o.LocationId.Value ) )
+                        .Where( o => o.ScheduleId.HasValue && scheduleIdList.Contains( o.ScheduleId.Value ) )
                         .Select( o => new { o.Id, o.GroupId, o.LocationId, o.ScheduleId } )
                         .ToList()
                         .Where( o => activeTriples.Contains( o.GroupId.Value + "|" + o.LocationId.Value + "|" + o.ScheduleId.Value ) )

--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
@@ -490,9 +490,12 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
                     .ToList();
 
                 // Stitch in each host's guest count from the standalone aggregation (see hostGuestCounts above).
+                // NOTE: declare guestCount separately (not "out int guestCount") -- RockWeb runtime-compiles
+                // this .ascx.cs as C# 6, which does not support inline out-variable declarations (CS8059).
+                int guestCount;
                 foreach ( var host in hosts )
                 {
-                    host.GuestCount = hostGuestCounts.TryGetValue( host.PersonId, out int guestCount ) ? guestCount : 0;
+                    host.GuestCount = hostGuestCounts.TryGetValue( host.PersonId, out guestCount ) ? guestCount : 0;
                 }
 
                 gHosts.DataSource = hosts;

--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
@@ -334,20 +334,47 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
                         } )
                     .ToList();
 
-                var occurrenceIds = new List<int>();
+                // ROCK-8706: Resolve today's active occurrences in ONE query instead of an
+                // AttendanceOccurrenceService.Get() round trip per active (group, location, schedule)
+                // triple (the old N+1 loop). The Get(DateTime,int?,int?,int?) overload is read-only
+                // (Queryable().FirstOrDefault(), no create) so batching is safe, and
+                // IX_GroupId_LocationID_ScheduleID_Date is UNIQUE on (GroupId, LocationId, ScheduleId,
+                // OccurrenceDate) so at most one row matches each triple -- "all matching" is identical
+                // to the old per-triple FirstOrDefault(). We over-fetch by three IN-lists (cheap; the
+                // active set is only currently-check-in-active schedules) then intersect against the
+                // exact triple set in memory to drop cartesian cross-matches.
+                var occurrenceDate = currentTime.Date;
+                var activeTriples = new HashSet<string>();
+                var activeGroupIds = new HashSet<int>();
+                var activeLocationIds = new HashSet<int>();
+                var activeScheduleIds = new HashSet<int>();
                 foreach (var item in groups)
                 {
                     foreach (var schedule in item.Schedules)
                     {
                         if (schedule.IsCheckInActive)
                         {
-                            var occurrence = occurrenceService.Get( currentTime, item.GroupId, item.LocationId, schedule.Id );
-                            if (occurrence != null)
-                            {
-                                occurrenceIds.Add( occurrence.Id );
-                            }
+                            activeTriples.Add( item.GroupId + "|" + item.LocationId + "|" + schedule.Id );
+                            activeGroupIds.Add( item.GroupId );
+                            activeLocationIds.Add( item.LocationId );
+                            activeScheduleIds.Add( schedule.Id );
                         }
                     }
+                }
+
+                var occurrenceIds = new List<int>();
+                if (activeTriples.Count > 0)
+                {
+                    occurrenceIds = occurrenceService.Queryable().AsNoTracking()
+                        .Where( o => o.OccurrenceDate == occurrenceDate )
+                        .Where( o => o.GroupId.HasValue && activeGroupIds.Contains( o.GroupId.Value ) )
+                        .Where( o => o.LocationId.HasValue && activeLocationIds.Contains( o.LocationId.Value ) )
+                        .Where( o => o.ScheduleId.HasValue && activeScheduleIds.Contains( o.ScheduleId.Value ) )
+                        .Select( o => new { o.Id, o.GroupId, o.LocationId, o.ScheduleId } )
+                        .ToList()
+                        .Where( o => activeTriples.Contains( o.GroupId.Value + "|" + o.LocationId.Value + "|" + o.ScheduleId.Value ) )
+                        .Select( o => o.Id )
+                        .ToList();
                 }
 
                 var workflowEntityType = EntityTypeCache.GetId(typeof(Workflow));
@@ -359,13 +386,22 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
                     .Where(av => av.AttributeId == hostAttribute.Id)
                     .Where(av => av.ValueAsPersonId.HasValue);
 
+                // ROCK-8706: Run the guest-count aggregation as its OWN query -> in-memory
+                // dictionary (the ~87ms query measured on DEV). Keeping it standalone means the
+                // ValueAsPersonId scalar UDF only runs inside this small, date+attribute-narrowed
+                // set. When this was folded into the attendance query via GroupJoin, EF6 rewrote it
+                // as a per-attendance-row correlated subquery that re-ran the UDF for every row and
+                // tail-spiked to 28.7s in Query Store. Do NOT fold this back into the attendance query.
                 var today = currentTime.Date;
-                var hostsGuests = new WorkflowService(rockContext).Queryable().AsNoTracking()
+                var hostGuestCounts = new WorkflowService(rockContext).Queryable().AsNoTracking()
                     .Where(w => w.WorkflowTypeId == workflowType.Id)
                     .Where(w => w.ActivatedDateTime.HasValue && w.ActivatedDateTime.Value > today )
-                    .Join(attributeValueQry, w => w.Id, av => av.EntityId, (w, av) => new { WorkflowId = w.Id, PersonId = av.ValueAsPersonId })
-                    .GroupBy(h => h.PersonId)
-                    .Select(h => new { PersonId = h.Key, GuestCount = h.Count() });
+                    .Join(attributeValueQry, w => w.Id, av => av.EntityId, (w, av) => av.ValueAsPersonId)
+                    .GroupBy(personId => personId)
+                    .Select(g => new { PersonId = g.Key, GuestCount = g.Count() })
+                    .ToList()
+                    .Where(x => x.PersonId.HasValue)
+                    .ToDictionary(x => x.PersonId.Value, x => x.GuestCount);
 
 
                 var memberConnectionStatus = DefinedValueCache.Get(Rock.SystemGuid.DefinedValue.PERSON_CONNECTION_STATUS_MEMBER.AsGuid());
@@ -376,15 +412,13 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
 
 
                 // ROCK-8706: Narrow the Attendance set with the active-occurrence filter (and the
-                // other Attendance predicates) BEFORE joining guest counts, so SQL Server applies
-                // "OccurrenceId IN (...)" against the base Attendance table first instead of scanning
-                // the full 9.4M-row table. Previously these Where clauses were applied AFTER the
-                // GroupJoin (against the projected anonymous type), which let EF6 defer the occurrence
-                // filter and run the member/employee predicate over the whole table (the 10-15s hang).
-                // The GroupJoin/DefaultIfEmpty guest-count join is preserved unchanged so the guest
-                // count is still computed once as a hash LEFT JOIN (do NOT switch it to a correlated
-                // subquery: hostsGuests resolves ValueAsPersonId via a scalar UDF, so a per-row
-                // subquery re-runs that UDF for every attendance row and is far slower).
+                // other Attendance predicates) so SQL Server applies "OccurrenceId IN (...)" against
+                // the base Attendance table first instead of scanning the full 9.4M-row table.
+                // Guest counts are NOT joined here — they come from the hostGuestCounts dictionary
+                // built above and are stitched in after this query materializes. Do NOT reintroduce
+                // a GroupJoin against the workflow/attribute-value guest counts: EF6 rewrites it as a
+                // per-attendance-row correlated subquery over the ValueAsPersonId scalar UDF, which
+                // tail-spiked to 28.7s in Query Store.
                 var attendanceQry = attendanceService.Queryable().AsNoTracking()
                     .Where( a => occurrenceIds.Contains( a.OccurrenceId ) )
                     .Where( a => a.DidAttend == true )
@@ -394,17 +428,15 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
                     .Where( a => a.Note == null || !a.Note.StartsWith( "Guest" ) );
 
                 var hostsQry = attendanceQry
-                    .GroupJoin( hostsGuests, a => a.PersonAlias.PersonId, h => h.PersonId,
-                        ( a, h ) => new { Attendance = a, GuestCount = h.Select( h1 => h1.GuestCount ).DefaultIfEmpty() } )
                     .Select( a => new SportsAndFitnessHost
                     {
-                        AttendanceId = a.Attendance.Id,
-                        PersonId = a.Attendance.PersonAlias.PersonId,
-                        Host = a.Attendance.PersonAlias.Person,
-                        LocationId = a.Attendance.Occurrence.LocationId.Value,
-                        Location = a.Attendance.Occurrence.Location.Name,
-                        CheckinTime = a.Attendance.StartDateTime,
-                        GuestCount = a.GuestCount.FirstOrDefault()
+                        AttendanceId = a.Id,
+                        PersonId = a.PersonAlias.PersonId,
+                        Host = a.PersonAlias.Person,
+                        LocationId = a.Occurrence.LocationId.Value,
+                        Location = a.Occurrence.Location.Name,
+                        CheckinTime = a.StartDateTime,
+                        GuestCount = 0
                     } );
 
                 var selectedLocationId = 0;
@@ -442,10 +474,18 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
                     item.Selected = true;
                 }
 
-                gHosts.DataSource = hostsQry
+                var hosts = hostsQry
                     .OrderBy( h => h.Host.LastName )
                     .ThenBy( h => h.Host.NickName )
                     .ToList();
+
+                // Stitch in each host's guest count from the standalone aggregation (see hostGuestCounts above).
+                foreach ( var host in hosts )
+                {
+                    host.GuestCount = hostGuestCounts.TryGetValue( host.PersonId, out int guestCount ) ? guestCount : 0;
+                }
+
+                gHosts.DataSource = hosts;
                 gHosts.DataBind();
 
                 pnlMain.Visible = false;

--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/GuestCheckin.ascx.cs
@@ -406,9 +406,19 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
 
                 var memberConnectionStatus = DefinedValueCache.Get(Rock.SystemGuid.DefinedValue.PERSON_CONNECTION_STATUS_MEMBER.AsGuid());
                 var attendanceService = new AttendanceService( rockContext );
-                var employees = new AttributeValueService(rockContext).Queryable().AsNoTracking()
-                    .Where(a => a.Attribute.Id == 740 && a.Value == "Southeast Christian Church")
-                    .Select(a => a.EntityId);
+
+                // ROCK-8706: Materialize the SECC-employee person ids ONCE (~few hundred rows) instead of
+                // leaving "employees.Contains(PersonId)" as an IQueryable inside the attendance WHERE. As a
+                // subquery, EF6 turned it into a correlated EXISTS re-evaluated PER attendance row: because
+                // AttributeValue.Value is nvarchar(max) it can't be an index key, so each evaluation seeked
+                // attribute 740 and residual-filtered the string over ~11k rows -> ~2M row reads, the single
+                // largest operator in the Query Store plan. Fetched once into a list, the OR below becomes a
+                // constant IN-list evaluated a single time. Attribute 740 is the (Arena-synced) employer attr.
+                var employeeIds = new AttributeValueService(rockContext).Queryable().AsNoTracking()
+                    .Where(a => a.AttributeId == 740 && a.Value == "Southeast Christian Church")
+                    .Where(a => a.EntityId.HasValue)
+                    .Select(a => a.EntityId.Value)
+                    .ToList();
 
 
                 // ROCK-8706: Narrow the Attendance set with the active-occurrence filter (and the
@@ -424,7 +434,7 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
                     .Where( a => a.DidAttend == true )
                     .Where( a => a.EndDateTime == null )
                     .Where( a => a.PersonAlias.Person.ConnectionStatusValueId == memberConnectionStatus.Id ||
-                        employees.Contains( a.PersonAlias.PersonId ) )
+                        employeeIds.Contains( a.PersonAlias.PersonId ) )
                     .Where( a => a.Note == null || !a.Note.StartsWith( "Guest" ) );
 
                 var hostsQry = attendanceQry


### PR DESCRIPTION
## TL;DR — how the three fixes relate

All three are variations on one theme: **EF6 doing per-attendance-row work over a huge table.** But they split into a *cousin* and a *matched pair*:

| | What EF6 did wrong | The fix |
|---|---|---|
| **#262** (already merged) | Occurrence filter applied *after* the GroupJoin, so EF **deferred** it and ran the member/employee OR over the full 9.4M-row Attendance table | **Reorder** — narrow by occurrence first |
| **Fix B** (guests) | Guest count compiled into a **correlated per-row subquery** (the `ValueAsPersonId` UDF, re-run for every row) | **Materialize once** into a dictionary |
| **Fix C** (employees) | Employee set (`IQueryable.Contains`) compiled into a **correlated per-row EXISTS** scanning attr-740 | **Materialize once** into an IN-list |

**Fix B and Fix C are the same bug on two different columns** — a correlated subquery that should be a one-time set operation, fixed the same way. **#262 was a cousin** (a filter-*ordering* problem, fixed by reordering — not by materializing).

Why three rounds instead of one: #262 removed the full-table scan (the post-#262 plan confirms Attendance is now reached by an `IX_OccurrenceId` seek), but the two correlated subqueries were underneath it the whole time and became the top of the plan. Note: there's no clean before/after *timing* for #262 — the pre-#262 statement has aged out of prod Query Store — so this ordering is **plan-based, not a measured delta**. #262 fixed a real cost; it just wasn't the floor that B and C set, which is why it didn't visibly move the wall-clock. One-liner: *#262 stopped scanning the whole table; B and C stop re-running a subquery once per row — the guest half and the employee half of the same remaining problem.*

---

Follow-up to #262 (merged). #262 reordered the attendance filters and added `AsNoTracking()`, which killed the 10–15s member/employee full-table scan. Pulling the actual **Query Store execution plan** for the surviving 28.7s statement (query_id 29156590) then showed the LoadHosts host-list query still had **three** hot operators — this PR removes all three.

## What the plan showed
For the `Project12` host-list query (returns `Host = PersonAlias.Person` + guest count):
- `NonParallelPlanReason="TSQLUserDefinedFunctionsNotParallelizable"` — the whole plan was forced **single-threaded** by the `ufnUtility_GetPersonIdFromPersonAliasGuid` scalar UDF.
- `StatementOptmEarlyAbortReason="TimeOut"` — the query was too complex for the optimizer to plan well; cardinality was badly off (1 estimated vs ~185 actual).
- Dominant operator: a correlated `AttributeValue` scan for `AttributeId=740` (~11k rows) rewound per attendance row ≈ **2M row reads**, subtree cost **2.42 of 3.01**.

## Fix A — batch the occurrence lookup (N+1 → 1)
`LoadHosts()` called `AttendanceOccurrenceService.Get()` once per active (group, location, schedule) triple. Collapsed into a single query intersected against the exact triple set in memory. Safe because `Get(DateTime,int?,int?,int?)` is read-only (`Queryable().FirstOrDefault()`, verified against Rock `1.13.7` source) and `IX_GroupId_LocationID_ScheduleID_Date` is UNIQUE, so "all matching" ≡ old per-triple `FirstOrDefault()`.

## Fix B — decouple the guest-count aggregation
The guest count was folded into the attendance query via `GroupJoin`; EF6 emitted it as **two** correlated `TOP 1` subqueries over the `ValueAsPersonId` scalar UDF, rebound per attendance row. Now runs as its own query materialized into a `Dictionary<int,int>` (~87ms on DEV) and stitched onto each host after the attendance query materializes. This also **removes the UDF from the query → unlocks parallelism** and simplifies it enough to stop the optimizer timeout.

## Fix C — decouple the employee lookup
The member/employee OR left `employees.Contains(PersonId)` as an `IQueryable` subquery → the correlated `AttributeId=740` scan above. `AttributeValue.Value` is `nvarchar(max)` so it **can't be an index key** (an index can't turn this into a seek). Materializing the ~676 employee person ids once turns the OR into a **constant IN-list** evaluated a single time, removing the ~2M-row rescan.

## Equivalence
Behavior-preserving across all three: same attendance filters, same `OrderBy/ThenBy`, same per-host guest counts, same employee id set (same `AttributeId=740` + Value predicate; null `EntityId`s filtered — a null could never match a non-null `PersonId`). `RowDataBound`'s max-guest logic reads `GuestCount` exactly as before.

**Verified on prod/DEV data (read-only):**
- Fix A uniqueness invariant — 0 violating rows over 60 days.
- Fix B guest-count equivalence — old correlated-subquery form vs new `GROUP BY` form diffed to **0 rows**, including a busy day (2025-12-30: 46 hosts, 24 of them multi-guest).
- The 28.7s statement confirmed as this LoadHosts query (not `LoadPendingCheckins`).
