### PR TITLE
ROCK-8780: Fix GroupRecommit IDOR — gate person-id params on block EDIT auth

### DIFF
--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupRecommit.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupRecommit.ascx.cs
@@ -192,6 +192,15 @@ namespace RockWeb.Plugins.org_secc.GroupManager
 
         private void BindGrid()
         {
+            // Grid rebind fires as a postback event even when OnLoad bailed out on a null
+            // person (e.g. an unauthorized id swap that no longer resolves), so guard the
+            // _person / _group dereferences below (ROCK-8780).
+            if ( _person == null || _group == null )
+            {
+                pnlMembers.Visible = false;
+                return;
+            }
+
             var members = _group.Members
                     .Where( gm => gm.PersonId != _person.Id
                     && gm.GroupMemberStatus == GroupMemberStatus.Active )
@@ -393,14 +402,27 @@ namespace RockWeb.Plugins.org_secc.GroupManager
             var personId = PageParameter( "PersonId" ).AsInteger();
             var urlEncodedKey = PageParameter( "UrlEncodedKey" );
 
-            if ( personId != 0 )
+            // Only authorized (block EDIT) staff may load an arbitrary person by a raw
+            // PersonId / PersonAliasId parameter. Members reach the public instances via an
+            // rckipid impersonation link or their own login (which set CurrentPerson but never
+            // pass these ids), so gating on block EDIT authorization prevents an anonymous or
+            // ordinary logged-in member from loading an arbitrary person by swapping the id in
+            // the URL (ROCK-8780 IDOR). Unauthorized callers fall through to the CurrentPerson
+            // (self only) fallback below.
+            bool canLoadArbitraryPerson = this.IsUserAuthorized( Rock.Security.Authorization.EDIT );
+
+            if ( canLoadArbitraryPerson && personId != 0 )
             {
                 _person = new PersonService( _rockContext ).Get( personId );
             }
 
-            if ( personAliasId != 0 && _person == null )
+            if ( canLoadArbitraryPerson && personAliasId != 0 && _person == null )
             {
-                _person = new PersonAliasService( _rockContext ).Get( personAliasId ).Person;
+                var personAlias = new PersonAliasService( _rockContext ).Get( personAliasId );
+                if ( personAlias != null )
+                {
+                    _person = personAlias.Person;
+                }
             }
 
             if ( !string.IsNullOrWhiteSpace( urlEncodedKey ) && _person == null )
@@ -426,6 +448,14 @@ namespace RockWeb.Plugins.org_secc.GroupManager
 
         protected void btnSave_Click( object sender, EventArgs e )
         {
+            // With the tighter authorization gate the person may no longer resolve on this
+            // postback; bail before dereferencing _person for any mutation (ROCK-8780).
+            if ( _person == null )
+            {
+                ShowMessage( GetAttributeValue( "LoginText" ), "Information" );
+                return;
+            }
+
             if ( lopAddress.Location == null
                 || string.IsNullOrWhiteSpace( lopAddress.Location.Street1 )
                 || string.IsNullOrWhiteSpace( lopAddress.Location.PostalCode ) )


### PR DESCRIPTION
## ROCK-8780 — GroupRecommit IDOR (High)

**Bug:** `GroupRecommit.LoadPerson()` trusted `PersonId` / `PersonAliasId` from the URL with no authorization check. The block runs as three instances — one internal staff tool plus two on public sites (LWYA, main SECC) that allow AllAuthenticatedUsers — so any anonymous caller, or any logged-in member on the public pages, could swap the id and drive the recommit / group-create flow (creates a `Group`, adds the person as leader, fires a workflow) against an arbitrary person.

## What changed
- **Gate the id params on `IsUserAuthorized( Authorization.EDIT )`** — only staff granted EDIT on the block may resolve an arbitrary person by id. This closes the IDOR.
- **Members are unaffected:** they arrive via the `rckipid` impersonation link or their own login (which set `CurrentPerson` but never pass these params) and fall through the unchanged `CurrentPerson` (self-only) fallback. Anonymous / member id-swaps become no-ops.
- **Null-safe** the `PersonAlias` lookup (was a latent NRE on a bad id).
- **`_person == null` guards** in `btnSave_Click` and `BindGrid` — postback paths that can now run unresolved under the tighter gate; they show the existing login message instead of NRE'ing.

## Required companion (same deploy window)
Auth **Edit-grant on block 884** (internal instance) to the **`RSR - Rock Edit Access`** role. Without it, staff lose the by-id lookup and can only edit themselves. Public blocks (911 / 2945) are intentionally left ungranted — that's what keeps members off the id path on the public sites. Recipe is on the ticket.

## Out of scope
- `GroupMember.GroupTypeId` (v16 NOT NULL) — reverted; no such column in 13.7, deferred to the v16 upgrade.
- Same antipattern in `ChangeEntry` / `FinancialAidFamilyProfile` and the permanent-`rckipid`-token risk — tracked as follow-ups on the ticket.

C# 6 compliant (runtime-compiled `.ascx.cs`). No merge until the companion Auth grant is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)