### PR TITLE
ROCK-8700: Fix double check-in caused by redundant Add after AddOrUpdate

### DIFF
--- a/Plugins/org.secc.FamilyCheckin/Workflows/SaveAttendance.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/SaveAttendance.cs
@@ -182,7 +182,11 @@ namespace org.secc.FamilyCheckin
                                                 }
                                             };
 
-                                            attendanceService.Add( attendance );
+                                            // NOTE: Do not call attendanceService.Add( attendance ) here. AddOrUpdate already
+                                            // adds new records to the context. When AddOrUpdate returns an EXISTING attendance
+                                            // (same person + occurrence), calling Add would flip the tracked entity's state to
+                                            // Added, causing EF to INSERT a duplicate row and silently drop the update that
+                                            // closed the old attendance — the double check-in bug (ROCK-8700).
                                             attendances.Add( attendance );
                                         }
                                     }

--- a/Plugins/org.secc.RoomScanner/Utilities/DataHelper.cs
+++ b/Plugins/org.secc.RoomScanner/Utilities/DataHelper.cs
@@ -203,6 +203,13 @@ namespace org.secc.RoomScanner.Utilities
             {
                 newAttendance.ForeignId = null;
             }
+            // NOTE (ROCK-8700): This Add looks redundant (AddOrUpdate already adds new records), but it is
+            // intentional here. When AddOrUpdate returns an EXISTING attendance row (e.g. subroom scan where
+            // the target occurrence matches the source attendance's occurrence), Add flips the tracked entity
+            // to Added so EF INSERTs a fresh row — that new row is the "clone", while the source attendance
+            // (tracked by the caller's context) is closed below/by the caller. Removing this Add would cause
+            // the same row to be reopened and then closed, checking the person out instead of moving them.
+            // This is safe here because the source row is always closed afterward, so only one row stays active.
             attendanceService.Add( newAttendance );
             var stayedFifteenMinutes = ( Rock.RockDateTime.Now - attendance.StartDateTime ) > new TimeSpan( 0, 15, 0 );
             attendance.DidAttend = stayedFifteenMinutes;


### PR DESCRIPTION
Rock core's AttendanceService.AddOrUpdate returns the existing tracked attendance when one exists for the same person + occurrence. The extra attendanceService.Add() flipped that entity to Added, so EF inserted a duplicate row and dropped the update closing the old attendance, leaving two active attendances (double check-in).

- SaveAttendance.cs: remove the redundant Add (AddOrUpdate already adds new records); existing records now update in place.
- DataHelper.cs (RoomScanner): comment only. The identical-looking Add in CloneAttendance is intentional clone-by-readd and must not be removed.

*NOTE*: Do not merge in before 7/13