### PR TITLE
ROCK-8762: fix brute-forceable account confirmation code

### DIFF
--- a/Plugins/org.secc.Migrations/034_UserLogin_ConfirmationCodeAttributes.cs
+++ b/Plugins/org.secc.Migrations/034_UserLogin_ConfirmationCodeAttributes.cs
@@ -1,0 +1,68 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License shoud be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using Rock.Plugin;
+
+namespace org.secc.Migrations
+{
+    /// <summary>
+    /// ROCK-8762: backing storage for the short account-confirmation code that
+    /// org.secc.Rest AccountController emails to mobile users.
+    ///
+    /// Only the hash of the outstanding code and the time it was issued are stored. The code
+    /// itself is never persisted, and both values are cleared once the code is used or expires.
+    /// Adding these attributes is metadata only -- no existing rows are read or rewritten.
+    ///
+    /// Attribute keys and the hash attribute's Guid are duplicated as constants in
+    /// AccountController.Partial.cs; keep the two in sync.
+    /// </summary>
+    [MigrationNumber( 34, "1.12.9" )]
+    public partial class UserLogin_ConfirmationCodeAttributes : Migration
+    {
+        public override void Up()
+        {
+            // Entity: Rock.Model.UserLogin Attribute: Confirmation Code Hash
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.UserLogin",
+                Rock.SystemGuid.FieldType.TEXT,
+                "",
+                "",
+                "Confirmation Code Hash",
+                "Confirmation Code Hash",
+                "SHA-256 hash of the account confirmation code most recently issued for this login. Written and cleared by the org.secc.Rest account API; not intended to be edited by hand.",
+                0,
+                "",
+                "7B3F9A42-5C81-4E6D-9F2A-1D8C4B60E3A7",
+                "SeccConfirmationCodeHash" );
+
+            // Entity: Rock.Model.UserLogin Attribute: Confirmation Code Issued
+            RockMigrationHelper.AddOrUpdateEntityAttribute( "Rock.Model.UserLogin",
+                Rock.SystemGuid.FieldType.TEXT,
+                "",
+                "",
+                "Confirmation Code Issued",
+                "Confirmation Code Issued",
+                "Tick count for the date and time the outstanding account confirmation code was issued. Used to expire the code.",
+                1,
+                "",
+                "C4E81D57-2A93-4F16-B8D5-6E70F9A24C1B",
+                "SeccConfirmationCodeIssued" );
+        }
+
+        public override void Down()
+        {
+            RockMigrationHelper.DeleteAttribute( "7B3F9A42-5C81-4E6D-9F2A-1D8C4B60E3A7" ); // Rock.Model.UserLogin: Confirmation Code Hash
+            RockMigrationHelper.DeleteAttribute( "C4E81D57-2A93-4F16-B8D5-6E70F9A24C1B" ); // Rock.Model.UserLogin: Confirmation Code Issued
+        }
+    }
+}

--- a/Plugins/org.secc.Migrations/org.secc.Migrations.csproj
+++ b/Plugins/org.secc.Migrations/org.secc.Migrations.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="033_Events_CommunityGivesBackCampaignAttribute.cs" />
+    <Compile Include="034_UserLogin_ConfirmationCodeAttributes.cs" />
     <Compile Include="Connection\SafetyAndSecurity_ConnectionVerification.cs" />
     <Compile Include="Metric\WorshipAttendanceTrigger.cs" />
     <Compile Include="Finance_MoveContributionSummaryStoredProcedure.cs" />

--- a/Plugins/org.secc.Rest/Controllers/AccountController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/AccountController.Partial.cs
@@ -89,36 +89,28 @@ namespace org.secc.Rest.Controllers
                 // Try to match the person
                 var matchPerson = personService.GetByMatch( account.FirstName, account.LastName, account.Birthdate, account.EmailAddress, account.MobileNumber, null, null );
 
-                bool confirmed = false;
+                // Never auto-confirm a login bound to an existing person from an OAuth
+                // client-credentials request. Any login created below is unconfirmed and
+                // must complete the emailed/OOB confirmation step. A matched existing
+                // person with no username is left untouched (no login, no email).
+                bool matched = false;
                 Person person = new Person();
                 if ( matchPerson != null && matchPerson.Count() == 1 )
                 {
                     var mobilePhone = matchPerson.First().PhoneNumbers.Where( pn => pn.NumberTypeValueId == DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_MOBILE.AsGuid() ).Id ).FirstOrDefault();
                     // The emails MUST match for security
-                    if ( matchPerson.First().Email == account.EmailAddress && ( mobilePhone == null || mobilePhone.Number.Right( 10 ) == account.MobileNumber.Right( 10 ) ) )
+                    if ( string.Equals( matchPerson.First().Email, account.EmailAddress, StringComparison.OrdinalIgnoreCase ) && ( mobilePhone == null || mobilePhone.Number.Right( 10 ) == account.MobileNumber.Right( 10 ) ) )
                     {
+                        // Adopt the existing person as-is. Never write requester-supplied fields
+                        // (phone, gender, etc.) onto an existing record — those writes happen only
+                        // when populating a genuinely new person below.
                         person = matchPerson.First();
-
-                        // If they don't have a current mobile phone, go ahead and set it
-                        if ( mobilePhone == null )
-                        {
-                            string cleanNumber = PhoneNumber.CleanNumber( account.MobileNumber );
-                            var phoneNumber = new PhoneNumber { NumberTypeValueId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_MOBILE.AsGuid() ).Id };
-                            person.PhoneNumbers.Add( phoneNumber );
-                            phoneNumber.CountryCode = cleanNumber.Length > 10 ? cleanNumber.Left( 10 - cleanNumber.Length ) : PhoneNumber.DefaultCountryCode();
-                            phoneNumber.Number = cleanNumber.Right( 10 );
-                            phoneNumber.IsMessagingEnabled = true;
-                        }
-
-                        // Make sure the gender matches
-                        person.Gender = account.Gender;
-
-                        confirmed = true;
+                        matched = true;
                     }
                 }
 
                 // If we don't have a match, create a new web prospect
-                if ( !confirmed )
+                if ( !matched )
                 {
                     DefinedValueCache dvcConnectionStatus = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_CONNECTION_STATUS_PROSPECT.AsGuid() );
                     DefinedValueCache dvcRecordStatus = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_RECORD_STATUS_PENDING.AsGuid() );
@@ -169,7 +161,7 @@ namespace org.secc.Rest.Controllers
 
                 if ( !string.IsNullOrWhiteSpace( account.Username ) && UserLoginService.IsPasswordValid( account.Password ) )
                 {
-                    // Create the user login (only require confirmation if we didn't match the person)
+                    // Create the user login. Always unconfirmed: every account must confirm below.
                     userLogin = UserLoginService.Create(
                         rockContext,
                         person,
@@ -177,9 +169,9 @@ namespace org.secc.Rest.Controllers
                         EntityTypeCache.Get( Rock.SystemGuid.EntityType.AUTHENTICATION_DATABASE.AsGuid() ).Id,
                         account.Username,
                         account.Password,
-                        confirmed );
+                        false );
                 }
-                else if ( !string.IsNullOrWhiteSpace( account.EmailAddress ) && !confirmed )
+                else if ( !string.IsNullOrWhiteSpace( account.EmailAddress ) && !matched )
                 {
                     userLogin = userLoginService.Queryable()
                         .Where( u => u.UserName == ( "SMS_" + person.Id.ToString() ) )
@@ -219,6 +211,7 @@ namespace org.secc.Rest.Controllers
                     message.SetRecipients( recipients );
                     message.AppRoot = GlobalAttributesCache.Get().GetValue( "PublicApplicationRoot" ).EnsureTrailingForwardslash();
                     message.CreateCommunicationRecord = false;
+                    // KNOWN LIMITATION (ROCK-8761): the login is already committed above, so if this send throws the login is orphaned and a retry hits the up-front "username already exists" check, blocking signup. Ordering fix tracked separately; not addressed here.
                     message.Send();
                 }
 
@@ -226,7 +219,7 @@ namespace org.secc.Rest.Controllers
 
                 return ControllerContext.Request.CreateResponse( HttpStatusCode.OK, new StandardResponse()
                 {
-                    Message = string.Format( "Account has been created.{0}", confirmed ? "" : " An email has been sent to confirm the email address." ),
+                    Message = string.Format( "Account has been created.{0}", userLogin != null ? " An email has been sent to confirm the email address." : "" ),
                     Result = StandardResponse.ResultCode.Success
                 }
                 );

--- a/Plugins/org.secc.Rest/Controllers/AccountController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/AccountController.Partial.cs
@@ -15,11 +15,12 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Numerics;
 using System.Security.Cryptography;
+using System.Text;
 using System.Web;
 using System.Web.Http;
 using System.Web.Routing;
@@ -43,16 +44,159 @@ namespace org.secc.Rest.Controllers
     {
         const int MINIMUM_AGE = 13;
 
+        #region Account Confirmation Code (ROCK-8762)
+
+        /// <summary>
+        /// Guid of the UserLogin entity attribute holding the hash of the outstanding mobile
+        /// confirmation code. Created by org.secc.Migrations 034_UserLogin_ConfirmationCodeAttributes.
+        /// </summary>
+        private const string CONFIRMATION_CODE_HASH_ATTRIBUTE_GUID = "7B3F9A42-5C81-4E6D-9F2A-1D8C4B60E3A7";
+
+        /// <summary>
+        /// Guid of the UserLogin entity attribute holding the time the outstanding code was issued.
+        /// </summary>
+        private const string CONFIRMATION_CODE_ISSUED_ATTRIBUTE_GUID = "C4E81D57-2A93-4F16-B8D5-6E70F9A24C1B";
+
+        /// <summary>
+        /// Attribute keys backing the outstanding mobile confirmation code. These must stay in
+        /// sync with org.secc.Migrations 034_UserLogin_ConfirmationCodeAttributes.
+        /// </summary>
+        private const string ATTRIBUTE_KEY_CONFIRMATION_CODE_HASH = "SeccConfirmationCodeHash";
+        private const string ATTRIBUTE_KEY_CONFIRMATION_CODE_ISSUED = "SeccConfirmationCodeIssued";
+
+        /// <summary>
+        /// Number of digits in the emailed confirmation code. Kept short because users type it
+        /// into the mobile app by hand. NOTE: 6 digits is only a 10^6 space, so the expiry window
+        /// and the attempt budgets below are what actually make guessing impractical -- see the
+        /// residual-risk note on ROCK-8762 before loosening either.
+        /// </summary>
+        private const int CONFIRMATION_CODE_DIGITS = 6;
+
+        /// <summary>
+        /// How long an issued confirmation code stays valid. Shorter is materially safer: the
+        /// chance a blind guess hits *some* account scales with the number of live codes.
+        /// </summary>
+        private const int CONFIRMATION_CODE_LIFETIME_MINUTES = 60;
+
+        /// <summary>
+        /// Confirmation attempts allowed per window for a single forwarded client IP. Tight,
+        /// because a legitimate user needs one or two tries. Note that X-Forwarded-For is
+        /// caller-supplied, so this budget alone can be escaped by rotating the header -- hence
+        /// the socket-level budget below.
+        /// </summary>
+        private const int CONFIRMATION_MAX_ATTEMPTS_PER_FORWARDED_IP = 10;
+
+        /// <summary>
+        /// Confirmation attempts allowed per window for a single socket-level peer (REMOTE_ADDR),
+        /// which the caller cannot forge. Sized generously because behind a reverse proxy every
+        /// user shares one REMOTE_ADDR: this is a ceiling on one network's traffic, not a
+        /// per-user limit. Raise it if legitimate confirmations ever hit it.
+        /// </summary>
+        private const int CONFIRMATION_MAX_ATTEMPTS_PER_PEER = 120;
+
+        /// <summary>
+        /// Attempts per window across the whole OAuth client that trigger an alert. This is
+        /// deliberately a log threshold and NOT a block: every user of the mobile app shares one
+        /// OAuth client, so refusing requests at this level would let one attacker stop everyone
+        /// from confirming their account.
+        /// </summary>
+        private const int CONFIRMATION_ALERT_THRESHOLD_PER_CLIENT = 100;
+
+        private const int CONFIRMATION_ATTEMPT_WINDOW_MINUTES = 15;
+
+        /// <summary>
+        /// Logins with a still-live confirmation code allowed per person. This bounds the number of
+        /// live codes, and therefore the odds a blind guess matches *something*: a guess lands with
+        /// roughly (live codes / 10^DIGITS) probability. Without a cap, api/account/create could be
+        /// called in a loop against one person to stack up thousands of simultaneously-valid codes.
+        ///
+        /// Counted over the code lifetime rather than over all unconfirmed logins, so it self-clears
+        /// and so people who already have abandoned unconfirmed logins from the old flow are not
+        /// permanently locked out of signing up.
+        /// </summary>
+        private const int MAX_LIVE_CONFIRMATION_CODES_PER_PERSON = 3;
+
+        /// <summary>
+        /// Account creations allowed per window for one forwarded client IP. api/account/create is
+        /// what manufactures confirmation codes, so leaving it unthrottled lets an attacker seed a
+        /// large live-code population and drive the per-guess hit rate up by orders of magnitude.
+        /// Throttling issuance matters as much as throttling verification.
+        /// </summary>
+        private const int CREATE_MAX_ATTEMPTS_PER_FORWARDED_IP = 5;
+
+        /// <summary>
+        /// Account creations allowed per window for one socket peer. Sized generously for the same
+        /// reason as the confirmation peer budget: behind a reverse proxy every user of the app
+        /// shares one REMOTE_ADDR, so a tight number here would refuse legitimate signups for the
+        /// whole church rather than for one abuser.
+        /// </summary>
+        private const int CREATE_MAX_ATTEMPTS_PER_PEER = 200;
+
+        #endregion
+
         [Route( "api/account/create" )]
         [Authorize]
         public HttpResponseMessage CreateAccount( Account account )
         {
             OAuthContext oAuthContext = new OAuthContext();
             ClientService clientService = new ClientService( oAuthContext );
-            var clientId = HttpContext.Current.User.Identity.Name;
-            Client oAuthClient = clientService.GetByApiKey( clientId.AsGuid() );
-            if ( oAuthClient.Active )
+            var clientId = HttpContext.Current?.User?.Identity?.Name;
+
+            if ( clientId.IsNullOrWhiteSpace() )
             {
+                return ControllerContext.Request.CreateResponse( HttpStatusCode.Forbidden );
+            }
+
+            Client oAuthClient = clientService.GetByApiKey( clientId.AsGuid() );
+            if ( oAuthClient != null && oAuthClient.Active )
+            {
+                // Throttle issuance, not just verification. api/account/create is what mints
+                // confirmation codes, so an unthrottled create lets an attacker seed a large live
+                // code population and raise the per-guess hit rate by orders of magnitude.
+                //
+                // Same two-tier keying as confirmation: tight on the forwarded client IP so one
+                // abuser is contained, generous on the socket peer so the shared proxy address is
+                // not a church-wide signup outage. Throttled before the missing-migration check
+                // below so that a misconfigured deploy cannot be turned into unbounded logging.
+                var createPeerKey = "create|client:" + clientId + "|peer:" + GetPeerIpAddress();
+                var createForwardedKey = "create|client:" + clientId + "|fwd:" + GetForwardedIpAddress();
+
+                if ( !ConfirmationAttempts.TryRegisterAttempt( createPeerKey, CREATE_MAX_ATTEMPTS_PER_PEER )
+                  || !ConfirmationAttempts.TryRegisterAttempt( createForwardedKey, CREATE_MAX_ATTEMPTS_PER_FORWARDED_IP ) )
+                {
+                    if ( ConfirmationAttempts.ShouldLogRefusal( createPeerKey ) )
+                    {
+                        ExceptionLogService.LogException( new Exception( string.Format(
+                            "Account creation budget exceeded. Client: {0} PeerIP: {1} ForwardedIP: {2}",
+                            clientId, GetPeerIpAddress(), GetForwardedIpAddress() ) ) );
+                    }
+
+                    return ControllerContext.Request.CreateResponse( ( HttpStatusCode ) 429, new StandardResponse()
+                    {
+                        Message = "Too many account creation attempts. Please try again later.",
+                        Result = StandardResponse.ResultCode.Error
+                    } );
+                }
+
+                // Checked before anything is written. SetAttributeValue silently no-ops on an
+                // unknown key, so without the migration we would create logins and email codes
+                // that were never stored and can never be confirmed. Failing here leaves no
+                // half-created account and no burned username behind.
+                if ( AttributeCache.Get( CONFIRMATION_CODE_HASH_ATTRIBUTE_GUID.AsGuid() ) == null
+                  || AttributeCache.Get( CONFIRMATION_CODE_ISSUED_ATTRIBUTE_GUID.AsGuid() ) == null )
+                {
+                    if ( ConfirmationAttempts.ShouldLogRefusal( "create|missing-migration" ) )
+                    {
+                        ExceptionLogService.LogException( new Exception(
+                            "Account confirmation code attributes are missing. Run org.secc.Migrations migration 034 (ROCK-8762)." ) );
+                    }
+
+                    return ControllerContext.Request.CreateResponse( HttpStatusCode.InternalServerError, new StandardResponse()
+                    {
+                        Message = "Account creation is temporarily unavailable.",
+                        Result = StandardResponse.ResultCode.Error
+                    } );
+                }
 
                 var rockContext = new Rock.Data.RockContext();
                 PersonService personService = new PersonService( rockContext );
@@ -161,6 +305,38 @@ namespace org.secc.Rest.Controllers
 
                 if ( !string.IsNullOrWhiteSpace( account.Username ) && UserLoginService.IsPasswordValid( account.Password ) )
                 {
+                    // Bound how many confirmation codes can be live for one person at once
+                    // (ROCK-8762). Without this, api/account/create can be called repeatedly
+                    // against a matched person to stack up simultaneously-valid codes, and the odds
+                    // that a blind guess at api/account/confirmaccount lands on one of them rise
+                    // with every extra code. Since ROCK-8761 the confirmation step is the only
+                    // thing standing between a requester-supplied password and the matched person's
+                    // account, so the size of this population is a security property.
+                    //
+                    // Only the window matters, not the all-time count: people with abandoned
+                    // unconfirmed logins from the old flow must not be locked out of signing up,
+                    // and nothing in Rock ever cleans those rows up.
+                    //
+                    // Scoped to this branch, which is the path that stacks codes onto an *existing*
+                    // person. The SMS branch below only runs for a person who was not matched, i.e.
+                    // one just created by this request, so a per-person cap could never bind there;
+                    // inflating the code population that way means creating a new person per code,
+                    // which is what the create rate limit above is for.
+                    var liveCodeCutoff = Rock.RockDateTime.Now.AddMinutes( -CONFIRMATION_CODE_LIFETIME_MINUTES );
+
+                    if ( person.Id > 0
+                      && userLoginService.Queryable().Count( ul => ul.PersonId == person.Id
+                            && ul.IsConfirmed != true
+                            && ul.CreatedDateTime.HasValue
+                            && ul.CreatedDateTime > liveCodeCutoff ) >= MAX_LIVE_CONFIRMATION_CODES_PER_PERSON )
+                    {
+                        return ControllerContext.Request.CreateResponse( ( HttpStatusCode ) 429, new StandardResponse()
+                        {
+                            Message = "A confirmation email was already sent for this person recently. Please use the most recent code, or try again later.",
+                            Result = StandardResponse.ResultCode.Error
+                        } );
+                    }
+
                     // Create the user login. Always unconfirmed: every account must confirm below.
                     userLogin = UserLoginService.Create(
                         rockContext,
@@ -195,9 +371,15 @@ namespace org.secc.Rest.Controllers
                 // Send an email to confirm the account.
                 if ( userLogin != null && userLogin.IsConfirmed != true )
                 {
+                    // The login has to exist in the database before attribute values can be
+                    // attached to it, so flush it now rather than at the end of the method.
+                    rockContext.SaveChanges();
 
-                    // For mobile we will make a custom/short confirmation code
-                    var mobileConfirmationCode = new BigInteger( MD5.Create().ComputeHash( userLogin.Guid.ToByteArray() ) ).ToString().Right( 6 );
+                    // For mobile we issue a custom/short confirmation code. It is randomly
+                    // generated, expiring and single-use, and only its hash is persisted
+                    // (ROCK-8762). The previous code was MD5( userLogin.Guid ) truncated to six
+                    // digits, which is deterministic and therefore guessable.
+                    var mobileConfirmationCode = IssueConfirmationCode( userLogin, rockContext );
                     var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( null, person );
                     mergeFields.Add( "MobileConfirmationCode", mobileConfirmationCode );
                     mergeFields.Add( "ConfirmAccountUrl", GlobalAttributesCache.Get().GetValue( "PublicApplicationRoot" ).EnsureTrailingForwardslash() + "ConfirmAccount" );
@@ -241,33 +423,582 @@ namespace org.secc.Rest.Controllers
         {
             OAuthContext oAuthContext = new OAuthContext();
             ClientService clientService = new ClientService( oAuthContext );
-            var clientId = HttpContext.Current.User.Identity.Name;
-            Client oAuthClient = clientService.GetByApiKey( clientId.AsGuid() );
-            if ( oAuthClient.Active )
+            var clientId = HttpContext.Current?.User?.Identity?.Name;
+
+            if ( clientId.IsNullOrWhiteSpace() )
             {
-                // Load the User Login that has the confirmation code and mark it as confirmed.
-                var rockContext = new Rock.Data.RockContext();
-                UserLoginService userLoginService = new UserLoginService( rockContext );
-                UserLogin user = userLoginService.GetByConfirmationCode( confirmationCode );
-                if ( user == null )
-                {
-                    var unconfirmedAccounts = userLoginService.Queryable().Where( ul => ul.IsConfirmed == false ).ToList();
-                    user = unconfirmedAccounts.FirstOrDefault( ul => new BigInteger( MD5.Create().ComputeHash( ul.Guid.ToByteArray() ) ).ToString().Right( 6 ) == confirmationCode );
-                }
-                if ( user != null )
-                {
-                    user.IsConfirmed = true;
-                    rockContext.SaveChanges();
-                    return ControllerContext.Request.CreateResponse( HttpStatusCode.OK, new StandardResponse() { Message = "Account has been confirmed", Result = StandardResponse.ResultCode.Success } );
-                }
-
-                return ControllerContext.Request.CreateResponse( HttpStatusCode.InternalServerError, new StandardResponse() { Message = "Error confirming account.", Result = StandardResponse.ResultCode.Error } );
-
+                return ControllerContext.Request.CreateResponse( HttpStatusCode.Forbidden );
             }
 
-            return ControllerContext.Request.CreateResponse( HttpStatusCode.Forbidden );
+            Client oAuthClient = clientService.GetByApiKey( clientId.AsGuid() );
+            if ( oAuthClient == null || !oAuthClient.Active )
+            {
+                return ControllerContext.Request.CreateResponse( HttpStatusCode.Forbidden );
+            }
 
+            // Throttle before doing any lookup work. Budgets are keyed on the caller, not on the
+            // target account: a confirmation request never names an account, so a per-account
+            // counter would not observe a code-space sweep at all. Keying on the caller also
+            // avoids handing an attacker a way to lock a victim out of confirming.
+            //
+            // The attempt is registered up front, so the check and the increment are a single
+            // atomic operation. Checking first and incrementing later would let concurrent requests
+            // all observe an empty budget and sail through together. Nothing is refunded on
+            // success -- see the note at the end of this method.
+            var forwardedIp = GetForwardedIpAddress();
+            var peerIp = GetPeerIpAddress();
+            string clientKey = "client:" + clientId;
+            string forwardedKey = clientKey + "|fwd:" + forwardedIp;
+            string peerKey = clientKey + "|peer:" + peerIp;
+
+            bool withinBudget =
+                ConfirmationAttempts.TryRegisterAttempt( peerKey, CONFIRMATION_MAX_ATTEMPTS_PER_PEER )
+                && ConfirmationAttempts.TryRegisterAttempt( forwardedKey, CONFIRMATION_MAX_ATTEMPTS_PER_FORWARDED_IP );
+
+            if ( !withinBudget )
+            {
+                // Logged at most once per key per window: an attacker who keeps hammering after
+                // being throttled must not be able to turn each request into an ExceptionLog row.
+                if ( ConfirmationAttempts.ShouldLogRefusal( peerKey ) )
+                {
+                    ExceptionLogService.LogException( new Exception( string.Format(
+                        "Account confirmation attempt budget exceeded. Client: {0} PeerIP: {1} ForwardedIP: {2}",
+                        clientId, peerIp, forwardedIp ) ) );
+                }
+
+                return ControllerContext.Request.CreateResponse( ( HttpStatusCode ) 429, new StandardResponse()
+                {
+                    Message = "Too many confirmation attempts. Please try again later.",
+                    Result = StandardResponse.ResultCode.Error
+                } );
+            }
+
+            // Client-wide volume is watched but never blocked: every user of the mobile app shares
+            // one OAuth client, so refusing at this level would let one attacker stop everyone from
+            // confirming their account. Counted only for requests that were inside budget, so a
+            // caller who keeps hammering after a 429 cannot inflate the tracking state.
+            if ( ConfirmationAttempts.RegisterAndCheckAlertThreshold( clientKey, CONFIRMATION_ALERT_THRESHOLD_PER_CLIENT ) )
+            {
+                ExceptionLogService.LogException( new Exception( string.Format(
+                    "Unusual volume of account confirmation attempts for OAuth client {0} ({1}+ in {2} minutes). Possible confirmation-code guessing.",
+                    clientId, CONFIRMATION_ALERT_THRESHOLD_PER_CLIENT, CONFIRMATION_ATTEMPT_WINDOW_MINUTES ) ) );
+            }
+
+            if ( confirmationCode.IsNullOrWhiteSpace() )
+            {
+                return ConfirmationFailedResponse();
+            }
+
+            // Load the User Login that has the confirmation code and mark it as confirmed.
+            var rockContext = new Rock.Data.RockContext();
+            UserLoginService userLoginService = new UserLoginService( rockContext );
+
+            // Rock's native confirmation code: a long encrypted token delivered as a URL.
+            UserLogin user = userLoginService.GetByConfirmationCode( confirmationCode );
+
+            if ( user == null )
+            {
+                // Short mobile code. Single scoped lookup against the stored hash, which resolves
+                // to at most one account. The previous implementation loaded *every* unconfirmed
+                // login and compared a deterministic MD5( Guid ) code, so one guess could confirm
+                // any account in the unconfirmed population (ROCK-8762).
+                user = FindLoginByConfirmationCode( confirmationCode, rockContext );
+
+                if ( user != null )
+                {
+                    var issuedDateTime = GetConfirmationCodeIssuedDateTime( user, rockContext );
+
+                    if ( !issuedDateTime.HasValue
+                      || issuedDateTime.Value.AddMinutes( CONFIRMATION_CODE_LIFETIME_MINUTES ) < Rock.RockDateTime.Now )
+                    {
+                        // Expired. Burn the code so it cannot be replayed, and return the same
+                        // generic failure body as an unknown code so the response does not confirm
+                        // that the guessed code was ever real.
+                        ClearConfirmationCode( user, rockContext );
+
+                        return ConfirmationFailedResponse();
+                    }
+                }
+            }
+
+            if ( user == null )
+            {
+                return ConfirmationFailedResponse();
+            }
+
+            user.IsConfirmed = true;
+            rockContext.SaveChanges();
+
+            // Single use: a consumed code must not confirm anything again.
+            ClearConfirmationCode( user, rockContext );
+
+            // Deliberately no budget refund on success. A refund looks user-friendly, but an
+            // attacker can mint a valid code for a throwaway account of their own at will, so
+            // "confirm something successfully" would be a budget reset they control -- which would
+            // make the budgets unbounded. Ten attempts per window is ample for someone mistyping
+            // their own code.
+
+            return ControllerContext.Request.CreateResponse( HttpStatusCode.OK, new StandardResponse() { Message = "Account has been confirmed", Result = StandardResponse.ResultCode.Success } );
         }
+
+        #region Account Confirmation Code helpers (ROCK-8762)
+
+        /// <summary>
+        /// The single response used for every failed confirmation, so the caller cannot tell an
+        /// unknown code from an expired one. Status code and message are unchanged from the
+        /// previous implementation to keep the mobile client's error handling working.
+        /// </summary>
+        private HttpResponseMessage ConfirmationFailedResponse()
+        {
+            return ControllerContext.Request.CreateResponse( HttpStatusCode.InternalServerError, new StandardResponse() { Message = "Error confirming account.", Result = StandardResponse.ResultCode.Error } );
+        }
+
+        /// <summary>
+        /// Generates a cryptographically random confirmation code of <see cref="CONFIRMATION_CODE_DIGITS"/> digits.
+        /// </summary>
+        private static string GenerateConfirmationCode()
+        {
+            // ulong rather than uint so raising CONFIRMATION_CODE_DIGITS past 9 cannot silently
+            // overflow the range.
+            ulong range = 1;
+            for ( int i = 0; i < CONFIRMATION_CODE_DIGITS; i++ )
+            {
+                range *= 10;
+            }
+
+            // Reject the top partial bucket so every code is equally likely. A plain
+            // "random % range" would make the lowest codes slightly more probable.
+            ulong limit = ulong.MaxValue - ( ulong.MaxValue % range );
+            var buffer = new byte[8];
+
+            using ( var rng = new RNGCryptoServiceProvider() )
+            {
+                ulong value;
+                do
+                {
+                    rng.GetBytes( buffer );
+                    value = BitConverter.ToUInt64( buffer, 0 );
+                }
+                while ( value >= limit );
+
+                return ( value % range ).ToString( CultureInfo.InvariantCulture ).PadLeft( CONFIRMATION_CODE_DIGITS, '0' );
+            }
+        }
+
+        /// <summary>
+        /// Hashes a confirmation code for storage and lookup.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately an unsalted digest: the code has to be findable by value, which a
+        /// per-row salt would prevent. That means a reader of the AttributeValue table could
+        /// recover a six-digit code by brute force, but anyone with that access can already set
+        /// IsConfirmed directly, so this does not widen the attack surface. What it does buy is
+        /// that the codes are not sitting in the database in plaintext.
+        /// </remarks>
+        private static string HashConfirmationCode( string code )
+        {
+            using ( var sha = SHA256.Create() )
+            {
+                return Convert.ToBase64String( sha.ComputeHash( Encoding.UTF8.GetBytes( code.Trim() ) ) );
+            }
+        }
+
+        /// <summary>
+        /// Issues a fresh confirmation code for the login, persisting only its hash plus the time
+        /// it was issued. The login must already be saved, since attribute values need its Id.
+        /// </summary>
+        /// <returns>The plaintext code, to be emailed to the person. It is not stored anywhere.</returns>
+        private static string IssueConfirmationCode( UserLogin userLogin, Rock.Data.RockContext rockContext )
+        {
+            // Fail loudly if migration 034 has not run. SetAttributeValue silently does nothing
+            // for an unknown key, so without this guard we would email a code that was never
+            // stored and can never be confirmed, with no error anywhere.
+            if ( AttributeCache.Get( CONFIRMATION_CODE_HASH_ATTRIBUTE_GUID.AsGuid() ) == null
+              || AttributeCache.Get( CONFIRMATION_CODE_ISSUED_ATTRIBUTE_GUID.AsGuid() ) == null )
+            {
+                throw new Exception( "Account confirmation code attributes are missing. Run org.secc.Migrations migration 034 (ROCK-8762) before creating accounts." );
+            }
+
+            string code = null;
+            string hash = null;
+            bool unique = false;
+
+            // A code must not collide with any other outstanding code, otherwise one guess could
+            // match more than one account and the wrong row could be consumed. Collisions are
+            // unlikely; if we somehow cannot find a free code, fail rather than issue an ambiguous
+            // one.
+            for ( int attempt = 0; attempt < 10 && !unique; attempt++ )
+            {
+                code = GenerateConfirmationCode();
+                hash = HashConfirmationCode( code );
+                unique = !FindLoginIdByConfirmationCodeHash( hash, rockContext ).HasValue;
+            }
+
+            if ( !unique )
+            {
+                throw new Exception( "Unable to allocate a unique account confirmation code. The outstanding-code population may be abnormally large." );
+            }
+
+            userLogin.LoadAttributes( rockContext );
+            userLogin.SetAttributeValue( ATTRIBUTE_KEY_CONFIRMATION_CODE_HASH, hash );
+
+            // Stored as ticks: a round-trip formatted string carries the offset in effect when it
+            // was written, so a DST change or a differently-configured server would shift the
+            // expiry window by an hour.
+            userLogin.SetAttributeValue( ATTRIBUTE_KEY_CONFIRMATION_CODE_ISSUED, Rock.RockDateTime.Now.Ticks.ToString( CultureInfo.InvariantCulture ) );
+            userLogin.SaveAttributeValues( rockContext );
+
+            return code;
+        }
+
+        /// <summary>
+        /// Resolves a plaintext confirmation code to at most one UserLogin by matching the stored
+        /// hash. Note what this deliberately does not do: enumerate unconfirmed logins.
+        /// </summary>
+        private static UserLogin FindLoginByConfirmationCode( string code, Rock.Data.RockContext rockContext )
+        {
+            var userLoginId = FindLoginIdByConfirmationCodeHash( HashConfirmationCode( code ), rockContext );
+
+            if ( !userLoginId.HasValue )
+            {
+                return null;
+            }
+
+            return new UserLoginService( rockContext ).Get( userLoginId.Value );
+        }
+
+        /// <summary>
+        /// Single equality lookup on the confirmation-code-hash attribute value.
+        /// </summary>
+        private static int? FindLoginIdByConfirmationCodeHash( string hash, Rock.Data.RockContext rockContext )
+        {
+            var attribute = AttributeCache.Get( CONFIRMATION_CODE_HASH_ATTRIBUTE_GUID.AsGuid() );
+
+            if ( attribute == null || hash.IsNullOrWhiteSpace() )
+            {
+                // Fail closed: with no attribute there is nothing to match against, so no code
+                // can confirm anything.
+                return null;
+            }
+
+            var attributeValueService = new AttributeValueService( rockContext );
+
+            var candidateIds = attributeValueService.Queryable()
+                .Where( av => av.AttributeId == attribute.Id && av.Value == hash && av.EntityId.HasValue )
+                .Select( av => av.EntityId.Value );
+
+            // Restricted to logins that are still unconfirmed, so a hash left behind on an
+            // already-confirmed login can never be matched again.
+            return new UserLoginService( rockContext ).Queryable()
+                .Where( ul => ul.IsConfirmed != true && candidateIds.Contains( ul.Id ) )
+                .Select( ul => ( int? ) ul.Id )
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Reads the time the outstanding confirmation code was issued, or null if absent/unparseable.
+        /// </summary>
+        private static DateTime? GetConfirmationCodeIssuedDateTime( UserLogin userLogin, Rock.Data.RockContext rockContext )
+        {
+            userLogin.LoadAttributes( rockContext );
+
+            var issued = userLogin.GetAttributeValue( ATTRIBUTE_KEY_CONFIRMATION_CODE_ISSUED );
+
+            long ticks;
+            if ( !issued.IsNullOrWhiteSpace()
+              && long.TryParse( issued, NumberStyles.Integer, CultureInfo.InvariantCulture, out ticks )
+              && ticks > 0
+              && ticks <= DateTime.MaxValue.Ticks )
+            {
+                return new DateTime( ticks );
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Clears any outstanding confirmation code so it cannot be reused.
+        /// </summary>
+        /// <remarks>
+        /// The rows are deleted rather than blanked. Leaving empty-valued rows behind would grow
+        /// the set that <see cref="FindLoginIdByConfirmationCodeHash"/> has to search forever
+        /// (AttributeValue.Value is nvarchar(max) and cannot be indexed) and would keep dead
+        /// hashes around to collide with freshly issued codes.
+        /// </remarks>
+        private static void ClearConfirmationCode( UserLogin userLogin, Rock.Data.RockContext rockContext )
+        {
+            var attributeIds = new List<int>();
+
+            foreach ( var attributeGuid in new[] { CONFIRMATION_CODE_HASH_ATTRIBUTE_GUID, CONFIRMATION_CODE_ISSUED_ATTRIBUTE_GUID } )
+            {
+                var attribute = AttributeCache.Get( attributeGuid.AsGuid() );
+
+                if ( attribute != null )
+                {
+                    attributeIds.Add( attribute.Id );
+                }
+            }
+
+            if ( !attributeIds.Any() )
+            {
+                return;
+            }
+
+            var attributeValueService = new AttributeValueService( rockContext );
+
+            var staleValues = attributeValueService.Queryable()
+                .Where( av => attributeIds.Contains( av.AttributeId ) && av.EntityId == userLogin.Id )
+                .ToList();
+
+            if ( !staleValues.Any() )
+            {
+                return;
+            }
+
+            foreach ( var staleValue in staleValues )
+            {
+                attributeValueService.Delete( staleValue );
+            }
+
+            rockContext.SaveChanges();
+        }
+
+        /// <summary>
+        /// The client IP from X-Forwarded-For, falling back to the socket peer.
+        /// </summary>
+        /// <remarks>
+        /// Reads the RIGHTMOST entry, not the leftmost. Proxies append, so the rightmost value is
+        /// the one our own edge observed, whereas the leftmost is whatever the caller chose to send
+        /// and can be forged freely -- keying a budget on it would let an attacker mint a fresh
+        /// budget per request. Note this assumes a single trusted proxy hop; if a second reverse
+        /// proxy is ever put in front, this needs to select the Nth-from-right entry instead.
+        ///
+        /// This is still only used to subdivide a budget, never to grant access, and the socket
+        /// peer is budgeted separately as the value the caller genuinely cannot control.
+        /// </remarks>
+        private static string GetForwardedIpAddress()
+        {
+            var request = HttpContext.Current?.Request;
+
+            if ( request == null )
+            {
+                return "unknown";
+            }
+
+            var forwardedFor = request.ServerVariables["HTTP_X_FORWARDED_FOR"];
+
+            if ( !forwardedFor.IsNullOrWhiteSpace() )
+            {
+                var hops = forwardedFor.Split( ',' );
+                var candidate = hops[hops.Length - 1].Trim();
+
+                // Strip a trailing :port. Only for IPv4-looking values, so bracketed IPv6
+                // addresses keep their colons.
+                if ( candidate.Count( c => c == ':' ) == 1 )
+                {
+                    candidate = candidate.Split( ':' )[0];
+                }
+
+                if ( !candidate.IsNullOrWhiteSpace() )
+                {
+                    return candidate;
+                }
+            }
+
+            return GetPeerIpAddress();
+        }
+
+        /// <summary>
+        /// The socket-level peer address, which the caller cannot forge. Behind a reverse proxy
+        /// this is the proxy, so it is shared by every user on that path.
+        /// </summary>
+        private static string GetPeerIpAddress()
+        {
+            var request = HttpContext.Current?.Request;
+
+            if ( request == null )
+            {
+                return "unknown";
+            }
+
+            var remoteAddress = request.ServerVariables["REMOTE_ADDR"];
+
+            return remoteAddress.IsNullOrWhiteSpace() ? "unknown" : remoteAddress;
+        }
+
+        /// <summary>
+        /// In-process rolling-window record of confirmation attempts, following the pattern already
+        /// used by SMSAuthentication's SMSRecords.
+        /// </summary>
+        /// <remarks>
+        /// Attempts are registered before the code is checked, so the check and the increment are
+        /// one atomic operation under the lock. Nothing is ever refunded: a caller who can produce a
+        /// valid code on demand (by creating a throwaway account of their own) would otherwise be
+        /// able to reset their own budget at will.
+        ///
+        /// State is per-server and is lost on an app-pool recycle, so behind a load balancer with
+        /// N servers the real budget is N times the configured one. For a throttle that is an
+        /// acceptable looseness -- it costs an attacker a constant factor -- which is why the code
+        /// hashes themselves are persisted in the database rather than held here. If the budgets
+        /// ever need to be exact, back this with RockCache instead.
+        /// </remarks>
+        private static class ConfirmationAttempts
+        {
+            /// <summary>
+            /// Ceiling on tracked keys. An attacker rotating X-Forwarded-For mints a new key per
+            /// request, so the table needs a hard bound. When it is reached the oldest windows are
+            /// evicted, which is fail-open -- eviction only ever discards state, so it cannot
+            /// wrongly refuse a real user. Note that the socket-peer keys are among the oldest and
+            /// so are evicted first; what makes key-flooding unprofitable is not eviction order but
+            /// that a spent peer budget short-circuits registration of any further forwarded keys,
+            /// capping how many keys one peer can mint in a window.
+            /// </summary>
+            private const int MAX_TRACKED_KEYS = 20000;
+
+            private class Window
+            {
+                public DateTime StartedAt;
+                public int Count;
+            }
+
+            private static readonly object _lock = new object();
+            private static readonly Dictionary<string, Window> _windows = new Dictionary<string, Window>();
+            private static readonly Dictionary<string, DateTime> _lastLogged = new Dictionary<string, DateTime>();
+            private static DateTime _lastPrunedAt = DateTime.MinValue;
+
+            /// <summary>
+            /// Registers an attempt against a key if the budget allows, atomically. Counting and
+            /// checking in one locked operation is what stops concurrent requests from all
+            /// observing an empty budget and passing together.
+            /// </summary>
+            /// <returns>False if the budget for this key is already spent.</returns>
+            public static bool TryRegisterAttempt( string key, int maxAttempts )
+            {
+                lock ( _lock )
+                {
+                    var window = GetOrStartWindow( key );
+
+                    if ( window.Count >= maxAttempts )
+                    {
+                        return false;
+                    }
+
+                    window.Count++;
+                    return true;
+                }
+            }
+
+            /// <summary>
+            /// Counts an attempt and reports whether the key has reached the alert threshold. Never
+            /// refuses anything; true at most once per key per window.
+            /// </summary>
+            public static bool RegisterAndCheckAlertThreshold( string key, int threshold )
+            {
+                lock ( _lock )
+                {
+                    var window = GetOrStartWindow( key );
+                    window.Count++;
+
+                    return window.Count >= threshold && ShouldLogInternal( "alert:" + key );
+                }
+            }
+
+            /// <summary>
+            /// Rate-limits the refusal logging itself, so hammering a spent budget cannot be turned
+            /// into unbounded ExceptionLog writes.
+            /// </summary>
+            public static bool ShouldLogRefusal( string key )
+            {
+                lock ( _lock )
+                {
+                    return ShouldLogInternal( "refusal:" + key );
+                }
+            }
+
+            private static Window GetOrStartWindow( string key )
+            {
+                Prune();
+
+                var now = Rock.RockDateTime.Now;
+                var cutoff = now.AddMinutes( -CONFIRMATION_ATTEMPT_WINDOW_MINUTES );
+
+                Window window;
+                if ( _windows.TryGetValue( key, out window ) )
+                {
+                    if ( window.StartedAt >= cutoff )
+                    {
+                        return window;
+                    }
+
+                    window.StartedAt = now;
+                    window.Count = 0;
+                    return window;
+                }
+
+                if ( _windows.Count >= MAX_TRACKED_KEYS )
+                {
+                    EvictOldest();
+                }
+
+                window = new Window { StartedAt = now, Count = 0 };
+                _windows[key] = window;
+                return window;
+            }
+
+            private static bool ShouldLogInternal( string key )
+            {
+                var now = Rock.RockDateTime.Now;
+                DateTime lastLogged;
+
+                if ( _lastLogged.TryGetValue( key, out lastLogged )
+                  && lastLogged > now.AddMinutes( -CONFIRMATION_ATTEMPT_WINDOW_MINUTES ) )
+                {
+                    return false;
+                }
+
+                _lastLogged[key] = now;
+                return true;
+            }
+
+            /// <summary>
+            /// Sweeps expired windows, at most once a minute so the cost is not paid per request.
+            /// </summary>
+            private static void Prune()
+            {
+                var now = Rock.RockDateTime.Now;
+
+                if ( _lastPrunedAt > now.AddMinutes( -1 ) )
+                {
+                    return;
+                }
+
+                _lastPrunedAt = now;
+                var cutoff = now.AddMinutes( -CONFIRMATION_ATTEMPT_WINDOW_MINUTES );
+
+                foreach ( var staleKey in _windows.Where( kv => kv.Value.StartedAt < cutoff ).Select( kv => kv.Key ).ToList() )
+                {
+                    _windows.Remove( staleKey );
+                }
+
+                foreach ( var staleKey in _lastLogged.Where( kv => kv.Value < cutoff ).Select( kv => kv.Key ).ToList() )
+                {
+                    _lastLogged.Remove( staleKey );
+                }
+            }
+
+            private static void EvictOldest()
+            {
+                foreach ( var staleKey in _windows.OrderBy( kv => kv.Value.StartedAt )
+                    .Take( Math.Max( 1, MAX_TRACKED_KEYS / 10 ) )
+                    .Select( kv => kv.Key )
+                    .ToList() )
+                {
+                    _windows.Remove( staleKey );
+                }
+            }
+        }
+
+        #endregion
 
 
         /// <summary>


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 dir="ltr" class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="21:1-21:21;589-609">The vulnerability</h2>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="23:1-23:231;611-841"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">api/account/create</code> emailed a six-digit code computed as <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MD5( userLogin.Guid ).Right( 6 )</code>. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">api/account/confirmaccount</code> accepted only that code — no username — and when Rock's native <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">GetByConfirmationCode</code> missed, it did this:</p>

<div role="group" aria-label="csharp code" tabindex="0" data-sourcepos="25:1-28:4;843-1122" class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-100"><div class="sticky opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"></div></div><div class="text-text-500 font-small p-3.5 pb-0">csharp</div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono);"><code class="language-csharp" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono); white-space: pre;"><span style="color: rgb(204, 123, 244);">var</span> unconfirmedAccounts = userLoginService<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">Queryable</span><span style="color: rgb(211, 215, 222);">().</span><span style="color: rgb(112, 184, 255);">Where</span><span style="color: rgb(211, 215, 222);">(</span> ul =&gt; ul<span style="color: rgb(211, 215, 222);">.</span>IsConfirmed == <span style="color: rgb(94, 237, 237);">false</span> <span style="color: rgb(211, 215, 222);">).</span><span style="color: rgb(112, 184, 255);">ToList</span><span style="color: rgb(211, 215, 222);">();</span>
user = unconfirmedAccounts<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">FirstOrDefault</span><span style="color: rgb(211, 215, 222);">(</span> ul =&gt; <span style="color: rgb(204, 123, 244);">new</span> <span style="color: rgb(251, 173, 96);">BigInteger</span><span style="color: rgb(211, 215, 222);">(</span> MD5<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">Create</span><span style="color: rgb(211, 215, 222);">().</span><span style="color: rgb(112, 184, 255);">ComputeHash</span><span style="color: rgb(211, 215, 222);">(</span> ul<span style="color: rgb(211, 215, 222);">.</span>Guid<span style="color: rgb(211, 215, 222);">.</span><span style="color: rgb(112, 184, 255);">ToByteArray</span><span style="color: rgb(211, 215, 222);">()</span> <span style="color: rgb(211, 215, 222);">)</span> <span style="color: rgb(211, 215, 222);">).</span><span style="color: rgb(112, 184, 255);">ToString</span><span style="color: rgb(211, 215, 222);">().</span><span style="color: rgb(112, 184, 255);">Right</span><span style="color: rgb(211, 215, 222);">(</span> <span style="color: rgb(94, 237, 237);">6</span> <span style="color: rgb(211, 215, 222);">)</span> == confirmationCode <span style="color: rgb(211, 215, 222);">);</span></code></pre></div></div>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="30:1-30:356;1124-1479">Three problems compounded: the code was deterministic and never expired, there was no rate limiting, and each guess was tested against <em>every</em> unconfirmed account at once. Since ROCK-8761, confirmation is the only thing standing between a requester-supplied password and a matched person's account — so confirming an arbitrary account is account takeover.</p>

<h2 dir="ltr" class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="32:1-32:41;1481-1521">Why randomising the code isn't enough</h2>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="34:1-34:343;1523-1865">Worth stating plainly, because it was the main gap in the original plan: unpredictable codes do <strong>not</strong> reduce the odds of a blind guess landing. Those odds are <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">live codes / 10^6</code> however the codes are generated. Randomness plus a scoped lookup guarantees a guess matches at most <em>one</em> account; it does nothing about matching <em>some</em> account.</p>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="36:1-36:156;1867-2022">So the fix has to attack three separate quantities — how guessable a given code is, how many codes are live at once, and how many guesses an attacker gets.</p>

<h2 dir="ltr" class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="38:1-38:16;2024-2039">What changed</h2>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="40:1-40:48;2041-2088"><strong>Verification — <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">api/account/confirmaccount</code></strong></p>

<ul dir="ltr" class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3 print:block print:space-y-1" data-sourcepos="42:1-48:114;2090-3480">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="42:1-42:146;2090-2235">One equality lookup on a stored SHA-256 hash, restricted to unconfirmed logins, resolving to at most one account. The <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">.ToList()</code> scan is gone.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="43:1-43:169;2236-2404">Codes expire after 60 minutes and are consumed on use. Stored rows are <strong>deleted</strong>, not blanked, so dead hashes can't collide with new codes or grow the searched set.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="44:1-44:264;2405-2668">Attempt budgets: tight per forwarded client IP (10 / 15 min), generous per socket peer (120 / 15 min). The attempt is registered <em>before</em> validation, so check-and-increment is atomic — otherwise concurrent requests all observe an empty budget and pass together.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="45:1-45:194;2669-2862"><strong>No refund on success.</strong> A refund reads as user-friendly, but an attacker can mint a valid code for a throwaway account of their own at will, which would make it a budget reset they control.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="46:1-46:302;2863-3164"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">X-Forwarded-For</code> is read <strong>rightmost</strong>-first. Proxies append, so the leftmost hop is caller-supplied and forgeable; keying a budget on it hands out a fresh budget per request. This assumes one trusted proxy hop — if another reverse proxy is ever added in front, this needs the Nth-from-right entry.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="47:1-47:202;3165-3366">Client-wide volume is <strong>alerted on, never blocked</strong>. Every user of the mobile app shares one OAuth client, so a hard limit there would let one attacker stop the whole church from confirming accounts.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="48:1-48:114;3367-3480">Unknown and expired codes return identical responses, so the endpoint isn't an oracle for "that code was real".</li>
</ul>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="50:1-50:36;3482-3517"><strong>Issuance — <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">api/account/create</code></strong></p>

<ul dir="ltr" class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3 print:block print:space-y-1" data-sourcepos="52:1-55:248;3519-4421">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="52:1-52:161;3519-3679">Cryptographically random code, rejection-sampled so there's no modulo bias. Only the hash and issue time are stored, in two new <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">UserLogin</code> entity attributes.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="53:1-53:357;3680-4036">Caps logins holding a live code per person, so create can't be looped against one person to stack up simultaneously-valid codes. Scoped to the code lifetime rather than counting all unconfirmed logins — nothing in Rock ever cleans those up, so an all-time count would permanently lock out anyone with three abandoned signups, including from the old flow.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="54:1-54:137;4037-4173">Create is rate limited too. It's the endpoint that mints codes, and seeding a large live-code population is what makes guessing cheap.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="55:1-55:248;4174-4421">The migration is verified before anything is written. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SetAttributeValue</code> silently no-ops on an unknown key, so without this guard a missing migration would email codes that were never stored and could never be confirmed, with no error anywhere.</li>
</ul>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="57:1-57:62;4423-4484">Rock's native encrypted confirmation-token path is untouched.</p>

<h2 dir="ltr" class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="59:1-59:9;4486-4494">Files</h2>

<div dir="ltr" class="overflow-x-auto w-full px-2 mb-6 print:overflow-x-visible" data-sourcepos="61:1-65:123;4496-4839">
File | Why
-- | --
Plugins/org.secc.Rest/Controllers/AccountController.Partial.cs | The fix
Plugins/org.secc.Migrations/034_UserLogin_ConfirmationCodeAttributes.cs | New — the two UserLogin attributes
Plugins/org.secc.Migrations/org.secc.Migrations.csproj | Registers the migration (unlisted files silently never run)

</div>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="79:1-79:413;5467-5879">The <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">M²</code> scaling is the uncomfortable part — a commodity proxy pool beats it. Eight digits is a one-constant change and multiplies every row by 100; worth doing once the mobile input field is confirmed to accept eight characters. The structural fix is to accept a username or email alongside the code, making the space per-account instead of global, which ends this attack class outright but needs an app change.</p>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="81:1-81:234;5881-6114"><strong>2. Deploy order matters.</strong> Migration 034 must run before the new controller serves traffic. If it hasn't, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">CreateAccount</code> returns 500 and refuses to create accounts — by design, and logged — rather than silently issuing dead codes.</p>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="83:1-83:354;6116-6469"><strong>3. Codes already sitting in inboxes stop working.</strong> Old codes were never stored, so after deploy they can't be matched and those users get the generic failure. They can't self-serve a new one either, since the username is already taken. Small population, but worth warning whoever fields the support call — and it argues for deploying at a quiet hour.</p>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="85:1-85:310;6471-6780"><strong>4. This has not been compiled.</strong> The repo builds only inside a parent Rock solution (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">$(SolutionDir)Rock\Rock.csproj</code>), which wasn't available. Every Rock API used was verified against <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Rock.xml</code> for existence and signature, and the file was structurally checked, but <strong>it needs a real build before merge.</strong></p>

<h2 dir="ltr" class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="87:1-87:28;6782-6809">Follow-ups worth tickets</h2>

<ol dir="ltr" class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-decimal flex flex-col gap-1 pl-8 mb-3 print:block print:space-y-1" data-sourcepos="89:1-91:192;6811-7481">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="89:1-89:302;6811-7112"><strong>Expired-code sweep job.</strong> Codes are cleared on use, but an abandoned signup leaves its hash indefinitely. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">AttributeValue.Value</code> is <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">nvarchar(max)</code> and can't be indexed, so unbounded growth there slowly degrades every lookup. A job deleting hash/issued rows older than the code lifetime fixes it.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="90:1-90:177;7113-7289"><strong>Account-scoped confirmation.</strong> Accept username or email alongside the code (see residual risk above). This is the real fix, and it makes the digit count almost irrelevant.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="91:1-91:192;7290-7481"><strong>Shared IP helper.</strong> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">GetForwardedIpAddress</code> here and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SMSAuthentication.GetIpAddress</code> are now two divergent implementations of the same security-relevant primitive. Worth extracting one.</li></ol><!--EndFragment-->
</body>
</html>