### PR TITLE
Fix "shoud" -> "should" typo in copyright headers

### DIFF
--- a/Content/Lava/18DaysofPrayer/ConnectionOpportunitySearch.ascx.cs
+++ b/Content/Lava/18DaysofPrayer/ConnectionOpportunitySearch.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Content/Lava/18DaysofPrayer/VolunteerSignupFormConnections.ascx.cs
+++ b/Content/Lava/18DaysofPrayer/VolunteerSignupFormConnections.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Content/Lava/18DaysofPrayer/VolunteerSignupWizard.ascx.cs
+++ b/Content/Lava/18DaysofPrayer/VolunteerSignupWizard.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Content/Lava/24HoursofPrayer/ConnectionOpportunitySearch.ascx.cs
+++ b/Content/Lava/24HoursofPrayer/ConnectionOpportunitySearch.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Content/Lava/24HoursofPrayer/VolunteerSignupFormConnections.ascx.cs
+++ b/Content/Lava/24HoursofPrayer/VolunteerSignupFormConnections.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Content/Lava/24HoursofPrayer/VolunteerSignupWizard.ascx.cs
+++ b/Content/Lava/24HoursofPrayer/VolunteerSignupWizard.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Administration/org_secc/Administration/GroupTypeChanger.ascx.cs
+++ b/Plugins/org.secc.Administration/org_secc/Administration/GroupTypeChanger.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Administration/org_secc/Administration/NeighborhoodGroupMerge.ascx.cs
+++ b/Plugins/org.secc.Administration/org_secc/Administration/NeighborhoodGroupMerge.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Administration/org_secc/Administration/SystemInfo.ascx.cs
+++ b/Plugins/org.secc.Administration/org_secc/Administration/SystemInfo.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Attributes/Attributes/CascadingDropDownFieldAttribute.cs
+++ b/Plugins/org.secc.Attributes/Attributes/CascadingDropDownFieldAttribute.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Attributes/Attributes/DynamicPhoneNumber.cs
+++ b/Plugins/org.secc.Attributes/Attributes/DynamicPhoneNumber.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Attributes/Controls/CascadingDropDownList.cs
+++ b/Plugins/org.secc.Attributes/Controls/CascadingDropDownList.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Attributes/Controls/DynamicPhoneNumberPicker.cs
+++ b/Plugins/org.secc.Attributes/Controls/DynamicPhoneNumberPicker.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Attributes/FieldTypes/CascadingDropdownFieldType.cs
+++ b/Plugins/org.secc.Attributes/FieldTypes/CascadingDropdownFieldType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Attributes/FieldTypes/DynamicPhoneNumberFieldType.cs
+++ b/Plugins/org.secc.Attributes/FieldTypes/DynamicPhoneNumberFieldType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Attributes/Helpers/KeyValueList.cs
+++ b/Plugins/org.secc.Attributes/Helpers/KeyValueList.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Attributes/Helpers/KeyValueMatrix.cs
+++ b/Plugins/org.secc.Attributes/Helpers/KeyValueMatrix.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Authentication/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.Authentication/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Authentication/SMSAuthentication.cs
+++ b/Plugins/org.secc.Authentication/SMSAuthentication.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Authentication/org_secc/Authentication/SMSLogin.ascx.cs
+++ b/Plugins/org.secc.Authentication/org_secc/Authentication/SMSLogin.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Data/ChangeManagerContext.cs
+++ b/Plugins/org.secc.ChangeManager/Data/ChangeManagerContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Data/ChangeManagerService.cs
+++ b/Plugins/org.secc.ChangeManager/Data/ChangeManagerService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Migrations/001_Init.cs
+++ b/Plugins/org.secc.ChangeManager/Migrations/001_Init.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Migrations/002_FamilyGroupOfPerson.cs
+++ b/Plugins/org.secc.ChangeManager/Migrations/002_FamilyGroupOfPerson.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Migrations/003_InternalCampusTypeValue.cs
+++ b/Plugins/org.secc.ChangeManager/Migrations/003_InternalCampusTypeValue.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Migrations/Configuration.cs
+++ b/Plugins/org.secc.ChangeManager/Migrations/Configuration.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Model/BasicEntity.cs
+++ b/Plugins/org.secc.ChangeManager/Model/BasicEntity.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Model/ChangeRecord.cs
+++ b/Plugins/org.secc.ChangeManager/Model/ChangeRecord.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Model/ChangeRecordService.cs
+++ b/Plugins/org.secc.ChangeManager/Model/ChangeRecordService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Model/ChangeRequest.cs
+++ b/Plugins/org.secc.ChangeManager/Model/ChangeRequest.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Model/ChangeRequestService.cs
+++ b/Plugins/org.secc.ChangeManager/Model/ChangeRequestService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Utilities/PropertyChangeEvaluators.cs
+++ b/Plugins/org.secc.ChangeManager/Utilities/PropertyChangeEvaluators.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/Utilities/SecurityChangeDetail.cs
+++ b/Plugins/org.secc.ChangeManager/Utilities/SecurityChangeDetail.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeEntry.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeEntry.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequestDetail.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequestDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequests.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequests.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/CacheInspect.ascx.cs
+++ b/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/CacheInspect.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/CheckinMonitor.ascx.cs
+++ b/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/CheckinMonitor.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/LiveMonitor.ascx.cs
+++ b/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/LiveMonitor.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/MobileCheckinViewer.ascx.cs
+++ b/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/MobileCheckinViewer.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/SuperCheckin.ascx.cs
+++ b/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/SuperCheckin.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/SuperSearch.ascx.cs
+++ b/Plugins/org.secc.CheckinMonitor/org_secc/CheckinMonitor/SuperSearch.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/Migrations/001_Init.cs
+++ b/Plugins/org.secc.Cms/Migrations/001_Init.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.Cms/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/SectionZone.cs
+++ b/Plugins/org.secc.Cms/SectionZone.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/org_secc/Cms/CacheTagsCheckList.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/CacheTagsCheckList.ascx.cs
@@ -4,7 +4,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/org_secc/Cms/LoginJS.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/LoginJS.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/org_secc/Cms/LoginStatus.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/LoginStatus.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/org_secc/Cms/PublicProfileEdit.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/PublicProfileEdit.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/org_secc/Cms/QRCodeGenerator.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/QRCodeGenerator.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/org_secc/Cms/SectionHeader.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/SectionHeader.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/org_secc/Cms/TimedContentChannel.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/TimedContentChannel.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/org_secc/Cms/Topper.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/Topper.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Cms/org_secc/Cms/TwitterLava.ascx.cs
+++ b/Plugins/org.secc.Cms/org_secc/Cms/TwitterLava.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Communication/Data/CommunicationDataContext.cs
+++ b/Plugins/org.secc.Communication/Data/CommunicationDataContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Communication/Data/CommunicationDataService.cs
+++ b/Plugins/org.secc.Communication/Data/CommunicationDataService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Communication/Jobs/SyncTwilioHistory.cs
+++ b/Plugins/org.secc.Communication/Jobs/SyncTwilioHistory.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Communication/Model/TwilioHistory.cs
+++ b/Plugins/org.secc.Communication/Model/TwilioHistory.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Communication/org_secc/Communication/SyncTwilioHistory.ascx.cs
+++ b/Plugins/org.secc.Communication/org_secc/Communication/SyncTwilioHistory.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Connection/org_secc/Connection/ConnectionOpportunitySearch.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/ConnectionOpportunitySearch.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupWizard.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupWizard.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ConnectionCards/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.ConnectionCards/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ConnectionCards/Utilities/ConnectionCardsUtilties.cs
+++ b/Plugins/org.secc.ConnectionCards/Utilities/ConnectionCardsUtilties.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ConnectionCards/org_secc/ConnectionCards/ConnectionCardEntry.ascx.cs
+++ b/Plugins/org.secc.ConnectionCards/org_secc/ConnectionCards/ConnectionCardEntry.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ConnectionsDigest/ConnectionsDigest.cs
+++ b/Plugins/org.secc.ConnectionsDigest/ConnectionsDigest.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ConnectionsDigest/Migrations/20180629120000_InitialCreate.cs
+++ b/Plugins/org.secc.ConnectionsDigest/Migrations/20180629120000_InitialCreate.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ConnectionsDigest/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.ConnectionsDigest/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.CustomIcons/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.CustomIcons/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.DevLib/Components/SettingsComponent.cs
+++ b/Plugins/org.secc.DevLib/Components/SettingsComponent.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.DevLib/Components/SettingsContainer.cs
+++ b/Plugins/org.secc.DevLib/Components/SettingsContainer.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.EMS/API.cs
+++ b/Plugins/org.secc.EMS/API.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.EMS/APIData.cs
+++ b/Plugins/org.secc.EMS/APIData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.EMS/APIMethods.cs
+++ b/Plugins/org.secc.EMS/APIMethods.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.EMS/Events.cs
+++ b/Plugins/org.secc.EMS/Events.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.EMS/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.EMS/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.EMS/org_secc/EMS/ViewEvents.ascx.cs
+++ b/Plugins/org.secc.EMS/org_secc/EMS/ViewEvents.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/ChapterDetail.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/ChapterDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/ChapterList.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/ChapterList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/CourseDetail.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/CourseDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/CourseEntry.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/CourseEntry.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/CourseInformation.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/CourseInformation.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/CourseLava.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/CourseLava.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/CourseList.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/CourseList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/CourseOutline.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/CourseOutline.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/CoursePageList.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/CoursePageList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/CourseRequirementDetail.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/CourseRequirementDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Equip/org_secc/Equip/CourseRequirementList.ascx.cs
+++ b/Plugins/org.secc.Equip/org_secc/Equip/CourseRequirementList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Attribute/CheckinGroupFieldAttribute.cs
+++ b/Plugins/org.secc.FamilyCheckin/Attribute/CheckinGroupFieldAttribute.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Cache/BreakoutGroupItem.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/BreakoutGroupItem.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinKioskTypeCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinKioskTypeCache.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Cache/MobileCheckinRecordCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/MobileCheckinRecordCache.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Cache/OccurrenceCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/OccurrenceCache.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Controls/CheckinGroupRowWithArchiving.cs
+++ b/Plugins/org.secc.FamilyCheckin/Controls/CheckinGroupRowWithArchiving.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Data/FamilyCheckinContext.cs
+++ b/Plugins/org.secc.FamilyCheckin/Data/FamilyCheckinContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Data/FamilyCheckinService.cs
+++ b/Plugins/org.secc.FamilyCheckin/Data/FamilyCheckinService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Exceptions/CheckInStateLost.cs
+++ b/Plugins/org.secc.FamilyCheckin/Exceptions/CheckInStateLost.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/FieldTypes/CheckinGroupFieldType.cs
+++ b/Plugins/org.secc.FamilyCheckin/FieldTypes/CheckinGroupFieldType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Jobs/RemoveExpiredMobileReservations.cs
+++ b/Plugins/org.secc.FamilyCheckin/Jobs/RemoveExpiredMobileReservations.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Jobs/ResetGroupLocationSchedules.cs
+++ b/Plugins/org.secc.FamilyCheckin/Jobs/ResetGroupLocationSchedules.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/001_Init.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/001_Init.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/002_Message.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/002_Message.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/004_Touchless.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/004_Touchless.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/005_KioskCategories.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/005_KioskCategories.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/006_KioskNameIndex.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/006_KioskNameIndex.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/007_SearchType.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/007_SearchType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/008_MobileCheckinRecord.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/008_MobileCheckinRecord.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/009_ExpirationTime.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/009_ExpirationTime.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/010_AttendanceQualifiers.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/010_AttendanceQualifiers.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/011_KioskTypeTheme.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/011_KioskTypeTheme.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/012_CheckinCampusFamilyDT.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/012_CheckinCampusFamilyDT.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/013_GroupFilterAttributes.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/013_GroupFilterAttributes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/014_AccessKey.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/014_AccessKey.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/020_FamilyCheckinWorkflow.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/020_FamilyCheckinWorkflow.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/021_DisabledGLSsDT.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/021_DisabledGLSsDT.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/022_CheckinGroupTypes.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/022_CheckinGroupTypes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/023_KioskTypePages.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/023_KioskTypePages.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/024_FamilyCheckinPages.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/024_FamilyCheckinPages.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/025_SuperCheckinPages.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/025_SuperCheckinPages.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/026_MobileCheckinPages.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/026_MobileCheckinPages.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/027_MoveGroupTypes.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/027_MoveGroupTypes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/030_LastMedicationCheckinAttribute.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/030_LastMedicationCheckinAttribute.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/031_MedicalConsentKioskTypeAttributes.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/031_MedicalConsentKioskTypeAttributes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Migrations/Configuration.cs
+++ b/Plugins/org.secc.FamilyCheckin/Migrations/Configuration.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Model/CheckinKioskType.cs
+++ b/Plugins/org.secc.FamilyCheckin/Model/CheckinKioskType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Model/CheckinKioskTypeService.cs
+++ b/Plugins/org.secc.FamilyCheckin/Model/CheckinKioskTypeService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Model/Kiosk.cs
+++ b/Plugins/org.secc.FamilyCheckin/Model/Kiosk.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Model/KioskService.cs
+++ b/Plugins/org.secc.FamilyCheckin/Model/KioskService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Model/MobileCheckinRecord.cs
+++ b/Plugins/org.secc.FamilyCheckin/Model/MobileCheckinRecord.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Model/MobileCheckinRecordService.cs
+++ b/Plugins/org.secc.FamilyCheckin/Model/MobileCheckinRecordService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.FamilyCheckin/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Rest/Controllers/FamilyCheckinController.Partial.cs
+++ b/Plugins/org.secc.FamilyCheckin/Rest/Controllers/FamilyCheckinController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Rest/Handlers/SessionControllerHandler.cs
+++ b/Plugins/org.secc.FamilyCheckin/Rest/Handlers/SessionControllerHandler.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Rest/Handlers/SessionRouteHandler.cs
+++ b/Plugins/org.secc.FamilyCheckin/Rest/Handlers/SessionRouteHandler.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/UI/CheckinGroupPicker.cs
+++ b/Plugins/org.secc.FamilyCheckin/UI/CheckinGroupPicker.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Utilities/Constants.cs
+++ b/Plugins/org.secc.FamilyCheckin/Utilities/Constants.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Utilities/LabelPrinter.cs
+++ b/Plugins/org.secc.FamilyCheckin/Utilities/LabelPrinter.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/CreateEventLabels.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/CreateEventLabels.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/CreateLabelsAggregate.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/CreateLabelsAggregate.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/CreateMedicationLabels.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/CreateMedicationLabels.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/CustFindFamilies.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/CustFindFamilies.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/FilterGroupsByAbility.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/FilterGroupsByAbility.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/FilterGroupsByBirthday.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/FilterGroupsByBirthday.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/FilterGroupsByGrade.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/FilterGroupsByGrade.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/FilterGroupsByMembership.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/FilterGroupsByMembership.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/HistoricalPreselect.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/HistoricalPreselect.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/LoadAllCacheless.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/LoadAllCacheless.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/LoadAllGroupTypes.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/LoadAllGroupTypes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/LoadAllGroups.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/LoadAllGroups.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/LoadAllLocations.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/LoadAllLocations.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/LoadAllOverride.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/LoadAllOverride.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/LoadPersonByPIN.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/LoadPersonByPIN.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/RemoveFullGroupLocationSchedules.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/RemoveFullGroupLocationSchedules.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/ReprintAggregate.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/ReprintAggregate.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/ReserveAttendance.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/ReserveAttendance.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/SaveAttendance.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/SaveAttendance.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/SaveAttendanceAndRemoveSession.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/SaveAttendanceAndRemoveSession.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/SaveSMSAttendance.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/SaveSMSAttendance.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/SearchByPin.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/SearchByPin.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/SelectAllPeople.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/SelectAllPeople.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/Workflows/SideloadGroups.cs
+++ b/Plugins/org.secc.FamilyCheckin/Workflows/SideloadGroups.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/AutoConfigure.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/AutoConfigure.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/KioskDetail.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/KioskDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/KioskList.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/KioskList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/KioskTypeDetail.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/KioskTypeDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/KioskTypeList.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/KioskTypeList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/MobileCheckinStart.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/MobileCheckinStart.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/MyAccountMedicalConsent.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/MyAccountMedicalConsent.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/PreRegistration.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/PreRegistration.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/QuickCheckin.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/QuickCheckin.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/QuickSearch.ascx.cs
+++ b/Plugins/org.secc.FamilyCheckin/org_secc/FamilyCheckin/QuickSearch.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.FamilyOnMission/org_secc/FamilyOnMission/FoMSignup.ascx.cs
+++ b/Plugins/org.secc.FamilyOnMission/org_secc/FamilyOnMission/FoMSignup.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Finance/Handlers/GetStatement.ashx.cs
+++ b/Plugins/org.secc.Finance/Handlers/GetStatement.ashx.cs
@@ -18,7 +18,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Finance/Jobs/ProcessGivingStatements.cs
+++ b/Plugins/org.secc.Finance/Jobs/ProcessGivingStatements.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Finance/Utility/Statement.cs
+++ b/Plugins/org.secc.Finance/Utility/Statement.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Finance/Workflow/GenerateStatement.cs
+++ b/Plugins/org.secc.Finance/Workflow/GenerateStatement.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Finance/org_secc/Finance/BulkRefund.ascx.cs
+++ b/Plugins/org.secc.Finance/org_secc/Finance/BulkRefund.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Finance/org_secc/Finance/ContributionStatementGenerator.ascx.cs
+++ b/Plugins/org.secc.Finance/org_secc/Finance/ContributionStatementGenerator.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Finance/org_secc/Finance/ContributionStatementLava.ascx.cs
+++ b/Plugins/org.secc.Finance/org_secc/Finance/ContributionStatementLava.ascx.cs
@@ -19,7 +19,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Finance/org_secc/Finance/ContributionStatementList.ascx.cs
+++ b/Plugins/org.secc.Finance/org_secc/Finance/ContributionStatementList.ascx.cs
@@ -19,7 +19,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Data/GroupManagerContext.cs
+++ b/Plugins/org.secc.GroupManager/Data/GroupManagerContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Data/GroupManagerService.cs
+++ b/Plugins/org.secc.GroupManager/Data/GroupManagerService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Exceptions/NonExistantFilter.cs
+++ b/Plugins/org.secc.GroupManager/Exceptions/NonExistantFilter.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Migrations/002_SpouseRegistration.cs
+++ b/Plugins/org.secc.GroupManager/Migrations/002_SpouseRegistration.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Migrations/003_MeetingDetails.cs
+++ b/Plugins/org.secc.GroupManager/Migrations/003_MeetingDetails.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Migrations/004_RegistrationOptions.cs
+++ b/Plugins/org.secc.GroupManager/Migrations/004_RegistrationOptions.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Migrations/005_ChildcareOptions.cs
+++ b/Plugins/org.secc.GroupManager/Migrations/005_ChildcareOptions.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Migrations/006_ChildcareDescription.cs
+++ b/Plugins/org.secc.GroupManager/Migrations/006_ChildcareDescription.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Migrations/007_RegistrationDescription.cs
+++ b/Plugins/org.secc.GroupManager/Migrations/007_RegistrationDescription.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Migrations/008_AddKeys.cs
+++ b/Plugins/org.secc.GroupManager/Migrations/008_AddKeys.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Migrations/009_RequestedChanges.cs
+++ b/Plugins/org.secc.GroupManager/Migrations/009_RequestedChanges.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Migrations/010_DropRequiresRegistration.cs
+++ b/Plugins/org.secc.GroupManager/Migrations/010_DropRequiresRegistration.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Model/PublishGroup.cs
+++ b/Plugins/org.secc.GroupManager/Model/PublishGroup.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Model/PublishGroupService.cs
+++ b/Plugins/org.secc.GroupManager/Model/PublishGroupService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.GroupManager/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/UI/GroupManagerBlock.cs
+++ b/Plugins/org.secc.GroupManager/UI/GroupManagerBlock.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/BreakoutGroupMigration.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/BreakoutGroupMigration.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/CampGroupMembers.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/CampGroupMembers.ascx.cs
@@ -4,7 +4,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupCreator.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupCreator.ascx.cs
@@ -4,7 +4,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupDetailButtonInject.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupDetailButtonInject.ascx.cs
@@ -4,7 +4,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupDetailLava.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupDetailLava.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupFinderMap.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupFinderMap.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupList.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupManagerAttendance.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupManagerAttendance.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupRecommit.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupRecommit.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupRegistrationModal.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupRegistrationModal.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupRoster.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/GroupRoster.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/LWYARoster.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/LWYARoster.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/PersonalGroupInformationPanel.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/PersonalGroupInformationPanel.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupLava.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupLava.ascx.cs
@@ -4,7 +4,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupList.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupList.ascx.cs
@@ -4,7 +4,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupRequest.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupRequest.ascx.cs
@@ -4,7 +4,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/SmallGroupContent.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/SmallGroupContent.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Imaging/AI/FaceCrop.cs
+++ b/Plugins/org.secc.Imaging/AI/FaceCrop.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Imaging/Components/MicrosoftFaceSettings.cs
+++ b/Plugins/org.secc.Imaging/Components/MicrosoftFaceSettings.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Imaging/Rest/ImagingController.Partial.cs
+++ b/Plugins/org.secc.Imaging/Rest/ImagingController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Imaging/org_secc/Imaging/UpdatePersonImage.ascx.cs
+++ b/Plugins/org.secc.Imaging/org_secc/Imaging/UpdatePersonImage.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Imaging/org_secc/Imaging/UpdatePersonImageFromRegistration.ascx.cs
+++ b/Plugins/org.secc.Imaging/org_secc/Imaging/UpdatePersonImageFromRegistration.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/CloseDeseasedPastoralWorkflows.cs
+++ b/Plugins/org.secc.Jobs/CloseDeseasedPastoralWorkflows.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/CompleteWorkflows.cs
+++ b/Plugins/org.secc.Jobs/CompleteWorkflows.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/DisableCommunicationsForInactivePeople.cs
+++ b/Plugins/org.secc.Jobs/DisableCommunicationsForInactivePeople.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/FrontPorchDeviceRemoval.cs
+++ b/Plugins/org.secc.Jobs/FrontPorchDeviceRemoval.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/Migrations/001_EventRelationshipRoles.cs
+++ b/Plugins/org.secc.Jobs/Migrations/001_EventRelationshipRoles.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.Jobs/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/PushPayDownloadCheckNumbers.cs
+++ b/Plugins/org.secc.Jobs/PushPayDownloadCheckNumbers.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/RemoveDevicesFromPersons.cs
+++ b/Plugins/org.secc.Jobs/RemoveDevicesFromPersons.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/RestoreCommunicationsForReactivatedPeople.cs
+++ b/Plugins/org.secc.Jobs/RestoreCommunicationsForReactivatedPeople.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/SetFirstAttendanceDate.cs
+++ b/Plugins/org.secc.Jobs/SetFirstAttendanceDate.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Jobs/StoreAttendanceFromInteraction.cs
+++ b/Plugins/org.secc.Jobs/StoreAttendanceFromInteraction.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Components/LeagueAppsSettings.cs
+++ b/Plugins/org.secc.LeagueApps/Components/LeagueAppsSettings.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Contracts/Member.cs
+++ b/Plugins/org.secc.LeagueApps/Contracts/Member.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Contracts/Programs.cs
+++ b/Plugins/org.secc.LeagueApps/Contracts/Programs.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Contracts/Registrations.cs
+++ b/Plugins/org.secc.LeagueApps/Contracts/Registrations.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Jobs/ImportData.cs
+++ b/Plugins/org.secc.LeagueApps/Jobs/ImportData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Migrations/001_CreateDefinedTypes.cs
+++ b/Plugins/org.secc.LeagueApps/Migrations/001_CreateDefinedTypes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Migrations/002_CreateDefinedValues.cs
+++ b/Plugins/org.secc.LeagueApps/Migrations/002_CreateDefinedValues.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Migrations/003_CreateGenderType.cs
+++ b/Plugins/org.secc.LeagueApps/Migrations/003_CreateGenderType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Migrations/004_CreateGenderDefinedValues .cs
+++ b/Plugins/org.secc.LeagueApps/Migrations/004_CreateGenderDefinedValues .cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Migrations/005_CreateAttribute.cs
+++ b/Plugins/org.secc.LeagueApps/Migrations/005_CreateAttribute.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Migrations/006_FamilyAttribute.cs
+++ b/Plugins/org.secc.LeagueApps/Migrations/006_FamilyAttribute.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Utilities/Constants.cs
+++ b/Plugins/org.secc.LeagueApps/Utilities/Constants.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LeagueApps/Utilities/LeagueAppsHelper.cs
+++ b/Plugins/org.secc.LeagueApps/Utilities/LeagueAppsHelper.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LessInclude/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.LessInclude/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LessInclude/Themes/StarkLess/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.LessInclude/Themes/StarkLess/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.LessInclude/org_secc/LessInclude/LessInclude.ascx.cs
+++ b/Plugins/org.secc.LessInclude/org_secc/LessInclude/LessInclude.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Mapping/Data/MappingContext.cs
+++ b/Plugins/org.secc.Mapping/Data/MappingContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Mapping/Data/MappingService.cs
+++ b/Plugins/org.secc.Mapping/Data/MappingService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Mapping/Migrations/001_Init.cs
+++ b/Plugins/org.secc.Mapping/Migrations/001_Init.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Mapping/Migrations/002_AddDefinedType.cs
+++ b/Plugins/org.secc.Mapping/Migrations/002_AddDefinedType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Mapping/Model/LocationDistanceStoreService.cs
+++ b/Plugins/org.secc.Mapping/Model/LocationDistanceStoreService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Mapping/Rest/Controllers/DistanceController.Partial.cs
+++ b/Plugins/org.secc.Mapping/Rest/Controllers/DistanceController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Mapping/Utilities/CampusUtilities.cs
+++ b/Plugins/org.secc.Mapping/Utilities/CampusUtilities.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Mapping/Utilities/Constants.cs
+++ b/Plugins/org.secc.Mapping/Utilities/Constants.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Mapping/Utilities/GroupUtilities.cs
+++ b/Plugins/org.secc.Mapping/Utilities/GroupUtilities.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Mapping/Workflow/ClosestCampusAction.cs
+++ b/Plugins/org.secc.Mapping/Workflow/ClosestCampusAction.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.MetricsDigest/MetricsDigest.cs
+++ b/Plugins/org.secc.MetricsDigest/MetricsDigest.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.MetricsDigest/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.MetricsDigest/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Data/MicroframeContext.cs
+++ b/Plugins/org.secc.Microframe/Data/MicroframeContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Data/MicroframeService.cs
+++ b/Plugins/org.secc.Microframe/Data/MicroframeService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Jobs/UpdateSigns.cs
+++ b/Plugins/org.secc.Microframe/Jobs/UpdateSigns.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Migrations/001_Init.cs
+++ b/Plugins/org.secc.Microframe/Migrations/001_Init.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Migrations/003_Indexes.cs
+++ b/Plugins/org.secc.Microframe/Migrations/003_Indexes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Migrations/Configuration.cs
+++ b/Plugins/org.secc.Microframe/Migrations/Configuration.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Model/Sign.cs
+++ b/Plugins/org.secc.Microframe/Model/Sign.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Model/SignCategory.cs
+++ b/Plugins/org.secc.Microframe/Model/SignCategory.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Model/SignCategoryService.cs
+++ b/Plugins/org.secc.Microframe/Model/SignCategoryService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Model/SignService.cs
+++ b/Plugins/org.secc.Microframe/Model/SignService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.Microframe/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Utilities/MicroframeConnection.cs
+++ b/Plugins/org.secc.Microframe/Utilities/MicroframeConnection.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/Utilities/SignUtilities.cs
+++ b/Plugins/org.secc.Microframe/Utilities/SignUtilities.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/org_secc/Microframe/SignCategoryDetail.ascx.cs
+++ b/Plugins/org.secc.Microframe/org_secc/Microframe/SignCategoryDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/org_secc/Microframe/SignCategoryList.ascx.cs
+++ b/Plugins/org.secc.Microframe/org_secc/Microframe/SignCategoryList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/org_secc/Microframe/SignCodeManager.ascx.cs
+++ b/Plugins/org.secc.Microframe/org_secc/Microframe/SignCodeManager.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/org_secc/Microframe/SignDetail.ascx.cs
+++ b/Plugins/org.secc.Microframe/org_secc/Microframe/SignDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Microframe/org_secc/Microframe/SignList.ascx.cs
+++ b/Plugins/org.secc.Microframe/org_secc/Microframe/SignList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/033_Events_CommunityGivesBackCampaignAttribute.cs
+++ b/Plugins/org.secc.Migrations/033_Events_CommunityGivesBackCampaignAttribute.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/Connection/SafetyAndSecurity_ConnectionVerification.cs
+++ b/Plugins/org.secc.Migrations/Connection/SafetyAndSecurity_ConnectionVerification.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/Metric/WorshipAttendanceTrigger.cs
+++ b/Plugins/org.secc.Migrations/Metric/WorshipAttendanceTrigger.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/Pages/FamilyCheckin_PageData.cs
+++ b/Plugins/org.secc.Migrations/Pages/FamilyCheckin_PageData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/Pages/GroupFinderMap_PageData.cs
+++ b/Plugins/org.secc.Migrations/Pages/GroupFinderMap_PageData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/Pages/GroupManager_PageData.cs
+++ b/Plugins/org.secc.Migrations/Pages/GroupManager_PageData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/Pages/MOC_PageData.cs
+++ b/Plugins/org.secc.Migrations/Pages/MOC_PageData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/Pages/Purchasing_PageData.cs
+++ b/Plugins/org.secc.Migrations/Pages/Purchasing_PageData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/Pages/SuperCheckin_PageData.cs
+++ b/Plugins/org.secc.Migrations/Pages/SuperCheckin_PageData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.Migrations/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/WorkflowsTypes/FamilyCheckin_WorkflowData.cs
+++ b/Plugins/org.secc.Migrations/WorkflowsTypes/FamilyCheckin_WorkflowData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/WorkflowsTypes/GroupTreasurerReport_WorkflowData.cs
+++ b/Plugins/org.secc.Migrations/WorkflowsTypes/GroupTreasurerReport_WorkflowData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/WorkflowsTypes/MOC_WorkflowData.cs
+++ b/Plugins/org.secc.Migrations/WorkflowsTypes/MOC_WorkflowData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/WorkflowsTypes/Pastoral_WorkflowData.cs
+++ b/Plugins/org.secc.Migrations/WorkflowsTypes/Pastoral_WorkflowData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/WorkflowsTypes/SportsAndFitness_WorkflowData.cs
+++ b/Plugins/org.secc.Migrations/WorkflowsTypes/SportsAndFitness_WorkflowData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/WorkflowsTypes/SuperCheckin_WorkflowData .cs
+++ b/Plugins/org.secc.Migrations/WorkflowsTypes/SuperCheckin_WorkflowData .cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Migrations/WorkflowsTypes/VolunteerApplication_WorkflowData.cs
+++ b/Plugins/org.secc.Migrations/WorkflowsTypes/VolunteerApplication_WorkflowData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Data/OAuthContext.cs
+++ b/Plugins/org.secc.OAuth/Data/OAuthContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Data/OAuthService.cs
+++ b/Plugins/org.secc.OAuth/Data/OAuthService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Migrations/201605171249414_InitialCreate.cs
+++ b/Plugins/org.secc.OAuth/Migrations/201605171249414_InitialCreate.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Migrations/201605201037000_CreatePlugin.cs
+++ b/Plugins/org.secc.OAuth/Migrations/201605201037000_CreatePlugin.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Migrations/201605271634000_CreateAdminPage.cs
+++ b/Plugins/org.secc.OAuth/Migrations/201605271634000_CreateAdminPage.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Migrations/201605311211000_CreateClientScopes.cs
+++ b/Plugins/org.secc.OAuth/Migrations/201605311211000_CreateClientScopes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Model/Authorization.cs
+++ b/Plugins/org.secc.OAuth/Model/Authorization.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Model/AuthorizationService.cs
+++ b/Plugins/org.secc.OAuth/Model/AuthorizationService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Model/Client.cs
+++ b/Plugins/org.secc.OAuth/Model/Client.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Model/ClientScope.cs
+++ b/Plugins/org.secc.OAuth/Model/ClientScope.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Model/ClientScopeService.cs
+++ b/Plugins/org.secc.OAuth/Model/ClientScopeService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Model/ClientService.cs
+++ b/Plugins/org.secc.OAuth/Model/ClientService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Model/Scope.cs
+++ b/Plugins/org.secc.OAuth/Model/Scope.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Model/ScopeService.cs
+++ b/Plugins/org.secc.OAuth/Model/ScopeService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/OAuthClient.cs
+++ b/Plugins/org.secc.OAuth/OAuthClient.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.OAuth/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Rest/Controllers/OAuthController.Partial.cs
+++ b/Plugins/org.secc.OAuth/Rest/Controllers/OAuthController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Startup.cs
+++ b/Plugins/org.secc.OAuth/Startup.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/Utilities/TokenResponse.cs
+++ b/Plugins/org.secc.OAuth/Utilities/TokenResponse.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/AuthLogout.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/AuthLogout.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/Authorize.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/Authorize.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/Configuration.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/Configuration.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/Login.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/Login.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/Logout.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/Logout.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/OAuthRestorer.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/OAuthRestorer.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/OAuthServiceProvider.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/OAuthServiceProvider.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PDF/Helpers/PDFWorkflowObject.cs
+++ b/Plugins/org.secc.PDF/Helpers/PDFWorkflowObject.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PDF/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.PDF/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PDF/Utilities/Utility.cs
+++ b/Plugins/org.secc.PDF/Utilities/Utility.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PDF/Workflows/InsertXHTMLLava.cs
+++ b/Plugins/org.secc.PDF/Workflows/InsertXHTMLLava.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PDF/Workflows/LavaPDF.cs
+++ b/Plugins/org.secc.PDF/Workflows/LavaPDF.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PDF/Workflows/PDFFormMerge.cs
+++ b/Plugins/org.secc.PDF/Workflows/PDFFormMerge.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PDF/org_secc/PDFExamples/PDFFormExample.ascx.cs
+++ b/Plugins/org.secc.PDF/org_secc/PDFExamples/PDFFormExample.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PDF/org_secc/PDFExamples/PDFLavaExample.ascx.cs
+++ b/Plugins/org.secc.PDF/org_secc/PDFExamples/PDFLavaExample.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PastoralCare/Migrations/001_Pastoral_DefinedTypes.cs
+++ b/Plugins/org.secc.PastoralCare/Migrations/001_Pastoral_DefinedTypes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PastoralCare/Migrations/002_Pastoral_WorkflowData.cs
+++ b/Plugins/org.secc.PastoralCare/Migrations/002_Pastoral_WorkflowData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PastoralCare/Migrations/003_Pastoral_Pages.cs
+++ b/Plugins/org.secc.PastoralCare/Migrations/003_Pastoral_Pages.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PastoralCare/Migrations/004_Fix_Nursing_Homes.cs
+++ b/Plugins/org.secc.PastoralCare/Migrations/004_Fix_Nursing_Homes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PastoralCare/Migrations/005_Pastoral_AddVisitCancel.cs
+++ b/Plugins/org.secc.PastoralCare/Migrations/005_Pastoral_AddVisitCancel.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PastoralCare/Migrations/006_Pastoral_FixLegacyLava.cs
+++ b/Plugins/org.secc.PastoralCare/Migrations/006_Pastoral_FixLegacyLava.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PastoralCare/org_secc/PastoralCare/CommunionList.ascx.cs
+++ b/Plugins/org.secc.PastoralCare/org_secc/PastoralCare/CommunionList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PastoralCare/org_secc/PastoralCare/HomeboundList.ascx.cs
+++ b/Plugins/org.secc.PastoralCare/org_secc/PastoralCare/HomeboundList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PastoralCare/org_secc/PastoralCare/HospitalList.ascx.cs
+++ b/Plugins/org.secc.PastoralCare/org_secc/PastoralCare/HospitalList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PastoralCare/org_secc/PastoralCare/NursingHomeList.ascx.cs
+++ b/Plugins/org.secc.PastoralCare/org_secc/PastoralCare/NursingHomeList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayFlowPro/Gateway.cs
+++ b/Plugins/org.secc.PayFlowPro/Gateway.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayFlowPro/Migrations/001_Create4WeekFrequency.cs
+++ b/Plugins/org.secc.PayFlowPro/Migrations/001_Create4WeekFrequency.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayFlowPro/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.PayFlowPro/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalExpress/Gateway.cs
+++ b/Plugins/org.secc.PayPalExpress/Gateway.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalExpress/Migrations/001_CreateCurrencyType.cs
+++ b/Plugins/org.secc.PayPalExpress/Migrations/001_CreateCurrencyType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalExpress/PayPalPaymentInfo.cs
+++ b/Plugins/org.secc.PayPalExpress/PayPalPaymentInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalExpress/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.PayPalExpress/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalExpress/RedirectGatewayComponent.cs
+++ b/Plugins/org.secc.PayPalExpress/RedirectGatewayComponent.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalExpress/org_secc/PayPalExpress/TransactionEntry.ascx.cs
+++ b/Plugins/org.secc.PayPalExpress/org_secc/PayPalExpress/TransactionEntry.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Data/PayPalReportingContext.cs
+++ b/Plugins/org.secc.PayPalReporting/Data/PayPalReportingContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Data/PayPalReportingService.cs
+++ b/Plugins/org.secc.PayPalReporting/Data/PayPalReportingService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Engine/API.cs
+++ b/Plugins/org.secc.PayPalReporting/Engine/API.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Engine/XMLReport.cs
+++ b/Plugins/org.secc.PayPalReporting/Engine/XMLReport.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/ImportData.cs
+++ b/Plugins/org.secc.PayPalReporting/ImportData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Migrations/001_CreateDb.cs
+++ b/Plugins/org.secc.PayPalReporting/Migrations/001_CreateDb.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Migrations/002_AddFinancialGateway.cs
+++ b/Plugins/org.secc.PayPalReporting/Migrations/002_AddFinancialGateway.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Model/Transaction.cs
+++ b/Plugins/org.secc.PayPalReporting/Model/Transaction.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Model/TransactionService.cs
+++ b/Plugins/org.secc.PayPalReporting/Model/TransactionService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.PayPalReporting/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Services/PayFlowProReportSvc.cs
+++ b/Plugins/org.secc.PayPalReporting/Services/PayFlowProReportSvc.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/Services/PayFlowProRequest.cs
+++ b/Plugins/org.secc.PayPalReporting/Services/PayFlowProRequest.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PayPalReporting/org_secc/PayPalReporting/Transaction.ascx.cs
+++ b/Plugins/org.secc.PayPalReporting/org_secc/PayPalReporting/Transaction.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PersonMatch/Extension.cs
+++ b/Plugins/org.secc.PersonMatch/Extension.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PersonMatch/Migrations/DiminutiveNames_DefinedType.cs
+++ b/Plugins/org.secc.PersonMatch/Migrations/DiminutiveNames_DefinedType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.PersonMatch/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.PersonMatch/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Approval.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Approval.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Attachment.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Attachment.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/CapitalRequest.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/CapitalRequest.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/CapitalRequestBid.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/CapitalRequestBid.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/CreditCard.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/CreditCard.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/DataLayer/ContextHelper.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/DataLayer/ContextHelper.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/DataLayer/Purchasing.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/DataLayer/Purchasing.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/DataLayer/StaffMemberData.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/DataLayer/StaffMemberData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Enums/HistoryType.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Enums/HistoryType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Helpers/Address.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Helpers/Address.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Helpers/Person.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Helpers/Person.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Helpers/Phone.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Helpers/Phone.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/History.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/History.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Note.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Note.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Payment.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Payment.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/PaymentCharge.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/PaymentCharge.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/PaymentMethod.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/PaymentMethod.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/PreferredVendor.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/PreferredVendor.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/PurchaseOrder.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/PurchaseOrder.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/PurchaseOrderItem.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/PurchaseOrderItem.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/PurchasingBase.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/PurchasingBase.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Receipt.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Receipt.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/ReceiptItem.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/ReceiptItem.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Requisition.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Requisition.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/RequisitionItem.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/RequisitionItem.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/App_Code/Vendor.cs
+++ b/Plugins/org.secc.Purchasing/App_Code/Vendor.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.Purchasing/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/Attachments.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/Attachments.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/CapitalRequestDetail.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/CapitalRequestDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/CapitalRequestList.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/CapitalRequestList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/Notes.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/Notes.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/PODetail.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/PODetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/POList.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/POList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/PaymentMethodList.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/PaymentMethodList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/RequisitionDetail.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/RequisitionDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/RequisitionList.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/RequisitionList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/StaffPicker.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/StaffPicker.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/StaffSearch.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/StaffSearch.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/VendorDetail.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/VendorDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/VendorList.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/VendorList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Purchasing/org_secc/Purchasing/VendorSelect.ascx.cs
+++ b/Plugins/org.secc.Purchasing/org_secc/Purchasing/VendorSelect.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RecurringCommunications/Data/RecurringCommunicationsContext.cs
+++ b/Plugins/org.secc.RecurringCommunications/Data/RecurringCommunicationsContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RecurringCommunications/Data/RecurringCommunicationsService.cs
+++ b/Plugins/org.secc.RecurringCommunications/Data/RecurringCommunicationsService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RecurringCommunications/Jobs/SendRecurringCommunications.cs
+++ b/Plugins/org.secc.RecurringCommunications/Jobs/SendRecurringCommunications.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RecurringCommunications/Migrations/201910311455314_Init.cs
+++ b/Plugins/org.secc.RecurringCommunications/Migrations/201910311455314_Init.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RecurringCommunications/Model/RecurringCommunication.cs
+++ b/Plugins/org.secc.RecurringCommunications/Model/RecurringCommunication.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RecurringCommunications/Model/RecurringCommunicationService.cs
+++ b/Plugins/org.secc.RecurringCommunications/Model/RecurringCommunicationService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RecurringCommunications/org_secc/RecurringCommunications/RecurringCommunicationsDetail.ascx.cs
+++ b/Plugins/org.secc.RecurringCommunications/org_secc/RecurringCommunications/RecurringCommunicationsDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RecurringCommunications/org_secc/RecurringCommunications/RecurringCommunicationsList.ascx.cs
+++ b/Plugins/org.secc.RecurringCommunications/org_secc/RecurringCommunications/RecurringCommunicationsList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/Data/ReportingContext.cs
+++ b/Plugins/org.secc.Reporting/Data/ReportingContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/Data/ReportingService.cs
+++ b/Plugins/org.secc.Reporting/Data/ReportingService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/DataFilter/SQLFilter.cs
+++ b/Plugins/org.secc.Reporting/DataFilter/SQLFilter.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/Migrations/001_Init.cs
+++ b/Plugins/org.secc.Reporting/Migrations/001_Init.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/Migrations/DecisionReportView.cs
+++ b/Plugins/org.secc.Reporting/Migrations/DecisionReportView.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/Migrations/WorshipAttendanceHistory.cs
+++ b/Plugins/org.secc.Reporting/Migrations/WorshipAttendanceHistory.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/Model/DataViewSqlFilterStore.cs
+++ b/Plugins/org.secc.Reporting/Model/DataViewSqlFilterStore.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/Model/DataViewSqlFilterStoreService.cs
+++ b/Plugins/org.secc.Reporting/Model/DataViewSqlFilterStoreService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/Transactions/SqlFilterCleanupTransaction.cs
+++ b/Plugins/org.secc.Reporting/Transactions/SqlFilterCleanupTransaction.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/Children/BreakoutGroupAttendance.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/Children/BreakoutGroupAttendance.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/Children/BreakoutGroupAttendanceSummary.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/Children/BreakoutGroupAttendanceSummary.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/Children/BreakoutGroupHandout.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/Children/BreakoutGroupHandout.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/Children/ChildrenAudit.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/Children/ChildrenAudit.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/Children/WithoutBreakoutGroupAttendance.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/Children/WithoutBreakoutGroupAttendance.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/FinancialAidFamilyProfile.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/FinancialAidFamilyProfile.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/HomeGroups/HomeGroupAttendance.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/HomeGroups/HomeGroupAttendance.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/MetricsEntry.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/MetricsEntry.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/Believe.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/Believe.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/BelieveLeader.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/BelieveLeader.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/BibleAndBeach.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/BibleAndBeach.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/FallRetreat.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/FallRetreat.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationDispense.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationInformation.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/MedicationInformation.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/Mix.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/Mix.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/SignatureAudit.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/NextGen/SignatureAudit.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Reporting/org_secc/Reporting/ServiceMetricsEntry.ascx.cs
+++ b/Plugins/org.secc.Reporting/org_secc/Reporting/ServiceMetricsEntry.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Controllers/AccountController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/AccountController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Controllers/FinancialTransactionsExtensionsController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/FinancialTransactionsExtensionsController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Controllers/GroupAppAttendanceController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/GroupAppAttendanceController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Controllers/GroupAppGroupListController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/GroupAppGroupListController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Controllers/GroupAppGroupMembersController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/GroupAppGroupMembersController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Controllers/GroupExtensionsController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/GroupExtensionsController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Controllers/GroupMemberExtensionsController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/GroupMemberExtensionsController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Controllers/PeopleExtensionsController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/PeopleExtensionsController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Controllers/SecurityController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/SecurityController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Handlers/SessionControllerHandler.cs
+++ b/Plugins/org.secc.Rest/Handlers/SessionControllerHandler.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Handlers/SessionRouteHandler.cs
+++ b/Plugins/org.secc.Rest/Handlers/SessionRouteHandler.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Rest/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.Rest/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Models/AttendanceCodes.cs
+++ b/Plugins/org.secc.RoomScanner/Models/AttendanceCodes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Models/AttendanceEntry.cs
+++ b/Plugins/org.secc.RoomScanner/Models/AttendanceEntry.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Models/Attendee.cs
+++ b/Plugins/org.secc.RoomScanner/Models/Attendee.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Models/MultiRequest.cs
+++ b/Plugins/org.secc.RoomScanner/Models/MultiRequest.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Models/Request.cs
+++ b/Plugins/org.secc.RoomScanner/Models/Request.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Models/Response.cs
+++ b/Plugins/org.secc.RoomScanner/Models/Response.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Models/Template.cs
+++ b/Plugins/org.secc.RoomScanner/Models/Template.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.RoomScanner/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Rest/Controllers/RoomScannerController.Partial.cs
+++ b/Plugins/org.secc.RoomScanner/Rest/Controllers/RoomScannerController.Partial.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Utilities/DataHelper.cs
+++ b/Plugins/org.secc.RoomScanner/Utilities/DataHelper.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/Utilities/ValidationHelper.cs
+++ b/Plugins/org.secc.RoomScanner/Utilities/ValidationHelper.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/org_secc/RoomScanner/Configuration.ascx.cs
+++ b/Plugins/org.secc.RoomScanner/org_secc/RoomScanner/Configuration.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.RoomScanner/org_secc/RoomScanner/RoomReport.ascx.cs
+++ b/Plugins/org.secc.RoomScanner/org_secc/RoomScanner/RoomReport.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Data/SafetyAndSecurityContext.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Data/SafetyAndSecurityContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Data/SafetyAndSecurityService.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Data/SafetyAndSecurityService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Model/AlertMessage.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Model/AlertMessage.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Model/AlertNotification.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Model/AlertNotification.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Workflows/DigitalIncidentReportMerge.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Workflows/DigitalIncidentReportMerge.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Workflows/ExternalChurchReferenceMerge.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Workflows/ExternalChurchReferenceMerge.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Workflows/MedicalIncidentReportMerge.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Workflows/MedicalIncidentReportMerge.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Workflows/MinistrySafeRequest.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Workflows/MinistrySafeRequest.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Workflows/MinistrySafeUpdate.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Workflows/MinistrySafeUpdate.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Workflows/MinorVolunteerApplicationMerge.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Workflows/MinorVolunteerApplicationMerge.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Workflows/ReferenceValidation.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Workflows/ReferenceValidation.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Workflows/VolunteerApplicationMerge.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Workflows/VolunteerApplicationMerge.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Workflows/VolunteerApplicationSSN.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Workflows/VolunteerApplicationSSN.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/Workflows/VolunteerApplicationValidation.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/Workflows/VolunteerApplicationValidation.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/org_secc/SafetyAndSecurity/CampusLockDown.ascx.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/org_secc/SafetyAndSecurity/CampusLockDown.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SafetyAndSecurity/org_secc/SafetyAndSecurity/CampusLockDownAlerts.ascx.cs
+++ b/Plugins/org.secc.SafetyAndSecurity/org_secc/SafetyAndSecurity/CampusLockDownAlerts.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Sass/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.Sass/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Sass/Startup.cs
+++ b/Plugins/org.secc.Sass/Startup.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Sass/ThemeExtensions.cs
+++ b/Plugins/org.secc.Sass/ThemeExtensions.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Sass/org_secc/Sass/AdminCss.ascx.cs
+++ b/Plugins/org.secc.Sass/org_secc/Sass/AdminCss.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Sass/org_secc/Sass/SiteDetail.ascx.cs
+++ b/Plugins/org.secc.Sass/org_secc/Sass/SiteDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Sass/org_secc/Sass/ThemeList.ascx.cs
+++ b/Plugins/org.secc.Sass/org_secc/Sass/ThemeList.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Search/Person/Address.cs
+++ b/Plugins/org.secc.Search/Person/Address.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Search/Person/DOB.cs
+++ b/Plugins/org.secc.Search/Person/DOB.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Search/Person/Envelope.cs
+++ b/Plugins/org.secc.Search/Person/Envelope.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Search/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.Search/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Search/org_secc/Crm/BulkSearch.ascx.cs
+++ b/Plugins/org.secc.Search/org_secc/Crm/BulkSearch.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Search/org_secc/Crm/PersonSearch.ascx.cs
+++ b/Plugins/org.secc.Search/org_secc/Crm/PersonSearch.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Security/Themes/my-secc/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.Security/Themes/my-secc/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Security/Themes/my-secc/Layouts/Site.Master.cs
+++ b/Plugins/org.secc.Security/Themes/my-secc/Layouts/Site.Master.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Security/org_secc/Security/AccountDetail.ascx.cs
+++ b/Plugins/org.secc.Security/org_secc/Security/AccountDetail.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Security/org_secc/Security/AccountEdit.ascx.cs
+++ b/Plugins/org.secc.Security/org_secc/Security/AccountEdit.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Security/org_secc/Security/CaptivePortalStaff.ascx.cs
+++ b/Plugins/org.secc.Security/org_secc/Security/CaptivePortalStaff.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Security/org_secc/Security/PINManager.ascx.cs
+++ b/Plugins/org.secc.Security/org_secc/Security/PINManager.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Security/org_secc/Security/UserLoginStatus.ascx.cs
+++ b/Plugins/org.secc.Security/org_secc/Security/UserLoginStatus.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Security/org_secc/Security/WellrightRedirect.ascx.cs
+++ b/Plugins/org.secc.Security/org_secc/Security/WellrightRedirect.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/Contracts/Address.cs
+++ b/Plugins/org.secc.ServiceReef/Contracts/Address.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/Contracts/Event.cs
+++ b/Plugins/org.secc.ServiceReef/Contracts/Event.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/Contracts/Events.cs
+++ b/Plugins/org.secc.ServiceReef/Contracts/Events.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/Contracts/Member.cs
+++ b/Plugins/org.secc.ServiceReef/Contracts/Member.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/Contracts/PageInfo.cs
+++ b/Plugins/org.secc.ServiceReef/Contracts/PageInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/Contracts/Participants.cs
+++ b/Plugins/org.secc.ServiceReef/Contracts/Participants.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/Contracts/Payments.cs
+++ b/Plugins/org.secc.ServiceReef/Contracts/Payments.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/HMACAuthenticator.cs
+++ b/Plugins/org.secc.ServiceReef/HMACAuthenticator.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/ImportData.cs
+++ b/Plugins/org.secc.ServiceReef/ImportData.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/ImportTrips.cs
+++ b/Plugins/org.secc.ServiceReef/ImportTrips.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/Migrations/001_CreateAttributes.cs
+++ b/Plugins/org.secc.ServiceReef/Migrations/001_CreateAttributes.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/Migrations/002_CreateAccountType.cs
+++ b/Plugins/org.secc.ServiceReef/Migrations/002_CreateAccountType.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.ServiceReef/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.ServiceReef/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SignNowWorkflow/Workflows/SignNowCreate.cs
+++ b/Plugins/org.secc.SignNowWorkflow/Workflows/SignNowCreate.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SignNowWorkflow/Workflows/SignNowDownload.cs
+++ b/Plugins/org.secc.SignNowWorkflow/Workflows/SignNowDownload.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SportsAndFitness/Properties/AssemblyInfo.cs
+++ b/Plugins/org.secc.SportsAndFitness/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SportsAndFitness/Themes/SportsAndFitness/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.SportsAndFitness/Themes/SportsAndFitness/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SportsAndFitness/Themes/SportsAndFitness/Layouts/Splash.aspx.cs
+++ b/Plugins/org.secc.SportsAndFitness/Themes/SportsAndFitness/Layouts/Splash.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ActivitiesCheckin.ascx.cs
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ActivitiesCheckin.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/GroupFitness.ascx.cs
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/GroupFitness.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Component/LavaMatchExpression.cs
+++ b/Plugins/org.secc.SystemsMonitor/Component/LavaMatchExpression.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Component/SQLMatchExpression.cs
+++ b/Plugins/org.secc.SystemsMonitor/Component/SQLMatchExpression.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Component/ServerIsUp.cs
+++ b/Plugins/org.secc.SystemsMonitor/Component/ServerIsUp.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Controllers/SystemTestController.cs
+++ b/Plugins/org.secc.SystemsMonitor/Controllers/SystemTestController.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Jobs/RunSystemTests.cs
+++ b/Plugins/org.secc.SystemsMonitor/Jobs/RunSystemTests.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Migrations/001_Init.cs
+++ b/Plugins/org.secc.SystemsMonitor/Migrations/001_Init.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Migrations/002_AlarmNotification.cs
+++ b/Plugins/org.secc.SystemsMonitor/Migrations/002_AlarmNotification.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Migrations/Configuration.cs
+++ b/Plugins/org.secc.SystemsMonitor/Migrations/Configuration.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Model/SystemTest.cs
+++ b/Plugins/org.secc.SystemsMonitor/Model/SystemTest.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Model/SystemTestHistory.cs
+++ b/Plugins/org.secc.SystemsMonitor/Model/SystemTestHistory.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Model/SystemTestHistoryService.cs
+++ b/Plugins/org.secc.SystemsMonitor/Model/SystemTestHistoryService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/Model/SystemTestService.cs
+++ b/Plugins/org.secc.SystemsMonitor/Model/SystemTestService.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/SystemTestComponent.cs
+++ b/Plugins/org.secc.SystemsMonitor/SystemTestComponent.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/SystemTestContainer.cs
+++ b/Plugins/org.secc.SystemsMonitor/SystemTestContainer.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.SystemsMonitor/SystemTestResult.cs
+++ b/Plugins/org.secc.SystemsMonitor/SystemTestResult.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/Easter/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.Themes/Themes/Easter/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/Easter/Layouts/Site.Master.cs
+++ b/Plugins/org.secc.Themes/Themes/Easter/Layouts/Site.Master.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/LWYA/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.Themes/Themes/LWYA/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/Rogers/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.Themes/Themes/Rogers/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/SECC2014/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.Themes/Themes/SECC2014/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/SECC2019/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.Themes/Themes/SECC2019/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/SECC2019Portal/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.Themes/Themes/SECC2019Portal/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/SECC2019_Child_Invert/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.Themes/Themes/SECC2019_Child_Invert/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/SECC2024/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/my-secc/Layouts/Error.aspx.cs
+++ b/Plugins/org.secc.Themes/Themes/my-secc/Layouts/Error.aspx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Themes/Themes/my-secc/Layouts/Site.Master.cs
+++ b/Plugins/org.secc.Themes/Themes/my-secc/Layouts/Site.Master.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Widgities/Data/WidgityContext.cs
+++ b/Plugins/org.secc.Widgities/Data/WidgityContext.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/Communication/SendSms.cs
+++ b/Plugins/org.secc.Workflow/Communication/SendSms.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/Person/GetPersonFromFields.cs
+++ b/Plugins/org.secc.Workflow/Person/GetPersonFromFields.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/Person/PersonAddHistory.cs
+++ b/Plugins/org.secc.Workflow/Person/PersonAddHistory.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/Registrations/AutoApplyDiscountCode.cs
+++ b/Plugins/org.secc.Workflow/Registrations/AutoApplyDiscountCode.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/Registrations/SetAttributeFromRegistrantField.cs
+++ b/Plugins/org.secc.Workflow/Registrations/SetAttributeFromRegistrantField.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/SignatureDocument/StoreSignedDocument.cs
+++ b/Plugins/org.secc.Workflow/SignatureDocument/StoreSignedDocument.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/Twilio/Lookup.cs
+++ b/Plugins/org.secc.Workflow/Twilio/Lookup.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/WorkflowAttributes/AttributeMatrixAddRow.cs
+++ b/Plugins/org.secc.Workflow/WorkflowAttributes/AttributeMatrixAddRow.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/WorkflowAttributes/AttributeMatrixCopy.cs
+++ b/Plugins/org.secc.Workflow/WorkflowAttributes/AttributeMatrixCopy.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/WorkflowAttributes/AttributeMatrixDeleteRow.cs
+++ b/Plugins/org.secc.Workflow/WorkflowAttributes/AttributeMatrixDeleteRow.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/WorkflowAttributes/AttributeMatrixUpdateRow.cs
+++ b/Plugins/org.secc.Workflow/WorkflowAttributes/AttributeMatrixUpdateRow.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/WorkflowAttributes/CopyAttributesFromWorkflow.cs
+++ b/Plugins/org.secc.Workflow/WorkflowAttributes/CopyAttributesFromWorkflow.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/WorkflowControl/ActivateWorkflowWithLava.cs
+++ b/Plugins/org.secc.Workflow/WorkflowControl/ActivateWorkflowWithLava.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/WorkflowControl/ClearAuthCache.cs
+++ b/Plugins/org.secc.Workflow/WorkflowControl/ClearAuthCache.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/WorkflowControl/ProcessWorkflow.cs
+++ b/Plugins/org.secc.Workflow/WorkflowControl/ProcessWorkflow.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/org_secc/Workflow/WorkflowBulkSelect.ascx.cs
+++ b/Plugins/org.secc.Workflow/org_secc/Workflow/WorkflowBulkSelect.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.Workflow/org_secc/Workflow/WorkflowBulkUpdate.ascx.cs
+++ b/Plugins/org.secc.Workflow/org_secc/Workflow/WorkflowBulkUpdate.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.WorkflowLauncher/Migrations/20180630120000_InitialCreate.cs
+++ b/Plugins/org.secc.WorkflowLauncher/Migrations/20180630120000_InitialCreate.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.WorkflowLauncher/WorkflowLauncher.cs
+++ b/Plugins/org.secc.WorkflowLauncher/WorkflowLauncher.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.WorkflowLauncher/org_secc/Workflow/WorkflowBulkSelect.ascx.cs
+++ b/Plugins/org.secc.WorkflowLauncher/org_secc/Workflow/WorkflowBulkSelect.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.WorkflowLauncher/org_secc/Workflow/WorkflowBulkUpdate.ascx.cs
+++ b/Plugins/org.secc.WorkflowLauncher/org_secc/Workflow/WorkflowBulkUpdate.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.WorkflowLauncher/org_secc/Workflow/WorkflowEntityLaunch.ascx.cs
+++ b/Plugins/org.secc.WorkflowLauncher/org_secc/Workflow/WorkflowEntityLaunch.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Plugins/org.secc.WorkflowLauncher/org_secc/Workflow/WorkflowLauncher.ascx.cs
+++ b/Plugins/org.secc.WorkflowLauncher/org_secc/Workflow/WorkflowLauncher.ascx.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/Arena.designer.cs
+++ b/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/Arena.designer.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/HomeBoundWorkflowImport.cs
+++ b/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/HomeBoundWorkflowImport.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/HospitalWorkflowImport.cs
+++ b/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/HospitalWorkflowImport.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/NursingHomeWorkflowImport.cs
+++ b/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/NursingHomeWorkflowImport.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/Program.cs
+++ b/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/Program.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/Properties/AssemblyInfo.cs
+++ b/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/Properties/Settings.Designer.cs
+++ b/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/Properties/Settings.Designer.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/WorkflowImport.cs
+++ b/Tools/MigratePastoralWorkflowData/MigratePastoralWorkflowData/WorkflowImport.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/org.secc.OAuthTestClient/App_Start/RouteConfig.cs
+++ b/Tools/org.secc.OAuthTestClient/App_Start/RouteConfig.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/org.secc.OAuthTestClient/Controllers/HomeController.cs
+++ b/Tools/org.secc.OAuthTestClient/Controllers/HomeController.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/org.secc.OAuthTestClient/Global.asax.cs
+++ b/Tools/org.secc.OAuthTestClient/Global.asax.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/org.secc.OAuthTestClient/Properties/AssemblyInfo.cs
+++ b/Tools/org.secc.OAuthTestClient/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 //
 // Licensed under the  Southeast Christian Church License (the "License");
 // you may not use this file except in compliance with the License.
-// A copy of the License shoud be included with this file.
+// A copy of the License should be included with this file.
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Corrects the license header line "A copy of the License shoud be included with this file." across 580 files.