### PR TITLE
ROCK-8766: Fix broken access control in ManageSportsPINs

### DIFF
--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/ManageSportsPINs.ascx
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/ManageSportsPINs.ascx
@@ -20,7 +20,6 @@
                     opacity: 1
                 }
         </style>
-        <asp:HiddenField ID="hfPersonId" runat="server" />
         <asp:Panel ID="pnlMain" runat="server" Visible="false">
             <asp:Panel ID="pnlAlert" runat="server" CssClass="alert alert-warning" Visible="false">
                 <h3><i class="fa fa-exclamation-triangle"></i> <asp:Literal ID="lAlertTitle" runat="server" /></h3>

--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/ManageSportsPINs.ascx.cs
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/ManageSportsPINs.ascx.cs
@@ -62,8 +62,6 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
             pnlMain.Visible = false;
             var personId = PageParameter( "Person" ).AsIntegerOrNull();
 
-            hfPersonId.Value = personId.ToString();
-
             if(!personId.HasValue)
             {
                 return;

--- a/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/ManageSportsPINs.ascx.cs
+++ b/Plugins/org.secc.SportsAndFitness/org_secc/SportsAndFitness/ControlCenter/ManageSportsPINs.ascx.cs
@@ -7,6 +7,7 @@ using System.Web.UI.WebControls;
 using Rock;
 using Rock.Data;
 using Rock.Model;
+using Rock.Security;
 using Rock.Web.Cache;
 using Rock.Web.UI;
 
@@ -103,15 +104,20 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
 
         private void AddPIN()
         {
-            var personId = hfPersonId.Value.AsInteger();
+            // Derive the target person from the server-side page parameter and
+            // verify the current user is authorized to edit them. The client-posted
+            // hidden field must never be trusted for this (ROCK-8766).
+            var person = GetAuthorizedPerson();
 
-            if(personId <= 0)
+            if(person == null)
             {
                 return;
             }
 
+            var personId = person.Id;
+
             var pin = tbPIN.Text.Trim();
-            if(pin.IsNullOrWhiteSpace() || pin.Length <= minPinLength)
+            if(pin.IsNullOrWhiteSpace() || pin.Length < minPinLength)
             {
                 ShowAlert( "PIN Not Valid", $"PIN must be at least {minPinLength} long." );
                 return;
@@ -167,8 +173,17 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
 
         private void RemovePIN(int loginId)
         {
+            // Same access-control requirement as AddPIN: resolve the person from the
+            // server-side page parameter and confirm the current user can edit them,
+            // rather than trusting the client-posted hidden field (ROCK-8766).
+            var person = GetAuthorizedPerson();
 
-            var personId = hfPersonId.Value.AsInteger();
+            if(person == null)
+            {
+                return;
+            }
+
+            var personId = person.Id;
 
             using (var rockContext = new RockContext())
             {
@@ -178,9 +193,48 @@ namespace RockWeb.Plugins.org_secc.SportsAndFitness.ControlCenter
                     .Where( l => l.PersonId == personId )
                     .SingleOrDefault();
 
+                if(login == null)
+                {
+                    return;
+                }
+
                 userLoginService.Delete( login );
                 rockContext.SaveChanges();
-                    
+
+            }
+        }
+
+        /// <summary>
+        /// Resolves the target person from the server-side "Person" page parameter and
+        /// verifies the current user is authorized to edit that person before any PIN
+        /// login is created or removed. Returns null (showing an alert when appropriate)
+        /// if no person is specified or the current user is not authorized.
+        /// </summary>
+        private Person GetAuthorizedPerson()
+        {
+            var personId = PageParameter( "Person" ).AsIntegerOrNull();
+
+            if(!personId.HasValue)
+            {
+                return null;
+            }
+
+            using (var rockContext = new RockContext())
+            {
+                var person = new PersonService( rockContext ).Get( personId.Value );
+
+                if(person == null)
+                {
+                    return null;
+                }
+
+                if(!person.IsAuthorized( Authorization.EDIT, CurrentPerson ))
+                {
+                    ShowAlert( "Not Authorized", "You are not authorized to manage PINs for this person." );
+                    return null;
+                }
+
+                return person;
             }
         }
 


### PR DESCRIPTION
AddPIN and RemovePIN derived the target person from hfPersonId, a client-controlled hidden field, allowing any user who reached the block to attach a confirmed PIN UserLogin to any person (e.g. a staff account) and then authenticate as them. Resolve the person server-side from the PageParameter("Person") instead, and require the current user to be authorized to EDIT that person before adding or removing a PIN. Also fix an off-by-one that rejected valid 4-character PINs (pin.Length <= minPinLength -> <).