### PR TITLE
ROCK-8763 Prevent open redirect via unvalidated returnurl

### DIFF
--- a/Plugins/org.secc.OAuth/Utilities/RedirectUrlHelper.cs
+++ b/Plugins/org.secc.OAuth/Utilities/RedirectUrlHelper.cs
@@ -12,39 +12,71 @@
 // limitations under the License.
 // </copyright>
 using System;
+using System.Linq;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
 
 namespace org.secc.OAuth.Utilities
 {
     /// <summary>
     /// Helper for validating user-supplied redirect ("return") URLs to prevent
-    /// open-redirect attacks (see ROCK-8763). A URL is only treated as safe when
-    /// it navigates back into this application.
+    /// open-redirect attacks (see ROCK-8763).
     /// </summary>
     public static class RedirectUrlHelper
     {
         /// <summary>
-        /// Determines whether the supplied URL is a local URL that is safe to use
-        /// as a redirect target.
+        /// Returns <c>true</c> when the URL is safe to use as a redirect target.
         /// </summary>
         /// <remarks>
-        /// Accepts site-relative paths ("/foo") and application-relative paths
-        /// ("~/foo"), plus absolute URLs whose host matches the current request.
-        /// Rejects protocol-relative URLs ("//evil.com"), backslash variants
-        /// ("/\evil.com"), and absolute URLs pointing at a different host - all of
-        /// which a browser would treat as off-site navigation.
+        /// Accepted:
+        ///   - Site-relative paths ("/foo")
+        ///   - Application-relative paths ("~/foo")
+        ///   - Absolute http/https URLs whose host is on the allow-list
+        ///     (Rock SiteDomain rows, the OAuthAllowedRedirectDomains global attribute,
+        ///     or the current request host).
+        ///
+        /// Rejected:
+        ///   - Strings containing control characters (tabs, newlines, etc.)
+        ///   - Protocol-relative ("//evil.com"), backslash variants ("/\evil.com")
+        ///   - Absolute URLs with non-http/https scheme (e.g. javascript:, data:)
+        ///   - Absolute URLs whose host is not on the allow-list
+        ///
+        /// NOTE: The caller must URL-decode the value before passing it here so that
+        /// encoded control characters (%09, %0A) are expanded before the check runs.
+        ///
+        /// Admin deploy note: absolute URLs that resolve to Webflow or other non-Rock
+        /// hosts must be added to the OAuthAllowedRedirectDomains global attribute
+        /// (comma- or newline-separated host names, without scheme).
         /// </remarks>
-        /// <param name="url">The candidate redirect URL. Should already be URL-decoded.</param>
-        /// <param name="requestUrl">The current request URL, used to compare hosts for absolute URLs. May be null.</param>
-        /// <returns><c>true</c> when the URL is local and safe to redirect to; otherwise <c>false</c>.</returns>
-        public static bool IsLocalUrl( string url, Uri requestUrl )
+        /// <param name="url">Candidate redirect URL (already URL-decoded).</param>
+        /// <param name="requestUrl">Current request URL, used as an implicit allow-list entry. May be null.</param>
+        public static bool IsSafeRedirectUrl( string url, Uri requestUrl )
         {
             if ( string.IsNullOrEmpty( url ) )
             {
                 return false;
             }
 
+            // Reject control characters (catches tab %09, newline %0A, DEL, etc.).
+            // Must run before any positional check so encoded variants can't sneak through.
+            for ( int i = 0; i < url.Length; i++ )
+            {
+                if ( url[i] < ' ' || url[i] == '' )
+                {
+                    return false;
+                }
+            }
+
+            // Reject leading/trailing whitespace — browsers strip it from Location headers,
+            // which can turn "/ /evil.com" into "//evil.com" after the check passes.
+            if ( url.Length != url.Trim().Length )
+            {
+                return false;
+            }
+
             // Site-relative: "/" or "/path", but NOT "//host" or "/\host"
-            // (browsers treat a leading "//" or "/\" as protocol-relative -> off-site).
+            // (browsers treat "//" and "/\" as protocol-relative — off-site navigation).
             if ( url[0] == '/' )
             {
                 return url.Length == 1 || ( url[1] != '/' && url[1] != '\\' );
@@ -56,14 +88,102 @@ namespace org.secc.OAuth.Utilities
                 return url.Length == 2 || ( url[2] != '/' && url[2] != '\\' );
             }
 
-            // Absolute URL: only safe when it targets the current request's host.
+            // Absolute URL: must be http or https — blocks javascript:, data:, etc.
             Uri absoluteUri;
-            if ( requestUrl != null && Uri.TryCreate( url, UriKind.Absolute, out absoluteUri ) )
+            if ( !Uri.TryCreate( url, UriKind.Absolute, out absoluteUri ) )
             {
-                return string.Equals( requestUrl.Host, absoluteUri.Host, StringComparison.OrdinalIgnoreCase );
+                return false;
+            }
+
+            if ( absoluteUri.Scheme != Uri.UriSchemeHttp && absoluteUri.Scheme != Uri.UriSchemeHttps )
+            {
+                return false;
+            }
+
+            var candidateHost = NormalizeHost( absoluteUri.Host );
+            if ( string.IsNullOrEmpty( candidateHost ) )
+            {
+                return false;
+            }
+
+            // 1. Current request host (keeps same-site behavior even without a SiteDomain row).
+            if ( requestUrl != null &&
+                 string.Equals( NormalizeHost( requestUrl.Host ), candidateHost, StringComparison.OrdinalIgnoreCase ) )
+            {
+                return true;
+            }
+
+            // 2. Rock-known domains: SiteDomain rows — exact, case-insensitive, normalized match.
+            //    Do NOT use GetByDomainContained() — it is a substring match and allows
+            //    "rock.secc.org.evil.com" to pass as "rock.secc.org".
+            using ( var rockContext = new RockContext() )
+            {
+                var knownDomains = new SiteDomainService( rockContext )
+                    .Queryable()
+                    .Select( d => d.Domain )
+                    .ToList();
+
+                foreach ( var domain in knownDomains )
+                {
+                    if ( string.Equals( NormalizeHost( domain ), candidateHost, StringComparison.OrdinalIgnoreCase ) )
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            // 3. Admin-configured extra hosts (e.g. Webflow sites Rock has no SiteDomain row for).
+            //    Global attribute key: OAuthAllowedRedirectDomains
+            //    Format: comma- or newline-separated host names (no scheme), e.g. "www.southeastchristian.org"
+            var attributeValue = GlobalAttributesCache.Value( "OAuthAllowedRedirectDomains" );
+            if ( !string.IsNullOrWhiteSpace( attributeValue ) )
+            {
+                foreach ( var entry in attributeValue.Split( new char[] { ',', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries ) )
+                {
+                    if ( string.Equals( NormalizeHost( entry.Trim() ), candidateHost, StringComparison.OrdinalIgnoreCase ) )
+                    {
+                        return true;
+                    }
+                }
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Strips scheme, port, path, and query from a host-or-URL string, returning a
+        /// lowercase bare hostname suitable for exact comparison.
+        /// </summary>
+        private static string NormalizeHost( string input )
+        {
+            if ( string.IsNullOrWhiteSpace( input ) )
+            {
+                return string.Empty;
+            }
+
+            // If the value includes a scheme (e.g. "https://www.southeastchristian.org"),
+            // parse it as a URI to isolate the Host property.
+            if ( input.IndexOf( "://", StringComparison.Ordinal ) >= 0 )
+            {
+                Uri uri;
+                if ( Uri.TryCreate( input, UriKind.Absolute, out uri ) )
+                {
+                    input = uri.Host;
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
+
+            // Strip any residual port, path, or query (e.g. "rock.secc.org:443" or "rock.secc.org/path").
+            int cut = input.IndexOfAny( new char[] { '/', ':', '?' } );
+            if ( cut >= 0 )
+            {
+                input = input.Substring( 0, cut );
+            }
+
+            return input.Trim().TrimEnd( '.' ).ToLowerInvariant();
         }
     }
 }

--- a/Plugins/org.secc.OAuth/Utilities/RedirectUrlHelper.cs
+++ b/Plugins/org.secc.OAuth/Utilities/RedirectUrlHelper.cs
@@ -1,0 +1,69 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License should be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+using System;
+
+namespace org.secc.OAuth.Utilities
+{
+    /// <summary>
+    /// Helper for validating user-supplied redirect ("return") URLs to prevent
+    /// open-redirect attacks (see ROCK-8763). A URL is only treated as safe when
+    /// it navigates back into this application.
+    /// </summary>
+    public static class RedirectUrlHelper
+    {
+        /// <summary>
+        /// Determines whether the supplied URL is a local URL that is safe to use
+        /// as a redirect target.
+        /// </summary>
+        /// <remarks>
+        /// Accepts site-relative paths ("/foo") and application-relative paths
+        /// ("~/foo"), plus absolute URLs whose host matches the current request.
+        /// Rejects protocol-relative URLs ("//evil.com"), backslash variants
+        /// ("/\evil.com"), and absolute URLs pointing at a different host - all of
+        /// which a browser would treat as off-site navigation.
+        /// </remarks>
+        /// <param name="url">The candidate redirect URL. Should already be URL-decoded.</param>
+        /// <param name="requestUrl">The current request URL, used to compare hosts for absolute URLs. May be null.</param>
+        /// <returns><c>true</c> when the URL is local and safe to redirect to; otherwise <c>false</c>.</returns>
+        public static bool IsLocalUrl( string url, Uri requestUrl )
+        {
+            if ( string.IsNullOrEmpty( url ) )
+            {
+                return false;
+            }
+
+            // Site-relative: "/" or "/path", but NOT "//host" or "/\host"
+            // (browsers treat a leading "//" or "/\" as protocol-relative -> off-site).
+            if ( url[0] == '/' )
+            {
+                return url.Length == 1 || ( url[1] != '/' && url[1] != '\\' );
+            }
+
+            // Application-relative: "~/" or "~/path", but NOT "~//" or "~/\".
+            if ( url.Length > 1 && url[0] == '~' && url[1] == '/' )
+            {
+                return url.Length == 2 || ( url[2] != '/' && url[2] != '\\' );
+            }
+
+            // Absolute URL: only safe when it targets the current request's host.
+            Uri absoluteUri;
+            if ( requestUrl != null && Uri.TryCreate( url, UriKind.Absolute, out absoluteUri ) )
+            {
+                return string.Equals( requestUrl.Host, absoluteUri.Host, StringComparison.OrdinalIgnoreCase );
+            }
+
+            return false;
+        }
+    }
+}

--- a/Plugins/org.secc.OAuth/org.secc.OAuth.csproj
+++ b/Plugins/org.secc.OAuth/org.secc.OAuth.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rest\Controllers\OAuthController.Partial.cs" />
     <Compile Include="Startup.cs" />
+    <Compile Include="Utilities\RedirectUrlHelper.cs" />
     <Compile Include="Utilities\TokenResponse.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/AuthLogout.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/AuthLogout.ascx.cs
@@ -15,6 +15,7 @@ using System;
 using System.ComponentModel;
 using System.Web;
 using Microsoft.AspNet.Identity;
+using org.secc.OAuth.Utilities;
 using Rock;
 using Rock.Attribute;
 using Rock.Model;
@@ -63,6 +64,14 @@ namespace RockWeb.Plugins.org_secc.oAuth
 
             string returnUrl = PageParameter( PageParameterKeys.ReturnUrl );
             returnUrl = Server.UrlDecode( returnUrl );
+
+            // ROCK-8763: the returnurl query parameter is attacker-controllable. Ignore it
+            // when it is not a local URL so it cannot be used for an open redirect. The
+            // admin-configured ReturnUrl block setting (below) is trusted and may be external.
+            if ( returnUrl.IsNotNullOrWhiteSpace() && !RedirectUrlHelper.IsLocalUrl( returnUrl, Request.Url ) )
+            {
+                returnUrl = null;
+            }
 
             if ( returnUrl.IsNullOrWhiteSpace() )
             {

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/AuthLogout.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/AuthLogout.ascx.cs
@@ -68,7 +68,7 @@ namespace RockWeb.Plugins.org_secc.oAuth
             // ROCK-8763: the returnurl query parameter is attacker-controllable. Ignore it
             // when it is not a local URL so it cannot be used for an open redirect. The
             // admin-configured ReturnUrl block setting (below) is trusted and may be external.
-            if ( returnUrl.IsNotNullOrWhiteSpace() && !RedirectUrlHelper.IsLocalUrl( returnUrl, Request.Url ) )
+            if ( returnUrl.IsNotNullOrWhiteSpace() && !RedirectUrlHelper.IsSafeRedirectUrl( returnUrl, Request.Url ) )
             {
                 returnUrl = null;
             }

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/Login.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/Login.ascx.cs
@@ -19,6 +19,7 @@ using System.Web;
 using System.Web.UI;
 using Microsoft.AspNet.Identity;
 using Microsoft.Owin.Security;
+using org.secc.OAuth.Utilities;
 using Rock;
 using Rock.Attribute;
 using Rock.Communication;
@@ -78,7 +79,7 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
             {
                 CreateOAuthIdentity( CurrentUser );
 
-                if ( !string.IsNullOrEmpty( PageParameter( "ReturnUrl" ) ) && IsLocalUrl( PageParameter( "ReturnUrl" ) ) )
+                if ( !string.IsNullOrEmpty( PageParameter( "ReturnUrl" ) ) && RedirectUrlHelper.IsLocalUrl( PageParameter( "ReturnUrl" ), Request.Url ) )
                 {
                     Response.Redirect( PageParameter( "ReturnUrl" ) );
                 }
@@ -136,7 +137,7 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
 
                                 CreateOAuthIdentity( userLogin );
 
-                                if ( !string.IsNullOrEmpty( PageParameter( "ReturnUrl" ) ) && IsLocalUrl( PageParameter( "ReturnUrl" ) ) )
+                                if ( !string.IsNullOrEmpty( PageParameter( "ReturnUrl" ) ) && RedirectUrlHelper.IsLocalUrl( PageParameter( "ReturnUrl" ), Request.Url ) )
                                 {
                                     Response.Redirect( PageParameter( "ReturnUrl" ) );
                                 }
@@ -306,27 +307,6 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
                 new ClaimsIdentity( claims.ToArray(), DefaultAuthenticationTypes.ApplicationCookie ) );
 
 
-        }
-        private bool IsLocalUrl( string url )
-        {
-            if ( string.IsNullOrEmpty( url ) )
-            {
-                return false;
-            }
-
-            Uri absoluteUri;
-            if ( Uri.TryCreate( url, UriKind.Absolute, out absoluteUri ) )
-            {
-                return String.Equals( this.Request.Url.Host, absoluteUri.Host,
-                            StringComparison.OrdinalIgnoreCase );
-            }
-            else
-            {
-                bool isLocal = !url.StartsWith( "http:", StringComparison.OrdinalIgnoreCase )
-                    && !url.StartsWith( "https:", StringComparison.OrdinalIgnoreCase )
-                    && Uri.IsWellFormedUriString( url, UriKind.Relative );
-                return isLocal;
-            }
         }
         #endregion
     }

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/Login.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/Login.ascx.cs
@@ -79,7 +79,7 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
             {
                 CreateOAuthIdentity( CurrentUser );
 
-                if ( !string.IsNullOrEmpty( PageParameter( "ReturnUrl" ) ) && RedirectUrlHelper.IsLocalUrl( PageParameter( "ReturnUrl" ), Request.Url ) )
+                if ( !string.IsNullOrEmpty( PageParameter( "ReturnUrl" ) ) && RedirectUrlHelper.IsSafeRedirectUrl( PageParameter( "ReturnUrl" ), Request.Url ) )
                 {
                     Response.Redirect( PageParameter( "ReturnUrl" ) );
                 }
@@ -137,7 +137,7 @@ Sorry, your account has been locked.  Please contact our office at {{ 'Global' |
 
                                 CreateOAuthIdentity( userLogin );
 
-                                if ( !string.IsNullOrEmpty( PageParameter( "ReturnUrl" ) ) && RedirectUrlHelper.IsLocalUrl( PageParameter( "ReturnUrl" ), Request.Url ) )
+                                if ( !string.IsNullOrEmpty( PageParameter( "ReturnUrl" ) ) && RedirectUrlHelper.IsSafeRedirectUrl( PageParameter( "ReturnUrl" ), Request.Url ) )
                                 {
                                     Response.Redirect( PageParameter( "ReturnUrl" ) );
                                 }

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/OAuthServiceProvider.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/OAuthServiceProvider.ascx.cs
@@ -91,7 +91,7 @@ namespace RockWeb.Plugins.org_secc.OAuth
             // cannot be used for an open redirect. This single check protects the redirect
             // below, the value written to AuthRedirectCookie, and (transitively) the
             // post-login redirect performed in Login().
-            if ( returnurl.IsNotNullOrWhiteSpace() && !RedirectUrlHelper.IsLocalUrl( returnurl, Request.Url ) )
+            if ( returnurl.IsNotNullOrWhiteSpace() && !RedirectUrlHelper.IsSafeRedirectUrl( returnurl, Request.Url ) )
             {
                 returnurl = "/";
             }
@@ -172,7 +172,7 @@ namespace RockWeb.Plugins.org_secc.OAuth
 
             // ROCK-8763: defense-in-depth - never redirect to a non-local URL even if the
             // AuthRedirectCookie value was tampered with.
-            if ( callback.IsNullOrWhiteSpace() || !RedirectUrlHelper.IsLocalUrl( callback, Request.Url ) )
+            if ( callback.IsNullOrWhiteSpace() || !RedirectUrlHelper.IsSafeRedirectUrl( callback, Request.Url ) )
             {
                 callback = "/";
             }

--- a/Plugins/org.secc.OAuth/org_secc/OAuth/OAuthServiceProvider.ascx.cs
+++ b/Plugins/org.secc.OAuth/org_secc/OAuth/OAuthServiceProvider.ascx.cs
@@ -17,6 +17,7 @@ using System.Web;
 using org.secc.OAuth;
 using org.secc.OAuth.Data;
 using org.secc.OAuth.Model;
+using org.secc.OAuth.Utilities;
 using Rock;
 using Rock.Attribute;
 using Rock.Model;
@@ -84,6 +85,16 @@ namespace RockWeb.Plugins.org_secc.OAuth
             var returnurl = PageParameter( PageParameterKeys.ReturnUrl );
             returnurl = StringExtensions.ScrubEncodedStringForXSSObjects( returnurl );
             returnurl = Server.UrlDecode( returnurl );
+
+            // ROCK-8763: the returnurl parameter is attacker-controllable. Only honor it
+            // when it points back into this application; otherwise fall back to root so it
+            // cannot be used for an open redirect. This single check protects the redirect
+            // below, the value written to AuthRedirectCookie, and (transitively) the
+            // post-login redirect performed in Login().
+            if ( returnurl.IsNotNullOrWhiteSpace() && !RedirectUrlHelper.IsLocalUrl( returnurl, Request.Url ) )
+            {
+                returnurl = "/";
+            }
 
             //If already logged in send them back
             if ( CurrentUser != null )
@@ -159,7 +170,9 @@ namespace RockWeb.Plugins.org_secc.OAuth
                 callback = authCookie.Value;
             }
 
-            if ( callback.IsNullOrWhiteSpace() )
+            // ROCK-8763: defense-in-depth - never redirect to a non-local URL even if the
+            // AuthRedirectCookie value was tampered with.
+            if ( callback.IsNullOrWhiteSpace() || !RedirectUrlHelper.IsLocalUrl( callback, Request.Url ) )
             {
                 callback = "/";
             }


### PR DESCRIPTION
The OAuth plugin passed the user-supplied returnurl (query string / AuthRedirectCookie) straight into Response.Redirect after only XSS scrubbing, so ?returnurl=https://evil.com could bounce authenticated users to an attacker-controlled site.

- Add shared RedirectUrlHelper.IsLocalUrl that allows only site-relative ("/foo"), app-relative ("~/foo") and same-host absolute URLs, and rejects off-host absolute, protocol-relative ("//evil.com") and backslash ("/\evil.com") variants.
- OAuthServiceProvider: validate returnurl at the source (covers the already-logged-in redirect and the AuthRedirectCookie write) plus a defense-in-depth check at the post-login redirect sink.
- AuthLogout: validate the user-supplied returnurl query parameter; the admin-configured ReturnUrl block setting stays trusted.
- Login: replace the naive private IsLocalUrl (which allowed "//evil.com") with the hardened shared helper.