### PR TITLE
ROCK-8856 Event Pass: group registrations for the logged-in viewer

### DIFF
--- a/Plugins/org.secc.Event/README.md
+++ b/Plugins/org.secc.Event/README.md
@@ -44,7 +44,7 @@ Category in Rock: **SECC > Event** (Community Gives Back blocks: **SECC > Commun
 | Event Redirect (`EventRedirect`) | Interprets event slugs and forwards to the right page. | Base Route (default `upcomingevents`) |
 | Registration Entry (`RegistrationEntry`) | SECC fork of Rock's stock registration-entry block (register for an instance). | Connection Status, Record Status, plus the stock registration-entry settings |
 | Registration Detail (`RegistrationDetail`) | SECC fork of Rock's registration-detail block (view/manage a registration). | (stock registration-detail settings) |
-| Event Pass (`EventPass`) | Displays a QR "Event Pass" for registrants of an event. | Include Registrants on Waitlist, Pass Not Found Header/Message |
+| Event Pass (`EventPass`) | Displays a QR "Event Pass" for registrants of an event. | Include Registrants on Waitlist, Include Registrar's Registrations, Pass Not Found Header/Message |
 | Generate Event Pass (`RequestEventPass`) | Public form that launches a workflow to request an Event Pass. | Block Title, Event Pass Workflow Type, Pass Person Attribute, Contact Fields Editable |
 | Family Registration List Lava (`FamilyRegistrationLava`) | Lava sidebar listing a family's children's registrations. | Lava Template, Max Results, Date Range, Limit To Owed |
 | SignNow (`SignNow`) | Embedded sub-control (a plain `System.Web.UI.UserControl`, **not** a registerable Rock block — no `[DisplayName]`/`[Category]`) that hosts the SignNow digital-signature flow inside registration; parses the returned `document_id` (falls back to the referer on iOS). | (none — driven by the registration's digital-signature component) |

--- a/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx
+++ b/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx
@@ -72,7 +72,7 @@
                                     <div class="col-xs-8">
                                         <i class="fas fa-ticket"></i> <%# Eval("EventName") %> <br />
                                         <%# string.Format(Eval("EventDate") == null ? "" : "<i class='far fa-calendar-alt'></i> {0:D}<br />", Eval("EventDate") ) %>
-                                        <%# string.Format(Eval("EventLocation") == null ? "" : "<i class=fas fa-map-marker-alt</i> {0}", Eval("EventLocation")) %>
+                                        <%# string.Format(Eval("EventLocation") == null ? "" : "<i class='fas fa-map-marker-alt'></i> {0}", Eval("EventLocation")) %>
                                     </div>
                                 </div>
                                 <div class="row bottom-row">

--- a/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx
+++ b/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx
@@ -85,14 +85,16 @@
                         </ItemTemplate>
                     </asp:Repeater>
                 </div>
-                <a class="left carousel-control" href="#carousel-EventItem" role="button" data-slide="prev">
-                    <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-                    <span class="sr-only">Previous</span>
-                </a>
-                <a class="right carousel-control" href="#carousel-EventItem" role="button" data-slide="next">
-                    <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-                    <span class="sr-only">Next</span>
-                </a>
+                <asp:PlaceHolder ID="phCarouselControls" runat="server">
+                    <a class="left carousel-control" href="#carousel-EventItem" role="button" data-slide="prev">
+                        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+                        <span class="sr-only">Previous</span>
+                    </a>
+                    <a class="right carousel-control" href="#carousel-EventItem" role="button" data-slide="next">
+                        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+                        <span class="sr-only">Next</span>
+                    </a>
+                </asp:PlaceHolder>
             </div>
         </asp:Panel>
         <asp:Panel ID="pnlAlert" runat="server" Visible="false">

--- a/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx.cs
+++ b/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx.cs
@@ -30,6 +30,14 @@ namespace RockWeb.Plugins.org_secc.Event
         Category = "Configuration",
         Key = AttributeKey.IncludeWaitList )]
 
+    [BooleanField( "Include Family Registrations",
+        Description = "Indicates if the pass should also include registrants from other registrations in the same registration instance that were made by members of the registrar's family. Useful for events where each registrant requires a separate registration (e.g. camps). Default is No.",
+        IsRequired = false,
+        DefaultBooleanValue = false,
+        Order = 1,
+        Category = "Configuration",
+        Key = AttributeKey.IncludeFamilyRegistrations )]
+
     [TextField( "Pass Not Found Header",
         Description = "The header/title of the message box that is displayed if the pass is not found.",
         IsRequired = false,
@@ -50,6 +58,7 @@ namespace RockWeb.Plugins.org_secc.Event
         public static class AttributeKey
         {
             public const string IncludeWaitList = "IncludeWaitList";
+            public const string IncludeFamilyRegistrations = "IncludeFamilyRegistrations";
             public const string PassNotFoundHeader = "PassNotFoundHeader";
             public const string PassNotFoundMessage = "PassNotFoundMessage";
 
@@ -121,6 +130,34 @@ namespace RockWeb.Plugins.org_secc.Event
                 registrantQry = registrantQry.Where( r => r.Registration.Guid.Equals( registrationGuid.Value ) );
             }
 
+            var includeFamilyRegistrations = GetAttributeValue( AttributeKey.IncludeFamilyRegistrations ).AsBoolean();
+            if (includeFamilyRegistrations)
+            {
+                // Anchor on the registration/registrant from the page parameters, then expand to all
+                // registrations in the same registration instance made by members of the registrar's family.
+                var anchor = registrantQry
+                    .Select( r => new
+                    {
+                        r.Registration.RegistrationInstanceId,
+                        RegistrarPersonId = r.Registration.PersonAlias.PersonId
+                    } )
+                    .FirstOrDefault();
+
+                if (anchor != null)
+                {
+                    var familyPersonIds = personService.GetFamilyMembers( anchor.RegistrarPersonId, true )
+                        .Select( m => m.PersonId )
+                        .ToList();
+
+                    registrantQry = new RegistrationRegistrantService( rockContext ).Queryable()
+                        .AsNoTracking()
+                        .Include( r => r.Registration.RegistrationInstance )
+                        .Include( r => r.PersonAlias.Person )
+                        .Where( r => r.Registration.RegistrationInstanceId == anchor.RegistrationInstanceId
+                            && familyPersonIds.Contains( r.Registration.PersonAlias.PersonId ) );
+                }
+            }
+
             if (!GetAttributeValue( AttributeKey.IncludeWaitList ).AsBoolean())
             {
                 registrantQry = registrantQry.Where( r => !r.OnWaitList );
@@ -131,6 +168,16 @@ namespace RockWeb.Plugins.org_secc.Event
                 .ThenBy( r => r.PersonAlias.Person.LastName )
                 .ThenBy( r => r.PersonAlias.Person.NickName )
                 .ToList();
+
+            if (includeFamilyRegistrations)
+            {
+                // A person could appear on multiple registrations (e.g. registered by both parents).
+                // Only generate one pass per person.
+                registrants = registrants
+                    .GroupBy( r => r.PersonAlias.PersonId )
+                    .Select( g => g.First() )
+                    .ToList();
+            }
 
             if(!registrants.Any())
             {

--- a/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx.cs
+++ b/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx.cs
@@ -237,7 +237,8 @@ namespace RockWeb.Plugins.org_secc.Event
             var itemOrder = 0;
             foreach (var registrant in registrants)
             {
-                alternateIdLookup.TryGetValue( registrant.PersonAlias.PersonId, out string alternateId );
+                string alternateId;
+                alternateIdLookup.TryGetValue( registrant.PersonAlias.PersonId, out alternateId );
 
                 var eventPassData = new EventPassData
                 {

--- a/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx.cs
+++ b/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx.cs
@@ -30,13 +30,13 @@ namespace RockWeb.Plugins.org_secc.Event
         Category = "Configuration",
         Key = AttributeKey.IncludeWaitList )]
 
-    [BooleanField( "Include Family Registrations",
-        Description = "Indicates if the pass should also include registrants from other registrations in the same registration instance that were made by members of the registrar's family. Useful for events where each registrant requires a separate registration (e.g. camps). Default is No.",
+    [BooleanField( "Include Registrar's Registrations",
+        Description = "Indicates if the pass, when viewed by a logged-in person, should also include registrants from other registrations in the same registration instance that were made by the viewer or a member of the viewer's family. Anonymous visitors always see only the registration/registrant the link points to. Useful for events where each registrant requires a separate registration (e.g. camps). Default is No.",
         IsRequired = false,
         DefaultBooleanValue = false,
         Order = 1,
         Category = "Configuration",
-        Key = AttributeKey.IncludeFamilyRegistrations )]
+        Key = AttributeKey.IncludeRegistrarRegistrations )]
 
     [TextField( "Pass Not Found Header",
         Description = "The header/title of the message box that is displayed if the pass is not found.",
@@ -58,7 +58,7 @@ namespace RockWeb.Plugins.org_secc.Event
         public static class AttributeKey
         {
             public const string IncludeWaitList = "IncludeWaitList";
-            public const string IncludeFamilyRegistrations = "IncludeFamilyRegistrations";
+            public const string IncludeRegistrarRegistrations = "IncludeRegistrarRegistrations";
             public const string PassNotFoundHeader = "PassNotFoundHeader";
             public const string PassNotFoundMessage = "PassNotFoundMessage";
 
@@ -107,75 +107,115 @@ namespace RockWeb.Plugins.org_secc.Event
 
             var rockContext = new RockContext();
             var personService = new PersonService( rockContext );
+            var registrantService = new RegistrationRegistrantService( rockContext );
 
-            var personSearchKeyQry = new PersonSearchKeyService( rockContext ).Queryable().AsNoTracking()
-                .Where( k => k.SearchTypeValueId == alternateIdDV.Id );
+            var includeWaitList = GetAttributeValue( AttributeKey.IncludeWaitList ).AsBoolean();
+            var includeRegistrarRegistrations = GetAttributeValue( AttributeKey.IncludeRegistrarRegistrations ).AsBoolean();
 
+            // Used to order a deep-linked registrant first. The OrderBy below runs unconditionally,
+            // so .Value would throw when the Registrant parameter is absent — Guid.Empty matches no row.
+            var registrantGuidValue = registrantGuid ?? Guid.Empty;
 
             var passes = new List<EventPassData>();
 
-
-            var registrantQry = new RegistrationRegistrantService( rockContext ).Queryable()
-                .AsNoTracking()
-                .Include( r => r.Registration.RegistrationInstance )
-                .Include( r => r.PersonAlias.Person );
-
-            if (registrantGuid.HasValue)
+            // Expansion is keyed to the authenticated viewer, never to the link: anonymous visitors
+            // see only what the page-parameter guids name. For a logged-in viewer, anchor on the
+            // registrants the guids unlock (after the waitlist filter, so a waitlist-only link stays
+            // "not found") and add registrations in the same instance made by the viewer's family.
+            var anchorRegistrantIds = new List<int>();
+            var registrarPersonIds = new List<int>();
+            var anchorRegistrationInstanceId = 0;
+            var expand = false;
+            if (includeRegistrarRegistrations && CurrentPersonId.HasValue)
             {
-                registrantQry = registrantQry.Where( r => r.Guid.Equals( registrantGuid.Value ) );
-            }
+                // Expansion may only trigger from rows the guid-only path would show, so this query
+                // must apply the same eligibility filters (waitlist, person alias) as the main query.
+                var anchorQry = ApplyPageParameterFilters( registrantService.Queryable().AsNoTracking() );
 
-            if (registrationGuid.HasValue)
-            {
-                registrantQry = registrantQry.Where( r => r.Registration.Guid.Equals( registrationGuid.Value ) );
-            }
+                if (!includeWaitList)
+                {
+                    anchorQry = anchorQry.Where( r => !r.OnWaitList );
+                }
 
-            var includeFamilyRegistrations = GetAttributeValue( AttributeKey.IncludeFamilyRegistrations ).AsBoolean();
-            if (includeFamilyRegistrations)
-            {
-                // Anchor on the registration/registrant from the page parameters, then expand to all
-                // registrations in the same registration instance made by members of the registrar's family.
-                var anchor = registrantQry
+                var anchors = anchorQry
+                    .Where( r => r.PersonAliasId.HasValue )
                     .Select( r => new
                     {
-                        r.Registration.RegistrationInstanceId,
-                        RegistrarPersonId = r.Registration.PersonAlias.PersonId
+                        r.Id,
+                        r.Registration.RegistrationInstanceId
                     } )
-                    .FirstOrDefault();
+                    .ToList();
 
-                if (anchor != null)
+                if (anchors.Any())
                 {
-                    var familyPersonIds = personService.GetFamilyMembers( anchor.RegistrarPersonId, true )
+                    expand = true;
+                    anchorRegistrantIds = anchors.Select( a => a.Id ).ToList();
+
+                    // The page parameters pin a single registrant or registration, so every anchor
+                    // shares one registration instance.
+                    anchorRegistrationInstanceId = anchors.First().RegistrationInstanceId;
+
+                    registrarPersonIds = personService.GetFamilyMembers( CurrentPersonId.Value, true )
                         .Select( m => m.PersonId )
                         .ToList();
 
-                    registrantQry = new RegistrationRegistrantService( rockContext ).Queryable()
-                        .AsNoTracking()
-                        .Include( r => r.Registration.RegistrationInstance )
-                        .Include( r => r.PersonAlias.Person )
-                        .Where( r => r.Registration.RegistrationInstanceId == anchor.RegistrationInstanceId
-                            && familyPersonIds.Contains( r.Registration.PersonAlias.PersonId ) );
+                    // GetFamilyMembers is built from family GroupMember rows, so a viewer with no
+                    // family group record gets an empty list — include the viewer themselves so
+                    // "registrar = me" always works.
+                    if (!registrarPersonIds.Contains( CurrentPersonId.Value ))
+                    {
+                        registrarPersonIds.Add( CurrentPersonId.Value );
+                    }
                 }
             }
 
-            if (!GetAttributeValue( AttributeKey.IncludeWaitList ).AsBoolean())
+            // Registrants with no person alias are excluded everywhere: a pass is person-keyed
+            // (QR = person search key) and the markup binds RegistrantPerson.*, so an alias-less
+            // row can never render.
+            var registrantQry = registrantService.Queryable()
+                .AsNoTracking()
+                .Include( r => r.Registration.RegistrationInstance )
+                .Include( r => r.PersonAlias.Person )
+                .Where( r => r.PersonAliasId.HasValue );
+
+            if (expand)
             {
+                // Keep every registrant the page parameters already unlocked (by id, so both sides
+                // of the OR stay index-seekable), and add registrants in the same registration
+                // instance whose registration was made by the viewer or the viewer's family
+                // (a null registrar never matches the IN list).
+                registrantQry = registrantQry.Where( r =>
+                    anchorRegistrantIds.Contains( r.Id )
+                    || ( r.Registration.RegistrationInstanceId == anchorRegistrationInstanceId
+                        && registrarPersonIds.Contains( r.Registration.PersonAlias.PersonId ) ) );
+            }
+            else
+            {
+                registrantQry = ApplyPageParameterFilters( registrantQry );
+            }
+
+            if (!includeWaitList)
+            {
+                // Must stay even though the anchor query filters the waitlist too — this is what
+                // hides waitlisted rows pulled in by the expansion branch.
                 registrantQry = registrantQry.Where( r => !r.OnWaitList );
             }
 
             var registrants = registrantQry
-                .OrderByDescending( r => r.PersonAlias.PersonId == r.Registration.PersonAlias.PersonId )
+                .OrderByDescending( r => r.Guid == registrantGuidValue )
+                .ThenByDescending( r => r.Registration.PersonAliasId.HasValue
+                    && r.PersonAlias.PersonId == r.Registration.PersonAlias.PersonId )
                 .ThenBy( r => r.PersonAlias.Person.LastName )
                 .ThenBy( r => r.PersonAlias.Person.NickName )
                 .ToList();
 
-            if (includeFamilyRegistrations)
+            if (expand)
             {
                 // A person could appear on multiple registrations (e.g. registered by both parents).
-                // Only generate one pass per person.
+                // Only generate one pass per person. DistinctBy keeps the FIRST row under the sort
+                // above, so the sort must keep the deep-linked registrant in front of duplicates.
                 registrants = registrants
-                    .GroupBy( r => r.PersonAlias.PersonId )
-                    .Select( g => g.First() )
+                    .DistinctBy( r => r.PersonAlias.PersonId )
                     .ToList();
             }
 
@@ -197,15 +237,28 @@ namespace RockWeb.Plugins.org_secc.Event
 
             if(occurrence != null)
             {
-                occurrenceDate = occurrence.Schedule.GetFirstStartDateTime();
+                occurrenceDate = occurrence.Schedule?.GetFirstStartDateTime();
                 location = occurrence.Location;
             }
+
+            var personIds = registrants
+                .Select( r => r.PersonAlias.PersonId )
+                .Distinct()
+                .ToList();
+
+            var alternateIdLookup = new PersonSearchKeyService( rockContext ).Queryable().AsNoTracking()
+                .Where( k => k.SearchTypeValueId == alternateIdDV.Id
+                    && personIds.Contains( k.PersonAlias.PersonId ) )
+                .Select( k => new { k.Id, k.PersonAlias.PersonId, k.SearchValue } )
+                .ToList()
+                .OrderBy( k => k.Id )
+                .GroupBy( k => k.PersonId )
+                .ToDictionary( g => g.Key, g => g.First().SearchValue );
 
             var itemOrder = 0;
             foreach (var registrant in registrants)
             {
-                var alternateId = personSearchKeyQry.Where( k => k.PersonAlias.PersonId == registrant.PersonAlias.PersonId )
-                    .Select( k => k.SearchValue ).FirstOrDefault();
+                alternateIdLookup.TryGetValue( registrant.PersonAlias.PersonId, out string alternateId );
 
                 var eventPassData = new EventPassData
                 {
@@ -238,6 +291,27 @@ namespace RockWeb.Plugins.org_secc.Event
             rockContext = null;
             pnlPass.Visible = true;
 
+        }
+
+        /// <summary>
+        /// Applies the Registration/Registrant page-parameter filters — the single definition of
+        /// which registrant rows a link's guids unlock.
+        /// </summary>
+        private IQueryable<RegistrationRegistrant> ApplyPageParameterFilters( IQueryable<RegistrationRegistrant> qry )
+        {
+            if (registrantGuid.HasValue)
+            {
+                var registrantGuidValue = registrantGuid.Value;
+                qry = qry.Where( r => r.Guid.Equals( registrantGuidValue ) );
+            }
+
+            if (registrationGuid.HasValue)
+            {
+                var registrationGuidValue = registrationGuid.Value;
+                qry = qry.Where( r => r.Registration.Guid.Equals( registrationGuidValue ) );
+            }
+
+            return qry;
         }
 
         private void ShowNoPassesFound()

--- a/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx.cs
+++ b/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx.cs
@@ -118,102 +118,81 @@ namespace RockWeb.Plugins.org_secc.Event
 
             var passes = new List<EventPassData>();
 
-            // Expansion is keyed to the authenticated viewer, never to the link: anonymous visitors
-            // see only what the page-parameter guids name. For a logged-in viewer, anchor on the
-            // registrants the guids unlock (after the waitlist filter, so a waitlist-only link stays
-            // "not found") and add registrations in the same instance made by the viewer's family.
-            var anchorRegistrantIds = new List<int>();
-            var registrarPersonIds = new List<int>();
-            var anchorRegistrationInstanceId = 0;
-            var expand = false;
-            if (includeRegistrarRegistrations && CurrentPersonId.HasValue)
-            {
-                // Expansion may only trigger from rows the guid-only path would show, so this query
-                // must apply the same eligibility filters (waitlist, person alias) as the main query.
-                var anchorQry = ApplyPageParameterFilters( registrantService.Queryable().AsNoTracking() );
-
-                if (!includeWaitList)
-                {
-                    anchorQry = anchorQry.Where( r => !r.OnWaitList );
-                }
-
-                var anchors = anchorQry
-                    .Where( r => r.PersonAliasId.HasValue )
-                    .Select( r => new
-                    {
-                        r.Id,
-                        r.Registration.RegistrationInstanceId
-                    } )
-                    .ToList();
-
-                if (anchors.Any())
-                {
-                    expand = true;
-                    anchorRegistrantIds = anchors.Select( a => a.Id ).ToList();
-
-                    // The page parameters pin a single registrant or registration, so every anchor
-                    // shares one registration instance.
-                    anchorRegistrationInstanceId = anchors.First().RegistrationInstanceId;
-
-                    registrarPersonIds = personService.GetFamilyMembers( CurrentPersonId.Value, true )
-                        .Select( m => m.PersonId )
-                        .ToList();
-
-                    // GetFamilyMembers is built from family GroupMember rows, so a viewer with no
-                    // family group record gets an empty list — include the viewer themselves so
-                    // "registrar = me" always works.
-                    if (!registrarPersonIds.Contains( CurrentPersonId.Value ))
-                    {
-                        registrarPersonIds.Add( CurrentPersonId.Value );
-                    }
-                }
-            }
-
             // Registrants with no person alias are excluded everywhere: a pass is person-keyed
             // (QR = person search key) and the markup binds RegistrantPerson.*, so an alias-less
             // row can never render.
-            var registrantQry = registrantService.Queryable()
+            var eligibleQry = registrantService.Queryable()
                 .AsNoTracking()
-                .Include( r => r.Registration.RegistrationInstance )
-                .Include( r => r.PersonAlias.Person )
                 .Where( r => r.PersonAliasId.HasValue );
-
-            if (expand)
-            {
-                // Keep every registrant the page parameters already unlocked (by id, so both sides
-                // of the OR stay index-seekable), and add registrants in the same registration
-                // instance whose registration was made by the viewer or the viewer's family
-                // (a null registrar never matches the IN list).
-                registrantQry = registrantQry.Where( r =>
-                    anchorRegistrantIds.Contains( r.Id )
-                    || ( r.Registration.RegistrationInstanceId == anchorRegistrationInstanceId
-                        && registrarPersonIds.Contains( r.Registration.PersonAlias.PersonId ) ) );
-            }
-            else
-            {
-                registrantQry = ApplyPageParameterFilters( registrantQry );
-            }
 
             if (!includeWaitList)
             {
-                // Must stay even though the anchor query filters the waitlist too — this is what
-                // hides waitlisted rows pulled in by the expansion branch.
-                registrantQry = registrantQry.Where( r => !r.OnWaitList );
+                eligibleQry = eligibleQry.Where( r => !r.OnWaitList );
             }
 
-            var registrants = registrantQry
-                .OrderByDescending( r => r.Guid == registrantGuidValue )
+            // The registrant rows the link's guids unlock. Kept as an unmaterialized queryable so
+            // the expansion below can reference it as EXISTS subqueries in the same SQL statement.
+            var anchorQry = ApplyPageParameterFilters( eligibleQry );
+
+            IQueryable<RegistrationRegistrant> registrantQry;
+
+            // Expansion is keyed to the authenticated viewer, never to the link: anonymous visitors
+            // see only what the page-parameter guids name.
+            var expanded = includeRegistrarRegistrations && CurrentPersonId.HasValue;
+            if (expanded)
+            {
+                var currentPersonId = CurrentPersonId.Value;
+
+                // Composed subquery (same rockContext) — translates to nested SQL instead of a
+                // separate round trip and a literal IN list. GetFamilyMembers is built from family
+                // GroupMember rows, so a viewer with no family group record yields an empty set —
+                // the explicit currentPersonId comparison keeps "registrar = me" working.
+                var registrarPersonIdQry = personService.GetFamilyMembers( currentPersonId, true )
+                    .Select( m => m.PersonId );
+
+                // Keep every registrant the link unlocks, and add registrants in the same
+                // registration instance whose registration was made by the viewer or the viewer's
+                // family (a null registrar matches neither side). The instance EXISTS also gates
+                // expansion on the link unlocking at least one eligible row: a link to nothing (or
+                // to waitlist-only rows when the waitlist is hidden) stays "Pass Not Found".
+                registrantQry = eligibleQry.Where( r =>
+                    anchorQry.Any( a => a.Id == r.Id )
+                    || ( anchorQry.Any( a => a.Registration.RegistrationInstanceId == r.Registration.RegistrationInstanceId )
+                        && r.Registration.PersonAliasId.HasValue
+                        && ( registrarPersonIdQry.Contains( r.Registration.PersonAlias.PersonId )
+                            || r.Registration.PersonAlias.PersonId == currentPersonId ) ) );
+            }
+            else
+            {
+                registrantQry = anchorQry;
+            }
+
+            var orderedQry = registrantQry
+                .Include( r => r.Registration.RegistrationInstance )
+                .Include( r => r.PersonAlias.Person )
+                .OrderByDescending( r => r.Guid == registrantGuidValue );
+
+            if (expanded)
+            {
+                // Rows the link unlocks outrank expansion rows, so the DistinctBy below keeps the
+                // registrant row from the linked registration when the same person also appears on
+                // another family registration. (The deep-link key above only covers Registrant links;
+                // this covers Registration links.)
+                orderedQry = orderedQry.ThenByDescending( r => anchorQry.Any( a => a.Id == r.Id ) );
+            }
+
+            var registrants = orderedQry
                 .ThenByDescending( r => r.Registration.PersonAliasId.HasValue
                     && r.PersonAlias.PersonId == r.Registration.PersonAlias.PersonId )
                 .ThenBy( r => r.PersonAlias.Person.LastName )
                 .ThenBy( r => r.PersonAlias.Person.NickName )
                 .ToList();
 
-            if (expand)
+            if (expanded)
             {
                 // A person could appear on multiple registrations (e.g. registered by both parents).
                 // Only generate one pass per person. DistinctBy keeps the FIRST row under the sort
-                // above, so the sort must keep the deep-linked registrant in front of duplicates.
+                // above, which keeps the linked registration's row in front of duplicates.
                 registrants = registrants
                     .DistinctBy( r => r.PersonAlias.PersonId )
                     .ToList();

--- a/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx.cs
+++ b/Plugins/org.secc.Event/org_secc/Event/EventPass.ascx.cs
@@ -233,6 +233,8 @@ namespace RockWeb.Plugins.org_secc.Event
             rPassIndicator.DataSource = passes.OrderBy( p => p.ItemOrder );
             rPassIndicator.DataBind();
 
+            phCarouselControls.Visible = passes.Count > 1;
+
             rockContext = null;
             pnlPass.Visible = true;
 


### PR DESCRIPTION
## Summary

Groups event-pass registrations for camp-style events (one registration per camper) into a single carousel, keyed to the **logged-in viewer** rather than the link:

- **Anonymous visitor** — sees exactly the registration/registrant the URL guid names (unchanged from pre-PR behavior). Forwarded links expose nothing beyond themselves.
- **Logged-in viewer** (with the new block setting enabled) — also sees registrants from other registrations in the same registration instance that were made by the viewer or a member of the viewer's family, so a parent who registered each kid separately (or whose spouse registered one) gets all of them in one carousel.

New block setting: **Include Registrar's Registrations** (`IncludeRegistrarRegistrations`, default No). Carousel prev/next arrows are hidden when there is only one pass.

## Fixes over the original approach

The first iteration expanded by the *registrar's family inferred from the URL guid*, which review flagged as an access-widening issue (one registrant guid could unlock other people's pass QR codes — person-level check-in credentials — including non-family registrants and, worst case, everything a staff data-entry registrar had created). Keying expansion to the authenticated viewer removes that class of exposure entirely. Also fixed along the way:

- Waitlist filter now applies before anchoring: with *Include Registrants on Waitlist* = No, a waitlist-only link shows "Pass Not Found" instead of rendering the family's other passes.
- Registrations with a null registrar (`Registration.PersonAliasId` is nullable) no longer crash the page during EF materialization.
- Registrants without a person alias are excluded — they can't render a pass (the template binds `RegistrantPerson.*`) and previously crashed the page.
- A `?Registrant=` deep link now opens with that registrant as the active carousel slide.
- One pass per person when a person appears on multiple registrations (order-preserving `DistinctBy`).
- The per-registrant `PersonSearchKey` lookup (N+1) is replaced with one batched query with a deterministic lowest-Id winner.

## Deployment note

The block setting was renamed from `IncludeFamilyRegistrations` (earlier commits on this branch) to `IncludeRegistrarRegistrations`. Any environment that deployed an earlier branch build will have an orphaned *Include Family Registrations* attribute — delete it and enable the new setting. Fresh deploys from master are unaffected.

## Verification

Query pipeline exercised against a local Rock 13 database via an EF6 integration harness — 17 scenarios covering anonymous vs logged-in, spouse-made registrations included, grandparent/staff-made excluded, waitlist links, null registrar, null alias, no-family viewer, mismatched guid pairs, and dedup. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
