### PR TITLE
ROCK-8879 Fix PCR warning display and encode stored requestor comments

### DIFF
--- a/Plugins/org.secc.ChangeManager/Migrations/004_EncodeStoredRequestorComments.cs
+++ b/Plugins/org.secc.ChangeManager/Migrations/004_EncodeStoredRequestorComments.cs
@@ -18,28 +18,37 @@ namespace org.secc.ChangeManager.Migrations
 
     /// <summary>
     /// ROCK-8879. ChangeRequestDetail no longer HTML-encodes RequestorComment at render
-    /// time, because the field holds system-generated markup composed at write time. Every
-    /// row written before that change stored raw, unencoded requestor text, so this
-    /// migration encodes the stored values to match the new write-site behavior.
+    /// time, because the field holds system-generated markup composed at write time. Rows
+    /// written before that change stored raw, unencoded requestor text — except that some
+    /// also contain system-composed markup mixed in (the duplicate-mobile-number warning
+    /// from ChangeEntry and the "Comment:" separator from CMPublicProfileEdit). This
+    /// migration encodes every stored value to neutralize the user text, then restores
+    /// those exact known system fragments so historical warnings keep rendering as markup.
     ///
-    /// This must ship in the same deploy as the block changes: it assumes every existing
-    /// row is unencoded, which stops being true once the new write sites are live. Rock
-    /// runs plugin migrations once, tracked in the PluginMigration table, so it will not
-    /// double-encode on subsequent restarts. Do not re-run the SQL by hand.
+    /// This must ship in the same deploy as the block changes: it assumes existing rows
+    /// are unencoded, which stops being true once the new write sites are live. The whole
+    /// Up() runs inside one IF guarded by the backup table's existence, so a re-run
+    /// (tracked-migration bookkeeping failing after the data commit, a restored database,
+    /// or the SQL being run by hand) is a no-op rather than a double-encode.
     ///
     /// Original values are copied to _org_secc_ChangeManager_ChangeRequestCommentBackup
     /// first, so Down() restores exactly and the change stays auditable. That table can be
-    /// dropped once the results have been spot-checked.
+    /// dropped once the results have been spot-checked — but note dropping it also removes
+    /// the re-run guard, so only drop it once the PluginMigration row is confirmed present.
     /// </summary>
     [MigrationNumber( 4, "1.13.7" )]
     public partial class EncodeStoredRequestorComments : Migration
     {
         public override void Up()
         {
-            // Preserve the originals before touching anything.
+            // Everything runs inside the one IF: the backup table's existence is the
+            // sentinel that the data work already happened, which makes the whole
+            // migration idempotent (Rock commits the migration transaction before it
+            // records the PluginMigration row, so a failure in that gap re-runs Up()).
             Sql( @"
                 IF OBJECT_ID( '_org_secc_ChangeManager_ChangeRequestCommentBackup' ) IS NULL
                 BEGIN
+                    -- Preserve the originals before touching anything.
                     CREATE TABLE [_org_secc_ChangeManager_ChangeRequestCommentBackup] (
                         [ChangeRequestId] INT NOT NULL
                             CONSTRAINT [PK__org_secc_ChangeManager_ChangeRequestCommentBackup] PRIMARY KEY,
@@ -52,42 +61,70 @@ namespace org.secc.ChangeManager.Migrations
                     SELECT [Id], [RequestorComment]
                     FROM [_org_secc_ChangeManager_ChangeRequest]
                     WHERE [RequestorComment] IS NOT NULL;
-                END
-" );
 
-            // Whitespace-only comments become empty, so the detail block's
-            // IsNotNullOrWhiteSpace() guard keeps hiding them once line breaks turn into
-            // <br> below. Run this before the encode so it sees the raw whitespace.
-            Sql( @"
-                UPDATE [_org_secc_ChangeManager_ChangeRequest]
-                SET [RequestorComment] = ''
-                WHERE [RequestorComment] IS NOT NULL
-                    AND LTRIM( RTRIM( REPLACE( REPLACE( REPLACE( [RequestorComment], CHAR(13), ' ' ), CHAR(10), ' ' ), CHAR(9), ' ' ) ) ) = '';
-" );
+                    -- Whitespace-only comments become empty, so the detail block's
+                    -- IsNotNullOrWhiteSpace() guard keeps hiding them once line breaks
+                    -- turn into <br> below. Runs before the encode so it sees the raw
+                    -- whitespace.
+                    UPDATE [_org_secc_ChangeManager_ChangeRequest]
+                    SET [RequestorComment] = ''
+                    WHERE [RequestorComment] IS NOT NULL
+                        AND LTRIM( RTRIM( REPLACE( REPLACE( REPLACE( [RequestorComment], CHAR(13), ' ' ), CHAR(10), ' ' ), CHAR(9), ' ' ) ) ) = '';
 
-            // Mirror EncodeHtml().ConvertCrLfToHtmlBr(). The ampersand must be replaced
-            // first or the entities introduced by the later replacements get re-encoded,
-            // and the <br> substitution must come last or its angle brackets get encoded.
-            // HttpUtility.HtmlEncode also emits numeric entities for some characters above
-            // ASCII; those render identically either way, so they are left alone here.
-            Sql( @"
-                UPDATE [_org_secc_ChangeManager_ChangeRequest]
-                SET [RequestorComment] =
-                    REPLACE(
+                    -- Mirror EncodeHtml().ConvertCrLfToHtmlBr(). The ampersand must be
+                    -- replaced first or the entities introduced by the later replacements
+                    -- get re-encoded, and the <br> substitution must come last or its
+                    -- angle brackets get encoded. HttpUtility.HtmlEncode also emits
+                    -- numeric entities for some characters above ASCII; those render
+                    -- identically either way, so they are left alone here.
+                    UPDATE [_org_secc_ChangeManager_ChangeRequest]
+                    SET [RequestorComment] =
                         REPLACE(
                             REPLACE(
                                 REPLACE(
                                     REPLACE(
                                         REPLACE(
-                                            REPLACE( [RequestorComment], '&', '&amp;' ),
-                                        '<', '&lt;' ),
-                                    '>', '&gt;' ),
-                                '""', '&quot;' ),
-                            '''', '&#39;' ),
-                        CHAR(13) + CHAR(10), '<br>' ),
-                    CHAR(10), '<br>' )
-                WHERE [RequestorComment] IS NOT NULL
-                    AND [RequestorComment] <> '';
+                                            REPLACE(
+                                                REPLACE( [RequestorComment], '&', '&amp;' ),
+                                            '<', '&lt;' ),
+                                        '>', '&gt;' ),
+                                    '""', '&quot;' ),
+                                '''', '&#39;' ),
+                            CHAR(13) + CHAR(10), '<br>' ),
+                        CHAR(10), '<br>' )
+                    WHERE [RequestorComment] IS NOT NULL
+                        AND [RequestorComment] <> '';
+
+                    -- Rows written before ROCK-8879 by ChangeEntry's duplicate-mobile
+                    -- warning mixed system-composed markup into the same column; the
+                    -- encode above turned that markup into literal text. Restore the
+                    -- exact known system fragments so historical warnings keep rendering
+                    -- as markup. The person names inside the warning stay encoded, which
+                    -- is the point of the migration. (A user comment containing these
+                    -- exact literal fragments would also be restored; accepted as
+                    -- vanishingly unlikely for a data repair.)
+                    UPDATE [_org_secc_ChangeManager_ChangeRequest]
+                    SET [RequestorComment] =
+                        REPLACE(
+                            REPLACE(
+                                REPLACE(
+                                    REPLACE(
+                                        REPLACE(
+                                            REPLACE( [RequestorComment],
+                                                '&lt;h4&gt;Dynamically Generated Warnings:&lt;/h4&gt;', '<h4>Dynamically Generated Warnings:</h4>' ),
+                                            '&lt;ul&gt;', '<ul>' ),
+                                        '&lt;/ul&gt;', '</ul>' ),
+                                    '&lt;li&gt;&lt;a href=&#39;/Person/', '<li><a href=''/Person/' ),
+                                '&#39; target=&#39;_blank&#39;&gt;', ''' target=''_blank''>' ),
+                            '&lt;/a&gt;&lt;/li&gt;', '</a></li>' )
+                    WHERE [RequestorComment] LIKE '%&lt;h4&gt;Dynamically Generated Warnings:&lt;/h4&gt;%';
+
+                    -- Same for CMPublicProfileEdit's system-composed separator between
+                    -- the fixed 'Added as new person' text and the user's comment.
+                    UPDATE [_org_secc_ChangeManager_ChangeRequest]
+                    SET [RequestorComment] = REPLACE( [RequestorComment], '&lt;br&gt;&lt;br&gt;Comment: ', '<br><br>Comment: ' )
+                    WHERE [RequestorComment] LIKE '%&lt;br&gt;&lt;br&gt;Comment: %';
+                END
 " );
         }
 

--- a/Plugins/org.secc.ChangeManager/Migrations/004_EncodeStoredRequestorComments.cs
+++ b/Plugins/org.secc.ChangeManager/Migrations/004_EncodeStoredRequestorComments.cs
@@ -1,0 +1,110 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License should be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace org.secc.ChangeManager.Migrations
+{
+    using Rock.Plugin;
+
+    /// <summary>
+    /// ROCK-8879. ChangeRequestDetail no longer HTML-encodes RequestorComment at render
+    /// time, because the field holds system-generated markup composed at write time. Every
+    /// row written before that change stored raw, unencoded requestor text, so this
+    /// migration encodes the stored values to match the new write-site behavior.
+    ///
+    /// This must ship in the same deploy as the block changes: it assumes every existing
+    /// row is unencoded, which stops being true once the new write sites are live. Rock
+    /// runs plugin migrations once, tracked in the PluginMigration table, so it will not
+    /// double-encode on subsequent restarts. Do not re-run the SQL by hand.
+    ///
+    /// Original values are copied to _org_secc_ChangeManager_ChangeRequestCommentBackup
+    /// first, so Down() restores exactly and the change stays auditable. That table can be
+    /// dropped once the results have been spot-checked.
+    /// </summary>
+    [MigrationNumber( 4, "1.13.7" )]
+    public partial class EncodeStoredRequestorComments : Migration
+    {
+        public override void Up()
+        {
+            // Preserve the originals before touching anything.
+            Sql( @"
+                IF OBJECT_ID( '_org_secc_ChangeManager_ChangeRequestCommentBackup' ) IS NULL
+                BEGIN
+                    CREATE TABLE [_org_secc_ChangeManager_ChangeRequestCommentBackup] (
+                        [ChangeRequestId] INT NOT NULL
+                            CONSTRAINT [PK__org_secc_ChangeManager_ChangeRequestCommentBackup] PRIMARY KEY,
+                        [RequestorComment] NVARCHAR(MAX) NULL,
+                        [BackedUpDateTime] DATETIME NOT NULL
+                            CONSTRAINT [DF__org_secc_ChangeManager_ChangeRequestCommentBackup_BackedUpDateTime] DEFAULT ( GETDATE() )
+                    );
+
+                    INSERT INTO [_org_secc_ChangeManager_ChangeRequestCommentBackup] ( [ChangeRequestId], [RequestorComment] )
+                    SELECT [Id], [RequestorComment]
+                    FROM [_org_secc_ChangeManager_ChangeRequest]
+                    WHERE [RequestorComment] IS NOT NULL;
+                END
+" );
+
+            // Whitespace-only comments become empty, so the detail block's
+            // IsNotNullOrWhiteSpace() guard keeps hiding them once line breaks turn into
+            // <br> below. Run this before the encode so it sees the raw whitespace.
+            Sql( @"
+                UPDATE [_org_secc_ChangeManager_ChangeRequest]
+                SET [RequestorComment] = ''
+                WHERE [RequestorComment] IS NOT NULL
+                    AND LTRIM( RTRIM( REPLACE( REPLACE( REPLACE( [RequestorComment], CHAR(13), ' ' ), CHAR(10), ' ' ), CHAR(9), ' ' ) ) ) = '';
+" );
+
+            // Mirror EncodeHtml().ConvertCrLfToHtmlBr(). The ampersand must be replaced
+            // first or the entities introduced by the later replacements get re-encoded,
+            // and the <br> substitution must come last or its angle brackets get encoded.
+            // HttpUtility.HtmlEncode also emits numeric entities for some characters above
+            // ASCII; those render identically either way, so they are left alone here.
+            Sql( @"
+                UPDATE [_org_secc_ChangeManager_ChangeRequest]
+                SET [RequestorComment] =
+                    REPLACE(
+                        REPLACE(
+                            REPLACE(
+                                REPLACE(
+                                    REPLACE(
+                                        REPLACE(
+                                            REPLACE( [RequestorComment], '&', '&amp;' ),
+                                        '<', '&lt;' ),
+                                    '>', '&gt;' ),
+                                '""', '&quot;' ),
+                            '''', '&#39;' ),
+                        CHAR(13) + CHAR(10), '<br>' ),
+                    CHAR(10), '<br>' )
+                WHERE [RequestorComment] IS NOT NULL
+                    AND [RequestorComment] <> '';
+" );
+        }
+
+        public override void Down()
+        {
+            Sql( @"
+                IF OBJECT_ID( '_org_secc_ChangeManager_ChangeRequestCommentBackup' ) IS NOT NULL
+                BEGIN
+                    UPDATE cr
+                    SET cr.[RequestorComment] = b.[RequestorComment]
+                    FROM [_org_secc_ChangeManager_ChangeRequest] cr
+                    INNER JOIN [_org_secc_ChangeManager_ChangeRequestCommentBackup] b
+                        ON b.[ChangeRequestId] = cr.[Id];
+
+                    DROP TABLE [_org_secc_ChangeManager_ChangeRequestCommentBackup];
+                END
+" );
+        }
+    }
+}

--- a/Plugins/org.secc.ChangeManager/org.secc.ChangeManager.csproj
+++ b/Plugins/org.secc.ChangeManager/org.secc.ChangeManager.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Migrations\002_FamilyGroupOfPerson.cs" />
     <Compile Include="Migrations\001_Init.cs" />
     <Compile Include="Migrations\003_InternalCampusTypeValue.cs" />
+    <Compile Include="Migrations\004_EncodeStoredRequestorComments.cs" />
     <Compile Include="Migrations\Configuration.cs" />
     <Compile Include="Model\BasicEntity.cs" />
     <Compile Include="Model\ChangeRequestService.cs" />

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/CMPublicProfileEdit.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/CMPublicProfileEdit.ascx.cs
@@ -516,7 +516,9 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
                 if ( changeRequest.ChangeRecords.Any()
                 || ( !familyChangeRequest.ChangeRecords.Any() && tbComments.Text.IsNotNullOrWhiteSpace() ) )
                 {
-                    changeRequest.RequestorComment = tbComments.Text;
+                    // RequestorComment is stored as trusted HTML (see ChangeRequestDetail),
+                    // so user-supplied text must be encoded before it goes in.
+                    changeRequest.RequestorComment = tbComments.Text.Trim().EncodeHtml().ConvertCrLfToHtmlBr();
                     ChangeRequestService changeRequestService = new ChangeRequestService( rockContext );
                     changeRequestService.Add( changeRequest );
                     rockContext.SaveChanges();
@@ -526,7 +528,7 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
 
                 if ( familyChangeRequest.ChangeRecords.Any() )
                 {
-                    familyChangeRequest.RequestorComment = tbComments.Text;
+                    familyChangeRequest.RequestorComment = tbComments.Text.Trim().EncodeHtml().ConvertCrLfToHtmlBr();
                     ChangeRequestService changeRequestService = new ChangeRequestService( rockContext );
                     changeRequestService.Add( familyChangeRequest );
                     rockContext.SaveChanges();
@@ -636,7 +638,7 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
 
                 if ( tbComments.Text.IsNotNullOrWhiteSpace() )
                 {
-                    changeRequest.RequestorComment += "<br><br>Comment: " + tbComments.Text;
+                    changeRequest.RequestorComment += "<br><br>Comment: " + tbComments.Text.Trim().EncodeHtml().ConvertCrLfToHtmlBr();
                 }
 
                 ChangeRequestService changeRequestService = new ChangeRequestService( rockContext );

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/CMPublicProfileRemovePerson.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/CMPublicProfileRemovePerson.ascx.cs
@@ -216,7 +216,9 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
                     EntityTypeId = EntityTypeCache.Get( typeof( Group ) ).Id,
                     EntityId = sharedFamily.Id,
                     RequestorAliasId = CurrentPersonAliasId.Value,
-                    RequestorComment = tbAdditionalInfo.Text.Trim(),
+                    // RequestorComment is stored as trusted HTML (see ChangeRequestDetail),
+                    // so user-supplied text must be encoded before it goes in.
+                    RequestorComment = tbAdditionalInfo.Text.Trim().EncodeHtml().ConvertCrLfToHtmlBr(),
                     ChangeRecords = new List<ChangeRecord>()
                 };
 

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeEntry.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeEntry.ascx.cs
@@ -337,7 +337,7 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
 
                         if ( hfPhoneType.Value.AsInteger() == DefinedValueCache.GetId( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_MOBILE.AsGuid() ) )
                         {
-                            var validationInfo = ValidateMobilePhoneNumber( PhoneNumber.CleanNumber( pnbPhone.Number ), true );
+                            var validationInfo = ValidateMobilePhoneNumber( PhoneNumber.CleanNumber( pnbPhone.Number ) );
                             if ( validationInfo.IsNotNullOrWhiteSpace() )
                             {
                                 changeRequest.RequestorComment += "<h4>Dynamically Generated Warnings:</h4>" + validationInfo;
@@ -611,8 +611,7 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
             {
 
                 var number = PhoneNumber.CleanNumber( tbPhone.Text );
-                // ModalAlert.Show escapes the message itself, so names go in unencoded here.
-                string validationInformation = ValidateMobilePhoneNumber( number, false );
+                string validationInformation = ValidateMobilePhoneNumber( number );
 
                 if ( validationInformation.IsNotNullOrWhiteSpace() )
                 {
@@ -623,16 +622,12 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
 
         /// <summary>
         /// Builds the duplicate-mobile-number warning as HTML, or an empty string when no
-        /// other record has the number.
+        /// other record has the number. Both consumers render it as HTML (RequestorComment
+        /// is trusted HTML, and ModalAlert.Show sanitizes but does not encode), so the
+        /// person names interpolated into the markup are always encoded.
         /// </summary>
         /// <param name="number">The cleaned mobile number.</param>
-        /// <param name="encodePersonNames">
-        /// Whether to encode the person names interpolated into the markup. Pass true when
-        /// the notice is persisted to RequestorComment, which is rendered as trusted HTML.
-        /// Pass false for ModalAlert.Show, which escapes the whole message itself and would
-        /// otherwise double-escape names containing characters like &amp;.
-        /// </param>
-        private string ValidateMobilePhoneNumber( string number, bool encodePersonNames )
+        private string ValidateMobilePhoneNumber( string number )
         {
             var person = GetPerson();
             RockContext rockContext = new RockContext();
@@ -647,16 +642,14 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
             if ( otherOwners.Any() )
             {
                 // This notice is intentional HTML. Person names are free text, so they are
-                // encoded when the caller is going to persist the notice as trusted HTML.
-                Func<string, string> nameText = n => encodePersonNames ? n.EncodeHtml() : n;
-
+                // always encoded before being interpolated into the markup.
                 var notice = string.Format(
                     "The phone number {0} is on the following records." +
                     "<ul>{1}</ul>" +
                     "Mobile phone numbers should exist on one record only. Please ensure that {0} belongs to {2} and remove this number from all other users.",
                     PhoneNumber.FormattedNumber( PhoneNumber.DefaultCountryCode(), number ),
-                    string.Join( "", otherOwners.Select( p => "<li><a href='/Person/" + p.Id.ToString() + "' target='_blank'>" + nameText( p.FullName ) + "</a></li>" ) ),
-                    nameText( person.FullName )
+                    string.Join( "", otherOwners.Select( p => "<li><a href='/Person/" + p.Id.ToString() + "' target='_blank'>" + p.FullName.EncodeHtml() + "</a></li>" ) ),
+                    person.FullName.EncodeHtml()
                     );
                 return notice;
             }

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeEntry.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeEntry.ascx.cs
@@ -240,7 +240,9 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
                 EntityTypeId = personAliasEntityType.Id,
                 EntityId = person.PrimaryAliasId ?? 0,
                 RequestorAliasId = CurrentPersonAliasId ?? 0,
-                RequestorComment = tbComments.Text
+                // RequestorComment is stored as trusted HTML (see ChangeRequestDetail),
+                // so user-supplied text must be encoded before it goes in.
+                RequestorComment = tbComments.Text.Trim().EncodeHtml().ConvertCrLfToHtmlBr()
             };
 
             changeRequest.EvaluatePropertyChange( person, "PhotoId", iuPhoto.BinaryFileId );
@@ -335,7 +337,7 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
 
                         if ( hfPhoneType.Value.AsInteger() == DefinedValueCache.GetId( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_MOBILE.AsGuid() ) )
                         {
-                            var validationInfo = ValidateMobilePhoneNumber( PhoneNumber.CleanNumber( pnbPhone.Number ) );
+                            var validationInfo = ValidateMobilePhoneNumber( PhoneNumber.CleanNumber( pnbPhone.Number ), true );
                             if ( validationInfo.IsNotNullOrWhiteSpace() )
                             {
                                 changeRequest.RequestorComment += "<h4>Dynamically Generated Warnings:</h4>" + validationInfo;
@@ -511,7 +513,7 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
 
             if ( familyChangeRequest.ChangeRecords.Any() )
             {
-                familyChangeRequest.RequestorComment = tbComments.Text;
+                familyChangeRequest.RequestorComment = tbComments.Text.Trim().EncodeHtml().ConvertCrLfToHtmlBr();
                 ChangeRequestService changeRequestService = new ChangeRequestService( rockContext );
                 changeRequestService.Add( familyChangeRequest );
                 rockContext.SaveChanges();
@@ -609,7 +611,8 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
             {
 
                 var number = PhoneNumber.CleanNumber( tbPhone.Text );
-                string validationInformation = ValidateMobilePhoneNumber( number );
+                // ModalAlert.Show escapes the message itself, so names go in unencoded here.
+                string validationInformation = ValidateMobilePhoneNumber( number, false );
 
                 if ( validationInformation.IsNotNullOrWhiteSpace() )
                 {
@@ -618,7 +621,18 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
             }
         }
 
-        private string ValidateMobilePhoneNumber( string number )
+        /// <summary>
+        /// Builds the duplicate-mobile-number warning as HTML, or an empty string when no
+        /// other record has the number.
+        /// </summary>
+        /// <param name="number">The cleaned mobile number.</param>
+        /// <param name="encodePersonNames">
+        /// Whether to encode the person names interpolated into the markup. Pass true when
+        /// the notice is persisted to RequestorComment, which is rendered as trusted HTML.
+        /// Pass false for ModalAlert.Show, which escapes the whole message itself and would
+        /// otherwise double-escape names containing characters like &amp;.
+        /// </param>
+        private string ValidateMobilePhoneNumber( string number, bool encodePersonNames )
         {
             var person = GetPerson();
             RockContext rockContext = new RockContext();
@@ -632,13 +646,17 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
 
             if ( otherOwners.Any() )
             {
+                // This notice is intentional HTML. Person names are free text, so they are
+                // encoded when the caller is going to persist the notice as trusted HTML.
+                Func<string, string> nameText = n => encodePersonNames ? n.EncodeHtml() : n;
+
                 var notice = string.Format(
                     "The phone number {0} is on the following records." +
                     "<ul>{1}</ul>" +
                     "Mobile phone numbers should exist on one record only. Please ensure that {0} belongs to {2} and remove this number from all other users.",
                     PhoneNumber.FormattedNumber( PhoneNumber.DefaultCountryCode(), number ),
-                    string.Join( "", otherOwners.Select( p => "<li><a href='/Person/" + p.Id.ToString() + "' target='_blank'>" + p.FullName + "</a></li>" ) ),
-                    person.FullName
+                    string.Join( "", otherOwners.Select( p => "<li><a href='/Person/" + p.Id.ToString() + "' target='_blank'>" + nameText( p.FullName ) + "</a></li>" ) ),
+                    nameText( person.FullName )
                     );
                 return notice;
             }
@@ -655,7 +673,7 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
                 EntityTypeId = personAliasEntityType.Id,
                 EntityId = person.PrimaryAliasId ?? 0,
                 RequestorAliasId = CurrentPersonAliasId ?? 0,
-                RequestorComment = tbSimpleRequest.Text
+                RequestorComment = tbSimpleRequest.Text.Trim().EncodeHtml().ConvertCrLfToHtmlBr()
             };
 
             ChangeRequestService changeRequestService = new ChangeRequestService( rockContext );

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequestDetail.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequestDetail.ascx.cs
@@ -126,10 +126,19 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
             if ( changeRequest.RequestorComment.IsNotNullOrWhiteSpace() )
             {
                 ltRequestComments.Visible = true;
-                ltRequestComments.Text = System.Web.HttpUtility.HtmlEncode( changeRequest.RequestorComment );
+
+                // RequestorComment is trusted HTML: the blocks that write it compose
+                // system-generated markup (the dynamically generated phone warnings, the
+                // "Comment:" separator) with user text that they encode at that point.
+                // Do not encode here or that markup renders literally (ROCK-8879).
+                // Comments stored before ROCK-8879 were never encoded, so any raw markup
+                // in historical rows still renders as markup.
+                ltRequestComments.Text = changeRequest.RequestorComment;
             }
 
-            ltApproverComment.Text = System.Web.HttpUtility.HtmlEncode( changeRequest.ApproverComment );
+            // ApproverComment is plain text straight from tbApproverComment, so it is
+            // encoded here rather than at the write site.
+            ltApproverComment.Text = changeRequest.ApproverComment.EncodeHtml().ConvertCrLfToHtmlBr();
             tbApproverComment.Text = changeRequest.ApproverComment;
 
             if ( !IsUserAuthorized( Rock.Security.Authorization.EDIT ) )

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequestDetail.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequestDetail.ascx.cs
@@ -131,8 +131,9 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
                 // system-generated markup (the dynamically generated phone warnings, the
                 // "Comment:" separator) with user text that they encode at that point.
                 // Do not encode here or that markup renders literally (ROCK-8879).
-                // Comments stored before ROCK-8879 were never encoded, so any raw markup
-                // in historical rows still renders as markup.
+                // Comments stored before ROCK-8879 were encoded by plugin migration 004
+                // (which also restores the known system-generated fragments), so stored
+                // values are uniformly safe to render without encoding.
                 ltRequestComments.Text = changeRequest.RequestorComment;
             }
 

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequests.ascx
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequests.ascx
@@ -7,7 +7,13 @@
         </Rock:GridFilter>
         <Rock:Grid runat="server" ID="gRequests" DataKeyNames="Id" OnRowSelected="gRequests_RowSelected">
             <Columns>
-                <Rock:RockBoundField HeaderText="Entity Name" DataField="Name" HtmlEncode="false" />
+                <%-- The icon gets its own template column (not included in the Excel export)
+                     so the Entity Name column can keep the grid's default HTML encoding and
+                     export the raw name. --%>
+                <Rock:RockTemplateField HeaderText="" ItemStyle-Wrap="false">
+                    <ItemTemplate><%# Eval( "Icon" ) %></ItemTemplate>
+                </Rock:RockTemplateField>
+                <Rock:RockBoundField HeaderText="Entity Name" DataField="Name" />
                 <Rock:RockBoundField HeaderText="Entity Type" DataField="EntityType" />
                 <Rock:RockBoundField HeaderText="Requestor" DataField="Requestor" />
                 <Rock:DateTimeField HeaderText="Requested" DataField="Requested" />

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequests.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequests.ascx.cs
@@ -110,17 +110,15 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
                  }
             ).ToList();
 
-            // The Entity Name column renders with HtmlEncode="false" so the warning icon
-            // below is markup, which means the name itself has to be encoded here.
-            // ChangeRequest.Name comes from the target entity's ToString(); for family
-            // Groups that is the group name, which is built from user-entered last names.
+            // The warning icon renders in its own template column so the Entity Name
+            // column keeps the grid's default HTML encoding (ChangeRequest.Name comes from
+            // the target entity's ToString(), which can contain user-entered text) and the
+            // Excel export gets the un-mangled name.
             foreach ( var request in requests )
             {
-                request.Name = request.Name.EncodeHtml();
-
                 if ( request.Applied == false && request.WasReviewed == false )
                 {
-                    request.Name = "<i class='fa fa-exclamation-triangle'></i> " + request.Name;
+                    request.Icon = "<i class='fa fa-exclamation-triangle'></i>";
                 }
             }
 
@@ -148,6 +146,7 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
         {
             public int Id { get; set; }
             public string Name { get; set; }
+            public string Icon { get; set; }
             private string entityType = "";
             public string EntityType
             {

--- a/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequests.ascx.cs
+++ b/Plugins/org.secc.ChangeManager/org_secc/ChangeManager/ChangeRequests.ascx.cs
@@ -110,8 +110,14 @@ namespace RockWeb.Plugins.org_secc.ChangeManager
                  }
             ).ToList();
 
+            // The Entity Name column renders with HtmlEncode="false" so the warning icon
+            // below is markup, which means the name itself has to be encoded here.
+            // ChangeRequest.Name comes from the target entity's ToString(); for family
+            // Groups that is the group name, which is built from user-entered last names.
             foreach ( var request in requests )
             {
+                request.Name = request.Name.EncodeHtml();
+
                 if ( request.Applied == false && request.WasReviewed == false )
                 {
                     request.Name = "<i class='fa fa-exclamation-triangle'></i> " + request.Name;


### PR DESCRIPTION
Fixes [ROCK-8879](https://seccdev.atlassian.net/browse/ROCK-8879) · Freshservice [INC-13831](https://southeastchristianchurch.freshservice.com/a/tickets/13831)

## What was broken

Bob reported that the duplicate-mobile-number warning on a profile change request had
stopped rendering — the approver saw raw markup instead of the clickable person links that
used to be there:

```
<h4>Dynamically Generated Warnings:</h4>The phone number (XXX) XXX-XXXX is on the
following records.<ul><li><a href='/Person/XXXXXX' target='_blank'>Jane Doe</a>...
```

This is a regression from our own XSS fix. ROCK-8638 (`ea9c4067`) added a blanket
`HttpUtility.HtmlEncode` to `ltRequestComments` in `ChangeRequestDetail.ascx.cs`.
`RockLiteral` inherits `Literal` with `Mode = Transform`, so that encode is load-bearing for
security — but `RequestorComment` holds a **mix** of plain requestor text and hand-built
markup concatenated at write time, so encoding the whole field at render time also
neutralized the intentional markup. Two write sites produce that markup:

- `ChangeEntry.ascx.cs` → `ValidateMobilePhoneNumber` — the `<h4>`/`<ul>`/`<li>`/`<a>` warning
- `CMPublicProfileEdit.ascx.cs` — the `<br><br>Comment: ` separator

A straight revert was not an option: `CMPublicProfileEdit` is a public-facing block, so
un-encoding at render would reopen the stored XSS ROCK-8638 closed.

## Approach

**Invert where encoding happens. `RequestorComment` is trusted HTML, encoded at every write
site, never at render.** Render time cannot distinguish system markup from user text, so the
decision moves to the point of composition, where the two are still separable.

## Commits

**`042d3e8d` — the display regression**

- All six requestor-text write sites across `ChangeEntry`, `CMPublicProfileEdit` and
  `CMPublicProfileRemovePerson` now run user input through
  `.Trim().EncodeHtml().ConvertCrLfToHtmlBr()`. Multi-line comments keep their line breaks,
  which they lost even before ROCK-8638. The `.Trim()` stops a whitespace-only comment from
  becoming `<br><br>` and rendering an empty comment block.
- `ValidateMobilePhoneNumber` takes an `encodePersonNames` flag and encodes the person names
  it interpolates into its `<li><a>` markup. **This closes a second-order injection that
  predates ROCK-8638** — person names are free text via the public profile block, and they
  were being persisted into `RequestorComment` as markup.
- `ChangeRequestDetail` renders `RequestorComment` raw again, with a comment recording the
  invariant. `ApproverComment` stays encoded at render since it is plain textarea input, and
  now converts line breaks too.

**`bcc7f4c0` — a second sink ROCK-8638 missed**

`ChangeRequests.ascx` renders `DataField="Name"` with `HtmlEncode="false"` so the block can
prepend a warning icon, but the name itself was never encoded. `ChangeRequest.Name` is
assigned in `PreSaveChanges` from the target entity's `ToString()`; for family Group requests
that resolves to `Group.Name`, which is built from user-entered last names. ROCK-8638
encoded this value in the detail header but not in the list block. Now encoded before the
icon is prepended.

**`3f67ba67` — migration 004, the stored rows**

Removing the render-time encode without touching the data would re-arm every row already in
the table. Encoding happened at render under ROCK-8638, so **no write site has ever encoded**
— every existing `RequestorComment` is raw, not just the pre-ROCK-8638 ones. A profile-change
comment containing an `img`/`onerror` payload would execute in an approver's session, and
completed requests stay visible in the list block indefinitely.

`Migrations/004_EncodeStoredRequestorComments.cs` encodes every existing row and converts its
line breaks, mirroring what the write sites now do. Originals are copied to
`_org_secc_ChangeManager_ChangeRequestCommentBackup` first, so `Down()` restores exactly and
the change stays auditable; drop that table once results are spot-checked.

## ⚠️ Deploy ordering

**The migration must ship in the same deploy as the block changes.** It assumes every stored
comment is unencoded, which stops being true the moment the new write sites go live. A Rock
plugin migration is the right vehicle because it runs at app startup before any new comment
can be written, and `PluginMigration` guarantees exactly-once so restarts cannot
double-encode.

Do not run the migration SQL by hand on a database where migration 4 is already recorded —
`Up()` is not idempotent, and a second pass turns `&amp;` into `&amp;amp;`.

## Review notes

Two ordering constraints in the migration's nested `REPLACE` chain are load-bearing, and
getting either wrong produces plausible-looking output:

- `&` must be replaced first, or the entities introduced by the later replacements get
  re-encoded.
- The `<br>` substitution must come last, or its angle brackets get encoded.

I verified the chain against `HttpUtility.HtmlEncode` + `ConvertCrLfToHtmlBr` on 11 inputs —
ampersands, angle brackets, both quote styles, CRLF, bare LF, lone CR, an `img`/`onerror`
payload, whitespace-only, empty, and the ticket's own warning markup. Zero divergence.
Characters above ASCII are deliberately left alone; `HtmlEncode` emits numeric entities for
some, but both forms render identically.

The `encodePersonNames: false` argument at the modal call site is intentional and worth a
close look. `ModalAlert.Show` runs its message through `SanitizeHtml`, which round-trips via
`XmlTextWriter` and re-escapes ampersands — passing pre-encoded HTML there would show
`Smith &amp; Jones` in the modal. The persisted path passes `true`, the modal passes `false`.

I also considered wrapping the render in `SanitizeHtml(false)` for defense in depth and
rejected it: the same `XmlTextWriter` round-trip would reintroduce a display bug of exactly
the shape this PR fixes.

The invariant is now enforced by convention plus code comments across four files, with no
chokepoint. **Any new code writing `RequestorComment` must encode at the write site.** Worth
discussing whether a `SetRequestorComment(string userText)` helper on the model is warranted.

## Testing status

This has been tested against dev database.

## Known follow-up (not in this PR)

The list block's Excel export uses `ExportSource = DataSource`, so an exported entity name
containing `&` now shows `&amp;`. The `<i>` icon markup already leaked into the export before
this change. The proper fix is moving the icon to a `RockTemplateField` and dropping
`HtmlEncode="false"`, which resolves both and removes the need for the manual encode. Noted in
`bcc7f4c0`'s commit message.

🤖 Generated with help from [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnyxtoVWCf4j2BbMR8w7sq

[ROCK-8879]: https://seccdev.atlassian.net/browse/ROCK-8879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ