### PR TITLE
ROCK-8790: Gate Specialty Roles Evaluate Group Requirements at Signup

### DIFF
--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx
@@ -68,6 +68,8 @@
 
                 <asp:PlaceHolder ID="phFormAttributes" runat="server" />
 
+                <asp:Literal ID="lRequirementBlockMessage" runat="server" Visible="false" />
+
                 <div class="actions">
                     <asp:LinkButton ID="btnConnectandAddAnother" Visible="false" runat="server" AccessKey="n" Text="Connect and Add Another" CssClass="btn btn-default" OnClick="btnConnect_Click" />
                     <asp:LinkButton ID="btnConnect" runat="server" AccessKey="m" Text="Connect" CssClass="btn btn-primary" OnClick="btnConnect_Click" />

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -68,6 +68,7 @@ namespace org.secc.Connection
     [TextField( "Comment label text", "The wording that should be used for the comment box title", true, "Comments", "", 12 )]
     [BooleanField( "Comments Required", "Whether the comment are required", true, "", 13 )]
     [CodeEditorField( "Waiver Text", "Optional waiver/legal text (supports Lava) shown directly above the Connect button. Leave blank to display nothing.", CodeEditorMode.Lava, CodeEditorTheme.Rock, 200, false, "", "", 14 )]
+    [TextField( "Signup-Blocking Requirement Types", "Comma-separated Group Requirement Type names that should hard-block a signup at the form when not met (e.g. 'Over 18 Years Old, Over 14 Years Old'). Leave blank to block none - requirements still evaluate/pass through onto the connection request as before.", false, key: "SignupBlockingRequirementTypes", order: 15 )]
 
     public partial class VolunteerSignupFormConnections : RockBlock
     {
@@ -406,14 +407,25 @@ namespace org.secc.Connection
 
                             }
 
-                            // ROCK-8790: Enforce the assigned role's Group Requirements at signup.
-                            // The person prospect has already been created/matched and committed above,
-                            // so requirement DataViews/SQL evaluate against the person's persisted data
-                            // (including any birthday just entered on the form — see the SaveChanges above).
-                            // If any BLOCKING requirement for this group + role is not met, hard-block the
-                            // submit BEFORE rockContext.SaveChanges() so that no ConnectionRequest (and
-                            // nothing downstream) is created for an ineligible volunteer.
-                            if ( connectionRequest.AssignedGroupId.HasValue )
+                            // ROCK-8790: Enforce the assigned role's Group Requirements at signup — but
+                            // OPT-IN per requirement type, per block instance. This block is shared across
+                            // ~30+ signup instances; only Group Requirement Types explicitly named in the
+                            // "Signup-Blocking Requirement Types" setting hard-block a signup at the form.
+                            // Blank => block nothing, so every other instance is unaffected by default and
+                            // its requirements still evaluate/pass through onto the connection request.
+                            var blockingRequirementTypeNames = ( GetAttributeValue( "SignupBlockingRequirementTypes" ) ?? string.Empty )
+                                .Split( ',' )
+                                .Select( n => n.Trim() )
+                                .Where( n => !string.IsNullOrWhiteSpace( n ) )
+                                .ToList();
+
+                            // The person prospect has already been created/matched and committed above, so
+                            // requirement DataViews/SQL evaluate against the person's persisted data (including
+                            // any birthday just filled in from the form — see the SaveChanges above). If any
+                            // listed requirement for this group + role is not met, hard-block the submit BEFORE
+                            // rockContext.SaveChanges() so that no ConnectionRequest (and nothing downstream)
+                            // is created for an ineligible volunteer.
+                            if ( blockingRequirementTypeNames.Any() && connectionRequest.AssignedGroupId.HasValue )
                             {
                                 var assignedGroup = new GroupService( rockContext ).Get( connectionRequest.AssignedGroupId.Value );
                                 if ( assignedGroup != null )
@@ -423,14 +435,16 @@ namespace org.secc.Connection
                                     {
                                         blockingMessages = assignedGroup
                                             .PersonMeetsGroupRequirements( rockContext, person.Id, connectionRequest.AssignedGroupMemberRoleId )
-                                            // Mirror Rock's own add-time enforcement: only auto-evaluable
-                                            // (DataView/SQL) requirements flagged "must meet to add member"
-                                            // can block. A Manual requirement returns NotMet for anyone with
-                                            // no GroupMember row (i.e. every new signup), so it must NOT block.
                                             .Where( r =>
                                                 r.GroupRequirement != null &&
-                                                r.GroupRequirement.MustMeetRequirementToAddMember &&
                                                 r.GroupRequirement.GroupRequirementType != null &&
+                                                // The explicit name allowlist (case-insensitive) is the intent
+                                                // control, so a listed type gates regardless of its
+                                                // MustMeetRequirementToAddMember flag (that filter is intentionally
+                                                // dropped). The non-Manual guard stays so a mistakenly-listed Manual
+                                                // type can't blanket-block every new signup (Manual returns NotMet
+                                                // for anyone with no GroupMember row).
+                                                blockingRequirementTypeNames.Contains( r.GroupRequirement.GroupRequirementType.Name, StringComparer.OrdinalIgnoreCase ) &&
                                                 r.GroupRequirement.GroupRequirementType.RequirementCheckType != RequirementCheckType.Manual &&
                                                 // Fail closed: block on NotMet AND on Error (a SQL requirement
                                                 // that threw). Do not block on Meets/MeetsWithWarning/NotApplicable.

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -338,8 +338,11 @@ namespace org.secc.Connection
                             SavePhone( pnPhone, person, _homePhone.Guid, changes );
                         }
 
-                        // Save the DOB
-                        if ( bpBirthdate.Visible && bpBirthdate.SelectedDate.HasValue && bpBirthdate.SelectedDate != person.BirthDate )
+                        // Save the DOB. ROCK-8790: on-file birthday is preferred and is NEVER
+                        // overwritten from the signup form. Only fill BirthDate from the form when
+                        // the person has none on file (brand-new person, or a matched person whose
+                        // BirthDate is null), so the age check has a fallback value to evaluate.
+                        if ( bpBirthdate.Visible && bpBirthdate.SelectedDate.HasValue && !person.BirthDate.HasValue )
                         {
                             person.BirthDay = bpBirthdate.SelectedDate.Value.Day;
                             person.BirthMonth = bpBirthdate.SelectedDate.Value.Month;
@@ -356,13 +359,13 @@ namespace org.secc.Connection
                                 changes );
                         }
 
-                        // ROCK-8790: Persist any pending Person changes (notably the birthday
-                        // entered on the form for a matched EXISTING person) BEFORE evaluating
-                        // Group Requirements below. PersonMeetsGroupRequirements reads the person
-                        // from the database, so the entered birthday must be committed first —
-                        // otherwise an age requirement would evaluate the stale on-file DOB.
-                        // (A brand-new person was already committed above via SaveNewPerson; this
-                        // is a no-op when nothing is dirty.)
+                        // ROCK-8790: Persist any pending Person changes BEFORE evaluating Group
+                        // Requirements below. PersonMeetsGroupRequirements reads the person from the
+                        // database, so a birthday just filled in from the form (only when none was on
+                        // file — see above) must be committed first for the age check to read it.
+                        // When the person already had an on-file birthday, none is changed here, so
+                        // their existing birthday is preserved and evaluated. (A brand-new person was
+                        // already committed above via SaveNewPerson; this is a no-op when clean.)
                         rockContext.SaveChanges();
 
                         // Now that we have a person, we can create the connection requests

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -356,6 +356,15 @@ namespace org.secc.Connection
                                 changes );
                         }
 
+                        // ROCK-8790: Persist any pending Person changes (notably the birthday
+                        // entered on the form for a matched EXISTING person) BEFORE evaluating
+                        // Group Requirements below. PersonMeetsGroupRequirements reads the person
+                        // from the database, so the entered birthday must be committed first —
+                        // otherwise an age requirement would evaluate the stale on-file DOB.
+                        // (A brand-new person was already committed above via SaveNewPerson; this
+                        // is a no-op when nothing is dirty.)
+                        rockContext.SaveChanges();
+
                         // Now that we have a person, we can create the connection requests
                         int RepeaterIndex = 0;
                         foreach ( ConnectionRoleRequest roleRequest in RoleRequests )
@@ -395,42 +404,61 @@ namespace org.secc.Connection
                             }
 
                             // ROCK-8790: Enforce the assigned role's Group Requirements at signup.
-                            // The person prospect has already been created/matched and committed above
-                            // (PersonService.SaveNewPerson), so requirement DataViews/SQL evaluate against
-                            // the person's on-file data. If any requirement for this group + role is not
-                            // met, hard-block the submit BEFORE rockContext.SaveChanges() so that no
-                            // ConnectionRequest (and nothing downstream) is created for an ineligible volunteer.
+                            // The person prospect has already been created/matched and committed above,
+                            // so requirement DataViews/SQL evaluate against the person's persisted data
+                            // (including any birthday just entered on the form — see the SaveChanges above).
+                            // If any BLOCKING requirement for this group + role is not met, hard-block the
+                            // submit BEFORE rockContext.SaveChanges() so that no ConnectionRequest (and
+                            // nothing downstream) is created for an ineligible volunteer.
                             if ( connectionRequest.AssignedGroupId.HasValue )
                             {
                                 var assignedGroup = new GroupService( rockContext ).Get( connectionRequest.AssignedGroupId.Value );
                                 if ( assignedGroup != null )
                                 {
-                                    var unmetRequirements = assignedGroup
-                                        .PersonMeetsGroupRequirements( rockContext, person.Id, connectionRequest.AssignedGroupMemberRoleId )
-                                        .Where( r => r.MeetsGroupRequirement == MeetsGroupRequirement.NotMet )
-                                        .ToList();
-
-                                    if ( unmetRequirements.Any() )
+                                    List<string> blockingMessages;
+                                    try
                                     {
-                                        var messages = unmetRequirements
+                                        blockingMessages = assignedGroup
+                                            .PersonMeetsGroupRequirements( rockContext, person.Id, connectionRequest.AssignedGroupMemberRoleId )
+                                            // Mirror Rock's own add-time enforcement: only auto-evaluable
+                                            // (DataView/SQL) requirements flagged "must meet to add member"
+                                            // can block. A Manual requirement returns NotMet for anyone with
+                                            // no GroupMember row (i.e. every new signup), so it must NOT block.
+                                            .Where( r =>
+                                                r.GroupRequirement != null &&
+                                                r.GroupRequirement.MustMeetRequirementToAddMember &&
+                                                r.GroupRequirement.GroupRequirementType != null &&
+                                                r.GroupRequirement.GroupRequirementType.RequirementCheckType != RequirementCheckType.Manual &&
+                                                // Fail closed: block on NotMet AND on Error (a SQL requirement
+                                                // that threw). Do not block on Meets/MeetsWithWarning/NotApplicable.
+                                                ( r.MeetsGroupRequirement == MeetsGroupRequirement.NotMet ||
+                                                  r.MeetsGroupRequirement == MeetsGroupRequirement.Error ) )
                                             .Select( r =>
                                             {
-                                                var requirementType = r.GroupRequirement != null ? r.GroupRequirement.GroupRequirementType : null;
-                                                if ( requirementType != null )
-                                                {
-                                                    return !string.IsNullOrWhiteSpace( requirementType.NegativeLabel )
-                                                        ? requirementType.NegativeLabel
-                                                        : requirementType.Name;
-                                                }
-
-                                                return "You do not meet the requirements for this role.";
+                                                var requirementType = r.GroupRequirement.GroupRequirementType;
+                                                return !string.IsNullOrWhiteSpace( requirementType.NegativeLabel )
+                                                    ? requirementType.NegativeLabel
+                                                    : requirementType.Name;
                                             } )
                                             .Distinct()
                                             .ToList();
+                                    }
+                                    catch ( Exception ex )
+                                    {
+                                        // Fail closed: if requirement evaluation itself throws (e.g. a deleted
+                                        // or renamed DataView, a bad SQL filter), do NOT let the signup through.
+                                        ExceptionLogService.LogException( ex, System.Web.HttpContext.Current );
+                                        blockingMessages = new List<string>
+                                        {
+                                            "We couldn't verify your eligibility for this role. Please try again or contact us."
+                                        };
+                                    }
 
+                                    if ( blockingMessages.Any() )
+                                    {
                                         lResponseMessage.Text = string.Format(
-                                            "<div class='alert alert-warning'>{0}</div>",
-                                            string.Join( "<br />", messages ) );
+                                            "<div class='alert alert-danger'>{0}</div>",
+                                            string.Join( "<br />", blockingMessages ) );
                                         lResponseMessage.Visible = true;
 
                                         // Keep the signup form visible and return before SaveChanges().

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -394,6 +394,54 @@ namespace org.secc.Connection
 
                             }
 
+                            // ROCK-8790: Enforce the assigned role's Group Requirements at signup.
+                            // The person prospect has already been created/matched and committed above
+                            // (PersonService.SaveNewPerson), so requirement DataViews/SQL evaluate against
+                            // the person's on-file data. If any requirement for this group + role is not
+                            // met, hard-block the submit BEFORE rockContext.SaveChanges() so that no
+                            // ConnectionRequest (and nothing downstream) is created for an ineligible volunteer.
+                            if ( connectionRequest.AssignedGroupId.HasValue )
+                            {
+                                var assignedGroup = new GroupService( rockContext ).Get( connectionRequest.AssignedGroupId.Value );
+                                if ( assignedGroup != null )
+                                {
+                                    var unmetRequirements = assignedGroup
+                                        .PersonMeetsGroupRequirements( rockContext, person.Id, connectionRequest.AssignedGroupMemberRoleId )
+                                        .Where( r => r.MeetsGroupRequirement == MeetsGroupRequirement.NotMet )
+                                        .ToList();
+
+                                    if ( unmetRequirements.Any() )
+                                    {
+                                        var messages = unmetRequirements
+                                            .Select( r =>
+                                            {
+                                                var requirementType = r.GroupRequirement != null ? r.GroupRequirement.GroupRequirementType : null;
+                                                if ( requirementType != null )
+                                                {
+                                                    return !string.IsNullOrWhiteSpace( requirementType.NegativeLabel )
+                                                        ? requirementType.NegativeLabel
+                                                        : requirementType.Name;
+                                                }
+
+                                                return "You do not meet the requirements for this role.";
+                                            } )
+                                            .Distinct()
+                                            .ToList();
+
+                                        lResponseMessage.Text = string.Format(
+                                            "<div class='alert alert-warning'>{0}</div>",
+                                            string.Join( "<br />", messages ) );
+                                        lResponseMessage.Visible = true;
+
+                                        // Keep the signup form visible and return before SaveChanges().
+                                        // Any ConnectionRequest added in a prior loop iteration is discarded
+                                        // because SaveChanges() is never reached for this submit.
+                                        pnlSignup.Visible = true;
+                                        return;
+                                    }
+                                }
+                            }
+
                             var connectionAttributes = GetGroupMemberAttributes( rockContext, RepeaterIndex );
 
                             if ( connectionAttributes != null && connectionAttributes.Keys.Any() )

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -430,6 +430,17 @@ namespace org.secc.Connection
                                 var assignedGroup = new GroupService( rockContext ).Get( connectionRequest.AssignedGroupId.Value );
                                 if ( assignedGroup != null )
                                 {
+                                    // Personalize the block message: "[Name] isn't eligible for the [Role] role — [reason]."
+                                    // The message renders in lRequirementBlockMessage (just above the submit buttons),
+                                    // NOT lResponseMessage (top), which is reserved for the normal connect response.
+                                    var registrantName = !string.IsNullOrWhiteSpace( person.NickName ) ? person.NickName : person.FirstName;
+                                    var assignedRoleName = connectionRequest.AssignedGroupMemberRoleId.HasValue
+                                        ? new GroupTypeRoleService( rockContext ).Get( connectionRequest.AssignedGroupMemberRoleId.Value )?.Name
+                                        : null;
+                                    var roleClause = !string.IsNullOrWhiteSpace( assignedRoleName )
+                                        ? string.Format( "the {0} role", assignedRoleName )
+                                        : "this role";
+
                                     List<string> blockingMessages;
                                     try
                                     {
@@ -464,19 +475,32 @@ namespace org.secc.Connection
                                     {
                                         // Fail closed: if requirement evaluation itself throws (e.g. a deleted
                                         // or renamed DataView, a bad SQL filter), do NOT let the signup through.
+                                        // Generic message (no role/reason format).
                                         ExceptionLogService.LogException( ex, System.Web.HttpContext.Current );
-                                        blockingMessages = new List<string>
-                                        {
-                                            "We couldn't verify your eligibility for this role. Please try again or contact us."
-                                        };
+                                        lRequirementBlockMessage.Text = string.Format(
+                                            "<div class='alert alert-danger'>We couldn't verify {0}'s eligibility for this role. Please try again or contact us.</div>",
+                                            registrantName );
+                                        lRequirementBlockMessage.Visible = true;
+                                        pnlSignup.Visible = true;
+                                        return;
                                     }
 
                                     if ( blockingMessages.Any() )
                                     {
-                                        lResponseMessage.Text = string.Format(
+                                        string messageBody;
+                                        if ( blockingMessages.Count == 1 )
+                                        {
+                                            messageBody = string.Format( "{0} isn't eligible for {1} — {2}.", registrantName, roleClause, blockingMessages[0] );
+                                        }
+                                        else
+                                        {
+                                            messageBody = string.Format( "{0} isn't eligible for {1}:<br />{2}", registrantName, roleClause, string.Join( "<br />", blockingMessages ) );
+                                        }
+
+                                        lRequirementBlockMessage.Text = string.Format(
                                             "<div class='alert alert-danger'>{0}</div>",
-                                            string.Join( "<br />", blockingMessages ) );
-                                        lResponseMessage.Visible = true;
+                                            messageBody );
+                                        lRequirementBlockMessage.Visible = true;
 
                                         // Keep the signup form visible and return before SaveChanges().
                                         // Any ConnectionRequest added in a prior loop iteration is discarded

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -433,9 +433,14 @@ namespace org.secc.Connection
                                     // Personalize the block message: "[Name] isn't eligible for the [Role] role — [reason]."
                                     // The message renders in lRequirementBlockMessage (just above the submit buttons),
                                     // NOT lResponseMessage (top), which is reserved for the normal connect response.
-                                    var registrantName = !string.IsNullOrWhiteSpace( person.NickName ) ? person.NickName : person.FirstName;
+                                    // HTML-encode every data-derived value interpolated into the alert-danger
+                                    // markup below (name / role / requirement labels) so values containing
+                                    // &, ', or < don't break the markup. .EncodeHtml() is Rock's string
+                                    // extension (via using Rock;) and is null-safe. Literal markup in the
+                                    // format strings (the div wrapper, <br />) stays un-encoded.
+                                    var registrantName = ( !string.IsNullOrWhiteSpace( person.NickName ) ? person.NickName : person.FirstName ).EncodeHtml();
                                     var assignedRoleName = connectionRequest.AssignedGroupMemberRoleId.HasValue
-                                        ? new GroupTypeRoleService( rockContext ).Get( connectionRequest.AssignedGroupMemberRoleId.Value )?.Name
+                                        ? new GroupTypeRoleService( rockContext ).Get( connectionRequest.AssignedGroupMemberRoleId.Value )?.Name.EncodeHtml()
                                         : null;
                                     var roleClause = !string.IsNullOrWhiteSpace( assignedRoleName )
                                         ? string.Format( "the {0} role", assignedRoleName )
@@ -464,9 +469,9 @@ namespace org.secc.Connection
                                             .Select( r =>
                                             {
                                                 var requirementType = r.GroupRequirement.GroupRequirementType;
-                                                return !string.IsNullOrWhiteSpace( requirementType.NegativeLabel )
+                                                return ( !string.IsNullOrWhiteSpace( requirementType.NegativeLabel )
                                                     ? requirementType.NegativeLabel
-                                                    : requirementType.Name;
+                                                    : requirementType.Name ).EncodeHtml();
                                             } )
                                             .Distinct()
                                             .ToList();

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -207,12 +207,42 @@ namespace org.secc.Connection
         #region Events
 
         /// <summary>
+        /// ROCK-8790: On a blocked signup, revert a birthday that was filled from the form THIS
+        /// request (new person, or a matched person who had none on file) back to null, so a
+        /// corrected resubmit re-reads the form value. An existing on-file birthday is never
+        /// touched (the caller only invokes this when it filled the value this request).
+        /// Uses a SEPARATE RockContext so it commits only the birthday revert — never the
+        /// ConnectionRequests added earlier in the submit loop on the main context (which is
+        /// abandoned without SaveChanges to keep a blocked submit all-or-nothing).
+        /// </summary>
+        /// <param name="personId">The person identifier whose form-filled birthday to clear.</param>
+        private void RevertFormBirthDate( int personId )
+        {
+            using ( var revertContext = new RockContext() )
+            {
+                var revertPerson = new PersonService( revertContext ).Get( personId );
+                if ( revertPerson != null )
+                {
+                    revertPerson.SetBirthDate( null );
+                    revertContext.SaveChanges();
+                }
+            }
+        }
+
+        /// <summary>
         /// Handles the Click event of the btnEdit control.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
         protected void btnConnect_Click( object sender, EventArgs e )
         {
+            // ROCK-8790: Clear any prior eligibility-block message up front. It persists via
+            // ViewState and pnlSignup stays visible on "Connect and Add Another", so a stale
+            // message would otherwise linger. Done here (not in the gate) because the gate is
+            // skipped entirely when the setting is blank.
+            lRequirementBlockMessage.Text = string.Empty;
+            lRequirementBlockMessage.Visible = false;
+
             using ( var rockContext = new RockContext() )
             {
                 var opportunityService = new ConnectionOpportunityService( rockContext );
@@ -235,6 +265,11 @@ namespace org.secc.Connection
                 if ( opportunity != null && defaultStatusId > 0 )
                 {
                     Person person = null;
+
+                    // ROCK-8790: Tracks whether we set BirthDate from the form THIS request (new person,
+                    // or matched person who had none on file). Only such a value is reverted on a blocked
+                    // submit — an existing on-file birthday is never touched.
+                    bool birthDateFilledFromForm = false;
 
                     string firstName = tbFirstName.Text.Trim();
                     string lastName = tbLastName.Text.Trim();
@@ -308,6 +343,7 @@ namespace org.secc.Connection
                         person.LastName = lastName;
                         person.IsEmailActive = true;
                         person.SetBirthDate( birthdate );
+                        birthDateFilledFromForm = birthdate.HasValue;
                         person.Email = email;
                         person.EmailPreference = EmailPreference.EmailAllowed;
                         person.RecordTypeValueId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_RECORD_TYPE_PERSON.AsGuid() ).Id;
@@ -348,6 +384,7 @@ namespace org.secc.Connection
                             person.BirthDay = bpBirthdate.SelectedDate.Value.Day;
                             person.BirthMonth = bpBirthdate.SelectedDate.Value.Month;
                             person.BirthYear = bpBirthdate.SelectedDate.Value.Year;
+                            birthDateFilledFromForm = true;
                         }
 
                         if ( changes.Any() )
@@ -483,9 +520,17 @@ namespace org.secc.Connection
                                         // Generic message (no role/reason format).
                                         ExceptionLogService.LogException( ex, System.Web.HttpContext.Current );
                                         lRequirementBlockMessage.Text = string.Format(
-                                            "<div class='alert alert-danger'>We couldn't verify {0}'s eligibility for this role. Please try again or contact us.</div>",
+                                            "<div class='alert alert-danger'>We couldn't verify {0}'s eligibility for this role. No signup was submitted. Please try again or contact us.</div>",
                                             registrantName );
                                         lRequirementBlockMessage.Visible = true;
+
+                                        // ROCK-8790: revert a birthday we filled from the form this request so a
+                                        // corrected resubmit re-reads the form value (on-file birthday untouched).
+                                        if ( birthDateFilledFromForm )
+                                        {
+                                            RevertFormBirthDate( person.Id );
+                                        }
+
                                         pnlSignup.Visible = true;
                                         return;
                                     }
@@ -495,17 +540,24 @@ namespace org.secc.Connection
                                         string messageBody;
                                         if ( blockingMessages.Count == 1 )
                                         {
-                                            messageBody = string.Format( "{0} isn't eligible for {1} — {2}.", registrantName, roleClause, blockingMessages[0] );
+                                            messageBody = string.Format( "{0} isn't eligible for {1} — {2}. No signup was submitted.", registrantName, roleClause, blockingMessages[0] );
                                         }
                                         else
                                         {
-                                            messageBody = string.Format( "{0} isn't eligible for {1}:<br />{2}", registrantName, roleClause, string.Join( "<br />", blockingMessages ) );
+                                            messageBody = string.Format( "{0} isn't eligible for {1}:<br />{2}<br />No signup was submitted.", registrantName, roleClause, string.Join( "<br />", blockingMessages ) );
                                         }
 
                                         lRequirementBlockMessage.Text = string.Format(
                                             "<div class='alert alert-danger'>{0}</div>",
                                             messageBody );
                                         lRequirementBlockMessage.Visible = true;
+
+                                        // ROCK-8790: revert a birthday we filled from the form this request so a
+                                        // corrected resubmit re-reads the form value (on-file birthday untouched).
+                                        if ( birthDateFilledFromForm )
+                                        {
+                                            RevertFormBirthDate( person.Id );
+                                        }
 
                                         // Keep the signup form visible and return before SaveChanges().
                                         // Any ConnectionRequest added in a prior loop iteration is discarded


### PR DESCRIPTION
## What this does

Adds an **opt-in** hard block at volunteer signup (ROCK-8790, age-gating Food Pack "Specialty" roles). If a person doesn't meet a **named** Group Requirement for their assigned role, the submit is stopped and **no `ConnectionRequest` or anything downstream is created**. This block is shared across ~30+ signup instances, so the gate is **off by default**.

Two files: `VolunteerSignupFormConnections.ascx.cs` (the gate in `btnConnect_Click`) and `.ascx` (a new `lRequirementBlockMessage` literal above the submit buttons).

## New block setting

`[TextField]` **"Signup-Blocking Requirement Types"** (`SignupBlockingRequirementTypes`, not required) — a comma-separated list of Group Requirement Type **names** that hard-block a signup when not met.

- **Blank => block nothing.** Requirements still evaluate and pass through onto the request as before. This is what keeps the other ~30 instances unaffected.
- Case-insensitive match on `GroupRequirementType.Name`.
- **Config (human/recipe, not code):** the Specialty instance sets this to `Over 18 Years Old, Over 14 Years Old`; every other instance stays blank.
- **Tradeoff:** matches on Name, so renaming a requirement type means updating this setting — same tradeoff the existing `UrlKeys`/`FormKeys` settings carry.

## Gate behavior

- **Opt-in.** Empty list => gate skipped entirely. A status blocks only when its type Name is in the list (case-insensitive), `RequirementCheckType != Manual`, and result is `NotMet` or `Error`. The non-Manual guard prevents a mistakenly-listed Manual type from blanket-blocking everyone.
- **Fail closed.** Requirement evaluation is wrapped in try/catch; a throwing DataView/SQL requirement is logged via `ExceptionLogService` and blocks with a generic message instead of erroring the page.
- **Birthday — on-file preferred, form as fallback, never overwrite.** An existing on-file birthday is preserved and evaluated as-is; a person with none gets it filled from the form and committed before evaluation. No complete date => `BirthDate` stays null => age check fails closed (no crash). On a blocked submit, a birthday we filled *this request* is reverted to null (separate `RockContext`) so a corrected resubmit re-reads the form value — an on-file birthday is never reverted.
- **Message.** Renders in `lRequirementBlockMessage` just above the submit buttons (not the top-of-block `lResponseMessage`), wrapped in `alert-danger`: *"[NickName] isn't eligible for the [Role] role — [reason]. No signup was submitted."* `[reason]` = the requirement type's Negative Label (fallback Name). Multiple failures list each reason. All data-derived values are `.EncodeHtml()`-encoded. Cleared at the top of the handler each submit.
- **Blocks before `SaveChanges()`.** The method returns before the loop's final `SaveChanges()`, so no request (and no downstream membership) is persisted for any role in an ineligible submit.

## Scope / behavior change (stakeholder-approved)

Touches shared block behavior (~30+ instances). Both changes approved:
1. **Gate is opt-in** — blank setting (the default everywhere) => behavior unchanged.
2. **On-file birthday preserved** — a matched person's birthday is no longer overwritten from the form (all instances). *Accepted tradeoff:* the age gate trusts a wrong on-file DOB.

## Must-test (human, at runtime)

- [x] **Blank setting (default) => nothing blocks** (behavior unchanged for the other instances).
- [x] **Setting = `Over 18 Years Old, Over 14 Years Old`** — under-age blocked / eligible passes, per role.
- [x] **Non-listed requirement does NOT block** — passes through onto the request.
- [x] **On-file preferred** — matched person with an on-file birthday keeps it; age check uses it.
- [x] **Typed fallback** — matched person with no on-file birthday (and a new person): form birthday saved and used.
- [x] **Message placement + wording** — appears above the Connect buttons; `[reason]` matches the Negative Label; multiple failures list each.
- [x] **Build-check** — compiled locally against `secc/Rock @ hotfix-1.13.7`. Builds clean.

## Notes

Base is `master`. PR #257 (`ROCK-8710`) touches the same file but a different region (`AddGroupMemberAttributes`/`GetGroupMemberAttributes`); this change is isolated to the `btnConnect_Click` submit flow. Whichever merges second needs at most a trivial rebase — no logical conflict.
