### PR TITLE
ROCK-8801 Fix Mobile Check In Bug

### DIFF
--- a/Plugins/org.secc.FamilyCheckin/README.md
+++ b/Plugins/org.secc.FamilyCheckin/README.md
@@ -104,6 +104,14 @@ Category in Rock: **SECC > Check-in** (medical-consent block: **SECC > Family Ch
 | Kiosk List / Kiosk Detail | Admin CRUD for `Kiosk` records. |
 | Kiosk Type List / Kiosk Type Detail | Admin CRUD for `CheckinKioskType` records. |
 
+**Mobile-reservation validation in QuickCheckin:** when a family with an active
+`MobileCheckinRecord` arrives at a kiosk, the block validates the reservation against the
+**persisted** Attendance → Occurrence → Group records, not `OccurrenceCache`. A reserved room can
+be closed (its group-location-schedule detached) between reservation and arrival, which makes the
+occurrence unresolvable in cache even though the reservation is still valid and completable — the
+completion path works straight off the attendance records. By design, closing a room does **not**
+cancel existing mobile reservations for it; the children's team moves those attendees manually.
+
 ### Jobs
 
 Quartz `IJob`s (both `[DisallowConcurrentExecution]`); scheduled in Rock, not self-registered.
@@ -181,3 +189,7 @@ attributes (don't hand-edit ones that have already run):
   `/Themes/`.
 - Related: scannable codes come from [org.secc.QRManager](../org.secc.QRManager/README.md);
   shared helpers from [org.secc.DevLib](../org.secc.DevLib/README.md).
+
+---
+
+Last updated: 2026-07-10

--- a/Plugins/org.secc.FamilyCheckin/README.md
+++ b/Plugins/org.secc.FamilyCheckin/README.md
@@ -190,6 +190,4 @@ attributes (don't hand-edit ones that have already run):
 - Related: scannable codes come from [org.secc.QRManager](../org.secc.QRManager/README.md);
   shared helpers from [org.secc.DevLib](../org.secc.DevLib/README.md).
 
----
-
-**Last updated:** 2026-07-13
+**Last updated:** 2026-07-14

--- a/Plugins/org.secc.FamilyCheckin/README.md
+++ b/Plugins/org.secc.FamilyCheckin/README.md
@@ -192,4 +192,4 @@ attributes (don't hand-edit ones that have already run):
 
 ---
 
-Last updated: 2026-07-10
+**Last updated:** 2026-07-13

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/QuickCheckin.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/QuickCheckin.ascx.cs
@@ -277,17 +277,32 @@ namespace RockWeb.Plugins.org_secc.FamilyCheckin
 
         private bool MCRValidForKiosk( CheckinKioskTypeCache kioskType, MobileCheckinRecordCache mcr )
         {
-            var groupTypeIds = new List<int>();
-            foreach ( var a in mcr.AttendanceIds )
+            if ( kioskType == null || mcr == null || mcr.AttendanceIds == null || !mcr.AttendanceIds.Any() )
             {
-                var attendance = AttendanceCache.Get( a );
-                var occurrence = OccurrenceCache.Get( attendance.OccurrenceAccessKey );
-
-                groupTypeIds.Add( occurrence.GroupTypeId );
+                return false;
             }
 
-            return kioskType.GroupTypeIds.Where( kg => groupTypeIds.Contains( kg ) ).Any();
+            //Determine which group types this reservation covers directly from the
+            //persisted attendance data. We intentionally do NOT use OccurrenceCache
+            //here: a reserved room can be closed (its GroupLocationSchedule detached)
+            //between the reservation and the family's arrival at the kiosk, which
+            //leaves the occurrence unresolvable in cache even though the reservation
+            //attendances are still perfectly valid. The completion path
+            //(btnCompleteMCRActual_Click) works straight off these attendance records
+            //and never touches the cache, so validation shouldn't either. Reading from
+            //the database keeps the reservation completable rather than hiding it (or,
+            //before the null guard, crashing the whole kiosk page).
+            using ( var rockContext = new RockContext() )
+            {
+                var reservationGroupTypeIds = new AttendanceService( rockContext )
+                    .Queryable().AsNoTracking()
+                    .Where( a => mcr.AttendanceIds.Contains( a.Id ) && a.Occurrence.GroupId.HasValue )
+                    .Select( a => a.Occurrence.Group.GroupTypeId )
+                    .Distinct()
+                    .ToList();
 
+                return kioskType.GroupTypeIds.Any( kg => reservationGroupTypeIds.Contains( kg ) );
+            }
         }
 
         private void ShowActiveMobileCheckin()

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/QuickCheckin.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/QuickCheckin.ascx.cs
@@ -283,26 +283,22 @@ namespace RockWeb.Plugins.org_secc.FamilyCheckin
                 return false;
             }
 
-            //Determine which group types this reservation covers directly from the
-            //persisted attendance data. We intentionally do NOT use OccurrenceCache
-            //here: a reserved room can be closed (its GroupLocationSchedule detached)
-            //between the reservation and the family's arrival at the kiosk, which
-            //leaves the occurrence unresolvable in cache even though the reservation
-            //attendances are still perfectly valid. The completion path
-            //(btnCompleteMCRActual_Click) works straight off these attendance records
-            //and never touches the cache, so validation shouldn't either. Reading from
-            //the database keeps the reservation completable rather than hiding it (or,
-            //before the null guard, crashing the whole kiosk page).
+            //Validate against persisted attendance data rather than OccurrenceCache:
+            //a reserved room can be closed before the family arrives, leaving the
+            //occurrence unresolvable in cache even though the reservation is still
+            //valid. Matches the completion path (btnCompleteMCRActual_Click).
+            if ( !kioskType.GroupTypeIds.Any() )
+            {
+                return false;
+            }
+
             using ( var rockContext = new RockContext() )
             {
-                var reservationGroupTypeIds = new AttendanceService( rockContext )
+                return new AttendanceService( rockContext )
                     .Queryable().AsNoTracking()
-                    .Where( a => mcr.AttendanceIds.Contains( a.Id ) && a.Occurrence.GroupId.HasValue )
-                    .Select( a => a.Occurrence.Group.GroupTypeId )
-                    .Distinct()
-                    .ToList();
-
-                return kioskType.GroupTypeIds.Any( kg => reservationGroupTypeIds.Contains( kg ) );
+                    .Any( a => mcr.AttendanceIds.Contains( a.Id )
+                        && a.Occurrence.GroupId.HasValue
+                        && kioskType.GroupTypeIds.Contains( a.Occurrence.Group.GroupTypeId ) );
             }
         }
 

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/QuickCheckin.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/QuickCheckin.ascx.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Data.Entity;
 using System.Linq;
 using System.Web.UI;
 using System.Web.UI.WebControls;


### PR DESCRIPTION
Mobile check in was coded to verify the check-in record from the cache, but if the cache key has a null occurrence, then it will throw an error and prevent the check in from completing. This fix has the MCR check the attendance against the database.

Note: this does not change the pre-existing behavior of a room is closing does *not* cancel existing MCRs for that room. This is set up as designed and the children's team knows that if they close a room then they need to move the attendees in that room.