### PR TITLE
ROCK-8880 Replace LinkList HTML blacklist sanitizer with an allowlist

### DIFF
--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/LinkListHtmlSanitizerTests.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/LinkListHtmlSanitizerTests.cs
@@ -1050,5 +1050,396 @@ namespace org.secc.LinkList.Tests
                 "<p style=\"background-color: \\75 rl(//evil/x)\">y</p>" );
             Assert.Contains( "background-color: \\75 rl(//evil/x)", result );
         }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 5 — reverse tabnabbing (`target` kept, `rel` stripped).
+        //
+        // `target` is allowlisted on <a> but `rel` is on NO allowlist, so before this
+        // fix the sanitizer kept `target="_blank"` while actively STRIPPING an
+        // author's `rel="noopener noreferrer"` — removing the mitigation and leaving
+        // no way for an editor to add it back, since this sanitizer is the single
+        // chokepoint. `rel` is now force-injected whenever `target` survives.
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public void Target_Blank_Link_Gets_Noopener_Noreferrer()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<a href=\"https://example.org\" target=\"_blank\">go</a>" );
+
+            Assert.Contains( "rel=\"noopener noreferrer\"", result );
+            Assert.Contains( "target=\"_blank\"", result );
+            Assert.Contains( "https://example.org", result );
+        }
+
+        [Theory]
+        [InlineData( "_blank" )]
+        [InlineData( "_new" )]
+        [InlineData( "someWindowName" )]
+        public void Any_Surviving_Target_Value_Gets_The_Guard( string target )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<a href=\"https://example.org\" target=\"" + target + "\">go</a>" );
+
+            Assert.Contains( "rel=\"noopener noreferrer\"", result );
+        }
+
+        [Fact]
+        public void Author_Rel_Is_Replaced_Not_Appended()
+        {
+            // The author value is stripped (rel is on no allowlist) and ours is
+            // injected — there must be exactly one rel, carrying our value.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<a href=\"https://example.org\" target=\"_blank\" rel=\"nofollow\">go</a>" );
+
+            Assert.DoesNotContain( "nofollow", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "rel=\"noopener noreferrer\"", result );
+            Assert.Equal( 1, CountOccurrences( result, "rel=" ) );
+        }
+
+        [Fact]
+        public void Author_Rel_Is_Stripped_When_There_Is_No_Target()
+        {
+            // No target means no tabnabbing exposure, so no guard is injected — and
+            // the author's rel is still stripped, as a non-allowlisted attribute.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<a href=\"https://example.org\" rel=\"nofollow\">go</a>" );
+
+            Assert.DoesNotContain( "rel=", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "https://example.org", result );
+        }
+
+        [Fact]
+        public void Link_Without_Target_Gets_No_Rel()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<a href=\"https://example.org\">go</a>" );
+
+            Assert.DoesNotContain( "rel=", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Fact]
+        public void Target_On_A_Dropped_Href_Still_Gets_The_Guard()
+        {
+            // The javascript: href is removed but the element (and its target)
+            // survive, so the guard must still be applied.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<a href=\"javascript:alert(1)\" target=\"_blank\">go</a>" );
+
+            Assert.DoesNotContain( "javascript:", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "rel=\"noopener noreferrer\"", result );
+        }
+
+        [Fact]
+        public void Target_Attribute_On_Non_Anchor_Does_Not_Inject_Rel()
+        {
+            // target is not allowlisted on <p>, so it is stripped and nothing is
+            // injected — the guard must key off a target that actually SURVIVED.
+            var result = LinkListHtmlSanitizer.Sanitize( "<p target=\"_blank\">x</p>" );
+
+            Assert.DoesNotContain( "target=", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "rel=", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Fact]
+        public void Injected_Rel_Is_Idempotent()
+        {
+            // Second pass strips the rel we injected (non-allowlisted) and re-injects
+            // it in the same trailing position — the bytes must not drift.
+            const string input = "<a href=\"https://example.org\" target=\"_blank\">go</a>";
+            var once = LinkListHtmlSanitizer.Sanitize( input );
+            var twice = LinkListHtmlSanitizer.Sanitize( once );
+
+            Assert.Equal( once, twice );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 5 — bare '<' in text destroyed the rest of the block.
+        //
+        // HAP parses `<p>Ages < 12 welcome</p>` as <p> + text "Ages " + an element
+        // with an EMPTY NAME whose swallowed words become ATTRIBUTES (`12=""`,
+        // `welcome=""`). The empty name is on neither allowlist, so Clean() unwraps
+        // it; Unwrap moves only ChildNodes, of which it has none, so the node and the
+        // words held in its attributes were DISCARDED. Bare '<' is now escaped before
+        // parsing, matching the HTML5 tokenizer's tag-open rule.
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public void Bare_LessThan_Does_Not_Eat_The_Rest_Of_The_Text()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<p>Ages < 12 welcome</p>" );
+
+            Assert.Contains( "12", result );
+            Assert.Contains( "welcome", result );
+            Assert.Contains( "Ages", result );
+            // The words must be TEXT, not an attribute soup like `12=""`.
+            Assert.DoesNotContain( "12=", result );
+            Assert.DoesNotContain( "welcome=", result );
+        }
+
+        [Fact]
+        public void Bare_LessThan_And_GreaterThan_Both_Survive_As_Text()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<p>3 < 4 and 5 > 2</p>" );
+
+            Assert.Contains( "4", result );
+            Assert.Contains( "2", result );
+            Assert.Contains( "and", result );
+        }
+
+        [Theory]
+        [InlineData( "<p>Cost < $5 per person</p>", "$5 per person" )]
+        [InlineData( "<p>a<3 forever</p>", "3 forever" )]
+        [InlineData( "<p>x < y</p>", "y" )]
+        public void Bare_LessThan_Real_Copy_Keeps_Its_Remainder( string input, string mustSurvive )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( input );
+
+            Assert.Contains( mustSurvive, result );
+        }
+
+        [Fact]
+        public void Trailing_LessThan_Does_Not_Throw_Or_Truncate()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<p>ends with <" );
+
+            Assert.Contains( "ends with", result );
+        }
+
+        [Fact]
+        public void Bare_LessThan_Is_Idempotent()
+        {
+            const string input = "<p>Ages < 12 welcome</p>";
+            var once = LinkListHtmlSanitizer.Sanitize( input );
+            var twice = LinkListHtmlSanitizer.Sanitize( once );
+
+            Assert.Equal( once, twice );
+        }
+
+        // The pre-parse escape must not defang tag detection: '<' followed by a
+        // letter, '/', '!' or '?' still opens markup, so comments, end tags and
+        // dangerous elements are all handled exactly as before.
+
+        [Fact]
+        public void LessThan_Escape_Does_Not_Break_Comment_Stripping()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<p>a<!-- secret comment -->b</p>" );
+
+            Assert.DoesNotContain( "secret", result );
+            Assert.DoesNotContain( "<!--", result );
+        }
+
+        [Fact]
+        public void LessThan_Escape_Does_Not_Break_End_Tag_Parsing()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<p>one</p><p>two</p>" );
+
+            Assert.Contains( "one", result );
+            Assert.Contains( "two", result );
+            Assert.Equal( 2, CountOccurrences( result.ToLowerInvariant(), "<p" ) );
+        }
+
+        [Fact]
+        public void LessThan_Escape_Does_Not_Break_Dangerous_Tag_Removal()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<p>a</p><script>alert(1)</script>" );
+
+            Assert.DoesNotContain( "<script", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "alert(1)", result );
+        }
+
+        [Fact]
+        public void LessThan_Escape_Does_Not_Reopen_The_Mxss_Breakout()
+        {
+            // A bare '<' alongside the smuggled-quote payload must not produce a live
+            // handler; the escape runs before parsing, so the mXSS gate still applies.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p>3 < 4</p><img src=x alt=a\"onerror=\"alert(1)>" );
+
+            Assert.DoesNotContain( "onerror=\"alert(1)\"", result );
+            Assert.Contains( "4", result );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 5 — allowlist gaps that silently dropped prod markup.
+        //
+        // Under an allowlist, anything omitted disappears: a missing ATTRIBUTE is
+        // stripped, and a missing TAG is unwrapped, which takes the `class` that
+        // scoped its CSS with it.
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public void Legacy_Bgcolor_Survives_On_Table_And_Cell()
+        {
+            // The email builder paints backgrounds with the bgcolor ATTRIBUTE
+            // (email clients strip <style>), so dropping it renders blocks white.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<table bgcolor=\"#ffffff\"><tr><td bgcolor=\"#eeeeee\">x</td></tr></table>" );
+
+            Assert.Contains( "bgcolor=\"#ffffff\"", result );
+            Assert.Contains( "bgcolor=\"#eeeeee\"", result );
+        }
+
+        [Fact]
+        public void Legacy_Nowrap_Survives_On_Cell()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<table><tr><td nowrap>x</td></tr></table>" );
+
+            Assert.Contains( "nowrap", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Theory]
+        [InlineData( "section" )]
+        [InlineData( "article" )]
+        [InlineData( "header" )]
+        [InlineData( "footer" )]
+        [InlineData( "nav" )]
+        [InlineData( "figure" )]
+        [InlineData( "pre" )]
+        [InlineData( "code" )]
+        [InlineData( "small" )]
+        [InlineData( "label" )]
+        [InlineData( "dl" )]
+        public void Class_Bearing_Wrapper_Survives_With_Its_Class( string tag )
+        {
+            // Unwrapping the wrapper drops the class that scopes its CSS — which
+            // would defeat the whole reason `class` is allowlisted.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<" + tag + " class=\"esd-block\"><p>copy</p></" + tag + ">" );
+
+            Assert.Contains( "<" + tag, result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "class=\"esd-block\"", result );
+            Assert.Contains( "copy", result );
+        }
+
+        [Fact]
+        public void Definition_List_Structure_Survives()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<dl><dt>Term</dt><dd>Def</dd></dl>" );
+
+            Assert.Contains( "<dt", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "<dd", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "Term", result );
+            Assert.Contains( "Def", result );
+        }
+
+        [Fact]
+        public void Table_Caption_Stays_Inside_The_Table()
+        {
+            // Unwrapping <caption> leaves a bare text node in <table>, which a
+            // browser's "in table" insertion mode foster-parents OUT of the table —
+            // the caption would render above it as loose body text.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<table><caption>Cap</caption><tr><td>B</td></tr></table>" );
+
+            Assert.Contains( "<caption", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "Cap", result );
+        }
+
+        [Fact]
+        public void Table_Head_And_Foot_Groupings_Survive()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>B</td></tr></tbody>"
+                + "<tfoot><tr><td>F</td></tr></tfoot></table>" );
+
+            Assert.Contains( "<thead", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "<tfoot", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "<tbody", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Fact]
+        public void Colgroup_Survives_With_Its_Span_Attribute()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<table><colgroup span=\"2\"><col span=\"1\"></colgroup><tr><td>x</td></tr></table>" );
+
+            Assert.Contains( "<colgroup", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "span=\"2\"", result );
+        }
+
+        [Fact]
+        public void Span_Attribute_Does_Not_Leak_Onto_Other_Tags()
+        {
+            // `span` is per-tag (col/colgroup), not global.
+            var result = LinkListHtmlSanitizer.Sanitize( "<p span=\"2\">x</p>" );
+
+            Assert.DoesNotContain( "span=", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Fact]
+        public void Newly_Allowed_Tags_Still_Have_Attributes_Filtered()
+        {
+            // Allowlisting a TAG must not allowlist anything on it.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<section onclick=\"alert(1)\" data-x=\"1\" class=\"keep\">y</section>" );
+
+            Assert.DoesNotContain( "onclick", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "data-x", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "class=\"keep\"", result );
+        }
+
+        [Fact]
+        public void Still_Unlisted_Benign_Tag_Is_Still_Unwrapped()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<p>a <marquee>scroll</marquee> b</p>" );
+
+            Assert.DoesNotContain( "<marquee", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "scroll", result );
+        }
+
+        [Fact]
+        public void Round5_Additions_Are_Idempotent()
+        {
+            const string input =
+                "<section class=\"esd-block\"><table bgcolor=\"#ffffff\"><caption>Cap</caption>"
+                + "<thead><tr><th nowrap>H</th></tr></thead><tbody><tr><td bgcolor=\"#eee\">"
+                + "<a href=\"https://example.org\" target=\"_blank\">go</a></td></tr></tbody>"
+                + "</table><p>Ages < 12 welcome</p></section>";
+            var once = LinkListHtmlSanitizer.Sanitize( input );
+            var twice = LinkListHtmlSanitizer.Sanitize( once );
+
+            Assert.Equal( once, twice );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 5 — pins the "non-element, non-text nodes never reach
+        // the output" claim in Clean().
+        //
+        // HtmlNodeType in HAP 1.4.9.5 has exactly four members (Document, Element,
+        // Comment, Text), so there is no declaration or processing-instruction node
+        // type for Clean() to drop explicitly. Doctypes and `<! ... >` parse as
+        // COMMENT nodes; `<? ... ?>` parses as an ELEMENT named `?` that falls to the
+        // benign-unknown unwrap path. These tests assert none of them are emitted, so
+        // the comment stays honest if a future HAP upgrade changes the parse.
+        // ----------------------------------------------------------------------
+
+        [Theory]
+        [InlineData( "<!DOCTYPE html><p>x</p>", "x" )]
+        [InlineData( "<! foo >x", "x" )]
+        [InlineData( "<? php echo 1 ?>x", "x" )]
+        [InlineData( "<?xml version=\"1.0\"?><p>y</p>", "y" )]
+        public void Declarations_And_Processing_Instructions_Are_Never_Emitted( string input, string mustSurvive )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( input );
+
+            Assert.Contains( mustSurvive, result );
+            Assert.DoesNotContain( "<!", result );
+            Assert.DoesNotContain( "<?", result );
+            Assert.DoesNotContain( "doctype", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "php", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Equal( result, LinkListHtmlSanitizer.Sanitize( result ) );
+        }
+
+        private static int CountOccurrences( string haystack, string needle )
+        {
+            var count = 0;
+            var index = haystack.IndexOf( needle, System.StringComparison.OrdinalIgnoreCase );
+            while ( index >= 0 )
+            {
+                count++;
+                index = haystack.IndexOf( needle, index + needle.Length, System.StringComparison.OrdinalIgnoreCase );
+            }
+            return count;
+        }
     }
 }

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/LinkListHtmlSanitizerTests.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/LinkListHtmlSanitizerTests.cs
@@ -12,6 +12,11 @@
 // limitations under the License.
 // </copyright>
 //
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+
 using org.secc.LinkList.Utility;
 
 using Xunit;
@@ -107,6 +112,943 @@ namespace org.secc.LinkList.Tests
         public void Passes_Through_Null_Or_Empty( string input )
         {
             Assert.Equal( input, LinkListHtmlSanitizer.Sanitize( input ) );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880: allowlist rewrite — new coverage
+        // ----------------------------------------------------------------------
+
+        [Theory]
+        [InlineData( "color: rgb(255,255,255)" )]
+        [InlineData( "text-align: center" )]
+        [InlineData( "width: 50%" )]
+        [InlineData( "font-size: 16px" )]
+        public void Style_Keeps_Allowlisted_Property( string declaration )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( $"<p style=\"{declaration}\">x</p>" );
+            Assert.Contains( declaration, result );
+        }
+
+        [Theory]
+        [InlineData( "position: fixed" )]
+        [InlineData( "z-index: 9999" )]
+        public void Style_Drops_Disallowed_Property( string declaration )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( $"<p style=\"{declaration}\">x</p>" );
+            // The only declaration is disallowed, so the whole style attr goes.
+            Assert.DoesNotContain( "style", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( ">x</p>", result );
+        }
+
+        [Fact]
+        public void Style_Mixed_Keeps_Only_Safe_Declarations()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"color: red; position: fixed; text-align: left\">x</p>" );
+            Assert.Contains( "color: red", result );
+            Assert.Contains( "text-align: left", result );
+            Assert.DoesNotContain( "position", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Theory]
+        [InlineData( "background-color: url(javascript:alert(1))" )]
+        [InlineData( "width: expression(alert(1))" )]
+        public void Style_Rejects_Dangerous_Value_Even_On_Allowed_Property( string declaration )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( $"<p style=\"{declaration}\">x</p>" );
+            Assert.DoesNotContain( "style", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "url(", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "expression(", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Fact]
+        public void Style_Empty_Attribute_Removed()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<p style=\"\">x</p>" );
+            Assert.DoesNotContain( "style", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( ">x</p>", result );
+        }
+
+        [Fact]
+        public void Style_Preserves_Important_On_Allowed_Property()
+        {
+            // Real prod value: line-height: 150% !important
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"line-height: 150% !important\">x</p>" );
+            Assert.Contains( "line-height: 150% !important", result );
+        }
+
+        [Theory]
+        [InlineData( "formaction" )]
+        [InlineData( "poster" )]
+        [InlineData( "background" )]
+        [InlineData( "xlink:href" )]
+        public void Non_Allowlisted_Url_Attribute_Is_Stripped( string attribute )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                $"<img src=\"https://x/y.png\" {attribute}=\"javascript:alert(1)\">" );
+            Assert.DoesNotContain( attribute, result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "javascript", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Theory]
+        [InlineData( "data:text/html,<script>alert(1)</script>" )]
+        [InlineData( "vbscript:msgbox(1)" )]
+        public void Blocks_Data_And_Vbscript_On_Href( string url )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( $"<a href=\"{url}\">x</a>" );
+            Assert.DoesNotContain( "data:", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "vbscript:", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( ">x</a>", result );
+        }
+
+        [Theory]
+        [InlineData( "data:image/png;base64,AAAA" )]
+        [InlineData( "vbscript:msgbox(1)" )]
+        public void Blocks_Data_And_Vbscript_On_Src( string url )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( $"<img src=\"{url}\">" );
+            Assert.DoesNotContain( "data:", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "vbscript:", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Fact]
+        public void Non_Allowlisted_Benign_Tag_Is_Unwrapped_Keeping_Text()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<p>a <marquee>scroll</marquee> b</p>" );
+            Assert.DoesNotContain( "<marquee", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "scroll", result );
+            Assert.Contains( "a ", result );
+            Assert.Contains( " b", result );
+        }
+
+        [Fact]
+        public void Non_Allowlisted_Attribute_Stripped_From_Allowlisted_Tag()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p data-track=\"1\" contenteditable=\"true\" class=\"keep\">x</p>" );
+            Assert.DoesNotContain( "data-track", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "contenteditable", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "class=\"keep\"", result );
+        }
+
+        [Fact]
+        public void Real_Prod_Malformed_Attribute_Soup_Is_Neutralized_And_Idempotent()
+        {
+            // Verbatim from prod item 9644 — mangled span/heading with a broken
+            // style attribute and entity-encoded angle brackets. Must not yield
+            // executable markup, and must be stable under re-sanitizing.
+            const string input =
+                "<h2 style=\"text-align: left;\" class=\"\"><span style=\"color: inherit; font-family: inherit;&gt;Changes to Registration&lt;/span&gt;&lt;/h2&gt;&lt;p style=\" text-align:=\"\" left;\"=\"\">Changes to Registration</span></h2>";
+
+            var once = LinkListHtmlSanitizer.Sanitize( input );
+            var twice = LinkListHtmlSanitizer.Sanitize( once );
+
+            Assert.DoesNotContain( "<script", once, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "javascript", once, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "Changes to Registration", once );
+            Assert.Equal( once, twice );
+        }
+
+        [Fact]
+        public void Fragment_Root_Bare_Td_Survives_With_Structure()
+        {
+            // Prod FooterContent starts at a bare <td>, not a full document.
+            const string input =
+                "<td align=\"center\" class=\"esd-block-image\" style=\"font-size: 0\"><img src=\"https://x/y.png\"></td>";
+            var result = LinkListHtmlSanitizer.Sanitize( input );
+
+            Assert.Contains( "<td", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( "align=\"center\"", result );
+            Assert.Contains( "esd-block-image", result );
+            Assert.Contains( "https://x/y.png", result );
+            // font-size is on the allowlist, so the style survives here.
+            Assert.Contains( "font-size: 0", result );
+        }
+
+        [Fact]
+        public void Html_Comments_Are_Stripped()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<p>a<!-- secret comment -->b</p>" );
+            Assert.DoesNotContain( "<!--", result );
+            Assert.DoesNotContain( "secret", result );
+            Assert.Contains( "a", result );
+            Assert.Contains( "b", result );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 2 — mXSS attribute-boundary breakout (BLOCKER 1)
+        // ----------------------------------------------------------------------
+
+        // Re-tokenization check: RE-PARSE the sanitized output with
+        // HtmlAgilityPack and prove nothing broke out of its attribute. Two
+        // invariants:
+        //   1. No element carries an event-handler (on*) attribute.
+        //   2. No attribute's raw value contains a literal double-quote, which is
+        //      the only character that can terminate a double-quoted value and is
+        //      exactly what an interior-quote breakout leaves behind.
+        // CAVEAT: this re-parses with HtmlAgilityPack - the SAME parser that
+        // produced the output - so it CANNOT detect a HAP-vs-browser tokenizer
+        // differential; it proves the output is self-consistent under HAP, not
+        // that it is browser-equivalent. The blocker-1 closure does not rest on
+        // this test: it holds on HTML-spec grounds (a forced double-quote
+        // delimiter around a value from which literal " < > have been encoded out
+        // cannot be re-tokenized by any conformant parser), which this check
+        // corroborates but does not by itself establish. It still catches the
+        // whole payload class regardless of substring spelling, unlike a naive
+        // DoesNotContain("onerror") check.
+        private static void AssertNoAttributeBreakout( string sanitized )
+        {
+            var doc = new HtmlAgilityPack.HtmlDocument();
+            doc.LoadHtml( sanitized );
+
+            foreach ( var el in doc.DocumentNode.DescendantsAndSelf().Where( n => n.NodeType == HtmlAgilityPack.HtmlNodeType.Element ) )
+            {
+                foreach ( var attr in el.Attributes )
+                {
+                    Assert.False(
+                        attr.Name.StartsWith( "on", System.StringComparison.OrdinalIgnoreCase ),
+                        $"Re-parse found event handler '{attr.Name}' on <{el.Name}> in: {sanitized}" );
+
+                    Assert.False(
+                        attr.Value.Contains( "\"" ),
+                        $"Re-parse found a literal quote in {el.Name}.{attr.Name} value '{attr.Value}' in: {sanitized}" );
+                }
+            }
+        }
+
+        // Every confirmed blocker-1 payload: an allowlisted attribute whose
+        // UNQUOTED source smuggles an embedded quote + handler. HAP parses the
+        // handler INSIDE the allowlisted attribute's value; the fix must ensure
+        // the emitted string cannot re-tokenize into a live handler.
+        public static IEnumerable<object[]> Blocker1Payloads()
+        {
+            yield return new object[] { "<img src=x alt=a\"onerror=\"alert(1)>" };                 // img / alt
+            yield return new object[] { "<p title=a\"onmouseover=\"alert(1)>x</p>" };              // p / title
+            yield return new object[] { "<font color=a\"onmouseover=\"alert(1)>x</font>" };        // font / color
+            yield return new object[] { "<table><tr><td align=a\"onmouseover=\"alert(1)>x</td></tr></table>" }; // td / align
+            yield return new object[] { "<a href=x\"onmouseover=\"alert(1)>x</a>" };               // a / href
+            yield return new object[] { "<a href=/ok title=a\"onmouseover=\"alert(1)>x</a>" };     // a / title alongside href
+            yield return new object[] { "<p style=width:1\"onmouseover=\"alert(1)>x</p>" };        // style path
+        }
+
+        [Theory]
+        [MemberData( nameof( Blocker1Payloads ) )]
+        public void Blocker1_Payload_Cannot_Break_Out_On_First_Pass( string payload )
+        {
+            var once = LinkListHtmlSanitizer.Sanitize( payload );
+
+            // The FIRST pass must already be safe — BuildBag sanitizes exactly
+            // once per render, so the first-pass output is what ships.
+            AssertNoAttributeBreakout( once );
+        }
+
+        [Theory]
+        [MemberData( nameof( Blocker1Payloads ) )]
+        public void Blocker1_Payload_Is_Idempotent( string payload )
+        {
+            var once = LinkListHtmlSanitizer.Sanitize( payload );
+            var twice = LinkListHtmlSanitizer.Sanitize( once );
+            Assert.Equal( once, twice );
+        }
+
+        [Fact]
+        public void Smuggled_Handler_Does_Not_Produce_A_Live_Onerror_Attribute()
+        {
+            // Concrete replay of the headline payload. The literal text
+            // "onerror" may survive ENCODED inside the alt value (that is inert);
+            // what must never happen is a real onerror ATTRIBUTE on the element.
+            var once = LinkListHtmlSanitizer.Sanitize( "<img src=x alt=a\"onerror=\"alert(1)>" );
+
+            var doc = new HtmlAgilityPack.HtmlDocument();
+            doc.LoadHtml( once );
+            var img = doc.DocumentNode.Descendants( "img" ).Single();
+            Assert.Null( img.Attributes["onerror"] );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 2 — entity-aware CSS parsing (BLOCKER 2)
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public void Style_Preserves_Entity_Quoted_Font_Family()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"font-family: Arial, &quot;Helvetica Neue&quot;, sans-serif; color: red\">x</p>" );
+
+            // The whole stack survives, quoted family name intact, color kept.
+            Assert.Contains( "font-family: Arial, &quot;Helvetica Neue&quot;, sans-serif", result );
+            Assert.Contains( "color: red", result );
+            AssertNoAttributeBreakout( result );
+        }
+
+        [Fact]
+        public void Style_Preserves_Real_Prod_Apple_System_Font_Stack()
+        {
+            const string stack =
+                "font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;";
+            var result = LinkListHtmlSanitizer.Sanitize( $"<p style=\"{stack}\">x</p>" );
+
+            Assert.Contains( "-apple-system", result );
+            Assert.Contains( "BlinkMacSystemFont", result );
+            Assert.Contains( "&quot;Segoe UI&quot;", result );
+            Assert.Contains( "&quot;Apple Color Emoji&quot;", result );
+            Assert.Contains( "&quot;Segoe UI Emoji&quot;", result );
+            Assert.Contains( "&quot;Segoe UI Symbol&quot;", result );
+            Assert.Contains( "sans-serif", result );
+            AssertNoAttributeBreakout( result );
+        }
+
+        [Fact]
+        public void Style_Entity_Quoted_Font_Family_Is_Idempotent()
+        {
+            const string input =
+                "<p style=\"font-family: Arial, &quot;Helvetica Neue&quot;, sans-serif; color: red\">x</p>";
+            var once = LinkListHtmlSanitizer.Sanitize( input );
+            var twice = LinkListHtmlSanitizer.Sanitize( once );
+            Assert.Equal( once, twice );
+        }
+
+        [Fact]
+        public void Style_Entity_Obfuscated_Url_Is_Rejected()
+        {
+            // &#117;rl( decodes to url( — must be caught now that the CSS value
+            // test runs on the DE-ENTITIZED declaration (MINOR fix).
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"background-color: &#117;rl(x)\">y</p>" );
+            Assert.DoesNotContain( "url(", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "style", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( ">y</p>", result );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 2 — culture-invariant security regexes (MAJOR)
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public void Blocks_Uppercase_Javascript_Scheme_Under_Turkish_Culture()
+        {
+            // Under tr-TR, ASCII 'I' does not case-fold to 'i'. Without
+            // RegexOptions.CultureInvariant, JAVASCRIPT: would slip past the
+            // scheme filter on a Turkish-culture request thread.
+            var original = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo( "tr-TR" );
+                var result = LinkListHtmlSanitizer.Sanitize( "<a href=\"JAVASCRIPT:alert(1)\">x</a>" );
+                Assert.DoesNotContain( "JAVASCRIPT", result, System.StringComparison.OrdinalIgnoreCase );
+                Assert.Contains( ">x</a>", result );
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+
+        [Fact]
+        public void Blocks_Uppercase_Css_Expression_Under_Turkish_Culture()
+        {
+            var original = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo( "tr-TR" );
+                var result = LinkListHtmlSanitizer.Sanitize(
+                    "<p style=\"width: EXPRESSION(alert(1))\">x</p>" );
+                Assert.DoesNotContain( "EXPRESSION", result, System.StringComparison.OrdinalIgnoreCase );
+                Assert.DoesNotContain( "style", result, System.StringComparison.OrdinalIgnoreCase );
+                Assert.Contains( ">x</p>", result );
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 2 — file: scheme coverage (NIT)
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public void Blocks_File_Scheme_On_Href()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( "<a href=\"file:///etc/passwd\">x</a>" );
+            Assert.DoesNotContain( "file:", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( ">x</a>", result );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 2 — re-tokenization safety on the prod mXSS fixture
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public void Item_9644_Mxss_Fixture_Cannot_Break_Out_On_First_Pass()
+        {
+            // Verbatim prod substring reconciled against the DB query (item 9644).
+            const string input =
+                "<h2 style=\"text-align: left;\" class=\"\"><span style=\"color: inherit; font-family: inherit;&gt;Changes to Registration&lt;/span&gt;&lt;/h2&gt;&lt;p style=\" text-align:=\"\" left;\"=\"\">Changes to Registration</span></h2>";
+
+            var once = LinkListHtmlSanitizer.Sanitize( input );
+            AssertNoAttributeBreakout( once );
+            Assert.Contains( "Changes to Registration", once );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 3 — DeEntitize must never throw (BLOCKER)
+        //
+        // HAP 1.4.9.5 HtmlEntity.DeEntitize THROWS KeyNotFoundException on any
+        // semicolon-terminated named entity absent from its HTML4 table. No call
+        // site had a try/catch, so one stored value with e.g. &colon; would
+        // permanently 500 the public list viewer. Sanitize must tolerate these in
+        // href, src, AND style values.
+        // ----------------------------------------------------------------------
+
+        public static IEnumerable<object[]> UndecodableEntityTokens()
+        {
+            yield return new object[] { "&colon;" };      // HTML5 named, HAP lacks -> throws
+            yield return new object[] { "&Tab;" };        // HTML5 named -> throws
+            yield return new object[] { "&semi;" };       // HTML5 named -> throws
+            yield return new object[] { "&foo;" };        // bogus named -> throws
+            yield return new object[] { "&#999999;" };    // numeric, out of BMP
+            yield return new object[] { "&" };            // bare ampersand
+            yield return new object[] { "x&" };           // ampersand at end of value
+        }
+
+        [Theory]
+        [MemberData( nameof( UndecodableEntityTokens ) )]
+        public void Sanitize_Does_Not_Throw_For_Undecodable_Entity_In_Href( string token )
+        {
+            // Must not throw (the whole point). Return value is not asserted here.
+            var ex = Record.Exception(
+                () => LinkListHtmlSanitizer.Sanitize( $"<a href=\"{token}\">x</a>" ) );
+            Assert.Null( ex );
+        }
+
+        [Theory]
+        [MemberData( nameof( UndecodableEntityTokens ) )]
+        public void Sanitize_Does_Not_Throw_For_Undecodable_Entity_In_Src( string token )
+        {
+            var ex = Record.Exception(
+                () => LinkListHtmlSanitizer.Sanitize( $"<img src=\"{token}\">" ) );
+            Assert.Null( ex );
+        }
+
+        [Theory]
+        [MemberData( nameof( UndecodableEntityTokens ) )]
+        public void Sanitize_Does_Not_Throw_For_Undecodable_Entity_In_Style( string token )
+        {
+            // Put the token inside an allowlisted property value so it reaches the
+            // FilterStyle DeEntitize path.
+            var ex = Record.Exception(
+                () => LinkListHtmlSanitizer.Sanitize( $"<p style=\"color: {token}\">x</p>" ) );
+            Assert.Null( ex );
+        }
+
+        [Fact]
+        public void Entity_Encoded_Colon_Does_Not_Enable_Scheme_Bypass()
+        {
+            // &colon; decodes to ':' in a browser, completing "javascript:". The
+            // safe decoder must decode it so the scheme check still neutralizes
+            // the href. (A best-effort decoder that left it literal would ship
+            // this XSS.)
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<a href=\"javascript&colon;alert(1)\">x</a>" );
+
+            Assert.Contains( ">x</a>", result );
+            // No live javascript: URL survived on the anchor.
+            var doc = new HtmlAgilityPack.HtmlDocument();
+            doc.LoadHtml( result );
+            var a = doc.DocumentNode.Descendants( "a" ).Single();
+            Assert.Null( a.Attributes["href"] );
+        }
+
+        [Fact]
+        public void Entity_Encoded_Lpar_Does_Not_Enable_Css_Url_Bypass()
+        {
+            // url&lpar; decodes to "url(" — must be caught on the allowed property.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"background-color: url&lpar;x&rpar;\">y</p>" );
+            Assert.DoesNotContain( "style", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( ">y</p>", result );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 3 — double-encoded style truncation (MAJOR)
+        //
+        // DeEntitize decodes one level, leaving a literal ';' that Split(';') then
+        // treats as a declaration separator, discarding the remainder. The raw-
+        // split-with-reattachment fix must preserve the FULL value byte-faithfully.
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public void Style_Double_Encoded_Quot_Font_Stack_Preserved_Whole()
+        {
+            const string stack =
+                "font-family: Arial, &amp;quot;Segoe UI&amp;quot;, sans-serif";
+            var result = LinkListHtmlSanitizer.Sanitize( $"<p style=\"{stack}\">x</p>" );
+            Assert.Contains( stack, result );
+        }
+
+        [Fact]
+        public void Style_Double_Encoded_Amp_In_Font_Family_Preserved_Whole()
+        {
+            const string style = "font-family: A &amp;amp; B; color: red";
+            var result = LinkListHtmlSanitizer.Sanitize( $"<p style=\"{style}\">x</p>" );
+            Assert.Contains( "font-family: A &amp;amp; B", result );
+            Assert.Contains( "color: red", result );
+        }
+
+        [Fact]
+        public void Style_Double_Encoded_Numeric_Semicolon_Preserved_Whole()
+        {
+            const string style = "color: red &amp;#59; more";
+            var result = LinkListHtmlSanitizer.Sanitize( $"<p style=\"{style}\">x</p>" );
+            Assert.Contains( "color: red &amp;#59; more", result );
+        }
+
+        [Fact]
+        public void Style_Double_Encoded_Cases_Are_Idempotent()
+        {
+            foreach ( var style in new[]
+            {
+                "font-family: Arial, &amp;quot;Segoe UI&amp;quot;, sans-serif",
+                "font-family: A &amp;amp; B; color: red",
+                "color: red &amp;#59; more"
+            } )
+            {
+                var once = LinkListHtmlSanitizer.Sanitize( $"<p style=\"{style}\">x</p>" );
+                var twice = LinkListHtmlSanitizer.Sanitize( once );
+                Assert.Equal( once, twice );
+            }
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 3 — style bytes are byte-faithful (dissolved MINOR)
+        //
+        // The old style path mutated &nbsp; -> U+00A0 and &#39; -> ' in stored
+        // values. Writing back the RAW declaration keeps them verbatim.
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public void Style_Preserves_Nbsp_Entity_As_Written()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"font-family: A&nbsp;B\">x</p>" );
+            Assert.Contains( "font-family: A&nbsp;B", result );
+            // Must remain the &nbsp; entity, NOT be mutated to a literal U+00A0.
+            Assert.DoesNotContain( "\u00A0", result );
+        }
+
+        [Fact]
+        public void Style_Preserves_Numeric_Apostrophe_Entity_As_Written()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"font-family: A&#39;B\">x</p>" );
+            Assert.Contains( "font-family: A&#39;B", result );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 4 — BLOCKER A: SafeDeEntitize must decode at least
+        // as aggressively as a browser.
+        //
+        // Browsers decode a numeric character reference in an attribute value even
+        // WITHOUT the terminating ';' (an HTML5 parse error, but the reference is
+        // still consumed and decoded). The round-3 decoder required the ';', so a
+        // scheme colon written as `&#58` (no ';'), `&#x3a` (no ';'), or a tab as
+        // `&#9` (no ';') slipped past the scheme check and executed on click.
+        // These assert the SECURITY OUTCOME (the url-bearing attribute is stripped),
+        // not the decoder internals.
+        // ----------------------------------------------------------------------
+
+        public static IEnumerable<object[]> BlockerA_SemicolonlessSchemePayloads()
+        {
+            // scheme colon as a decimal ref with NO ';' (the digit run stops at
+            // the non-digit 'a', so the colon materializes before "alert")
+            yield return new object[] { "javascript&#58alert(1)" };
+            // scheme colon as a hex ref with NO ';'. The hex-digit run must be
+            // terminated by a NON-hex char for the colon to materialize — here the
+            // 'w' of "window" (a real attack payload `javascript:window...`). NB:
+            // `&#x3aalert` is NOT used: 'a' is a hex digit, so a browser AND this
+            // decoder both fold it into `&#x3aa` (U+03AA) and no colon appears —
+            // that spelling is a non-exploit at parity, not a bypass.
+            yield return new object[] { "javascript&#x3awindow.alert(1)" };
+            // tab as a decimal ref with NO ';' — URL parser strips it, leaving
+            // "javascript:"
+            yield return new object[] { "java&#9script:alert(1)" };
+        }
+
+        [Theory]
+        [MemberData( nameof( BlockerA_SemicolonlessSchemePayloads ) )]
+        public void Semicolonless_Scheme_Entity_Is_Stripped_On_Href( string payload )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( $"<a href=\"{payload}\">x</a>" );
+
+            var doc = new HtmlAgilityPack.HtmlDocument();
+            doc.LoadHtml( result );
+            var a = doc.DocumentNode.Descendants( "a" ).Single();
+            Assert.Null( a.Attributes["href"] );   // scheme detected -> href removed
+            Assert.Contains( ">x</a>", result );
+        }
+
+        [Theory]
+        [MemberData( nameof( BlockerA_SemicolonlessSchemePayloads ) )]
+        public void Semicolonless_Scheme_Entity_Is_Stripped_On_Src( string payload )
+        {
+            var result = LinkListHtmlSanitizer.Sanitize( $"<img src=\"{payload}\">" );
+
+            var doc = new HtmlAgilityPack.HtmlDocument();
+            doc.LoadHtml( result );
+            var img = doc.DocumentNode.Descendants( "img" ).Single();
+            Assert.Null( img.Attributes["src"] );   // scheme detected -> src removed
+        }
+
+        [Theory]
+        [MemberData( nameof( BlockerA_SemicolonlessSchemePayloads ) )]
+        public void Semicolonless_Scheme_Payload_Is_Idempotent( string payload )
+        {
+            var once = LinkListHtmlSanitizer.Sanitize( $"<a href=\"{payload}\">x</a>" );
+            var twice = LinkListHtmlSanitizer.Sanitize( once );
+            Assert.Equal( once, twice );
+        }
+
+        // The regression risk of the more-aggressive decoder: it must NOT reject a
+        // legitimate https URL whose query string contains '&', '&amp;', and param
+        // names that look like entity prefixes (&centerId=, &copyright=). The
+        // scheme regex is anchored at '^', so query-string decoding can never turn
+        // an https URL into a dangerous scheme — the href must survive intact and
+        // byte-faithful.
+        [Fact]
+        public void Aggressive_Decoder_Keeps_Legit_Url_With_Entity_Like_Query_Params()
+        {
+            const string url =
+                "https://se.church/give?centerId=2&amp;ref=1&copyright=se&sol=x";
+            var result = LinkListHtmlSanitizer.Sanitize( $"<a href=\"{url}\">give</a>" );
+
+            var doc = new HtmlAgilityPack.HtmlDocument();
+            doc.LoadHtml( result );
+            var a = doc.DocumentNode.Descendants( "a" ).Single();
+            Assert.NotNull( a.Attributes["href"] );                       // NOT rejected
+            Assert.Contains( "se.church/give", a.Attributes["href"].Value );
+            Assert.Contains( "&amp;ref=1", result );                      // entity kept verbatim
+            Assert.Contains( "&copyright=se", result );                   // no mangling
+            Assert.Contains( ">give</a>", result );
+        }
+
+        [Fact]
+        public void Aggressive_Decoder_Legit_Url_Is_Idempotent()
+        {
+            const string input =
+                "<a href=\"https://se.church/give?centerId=2&amp;ref=1&copyright=se\">give</a>";
+            var once = LinkListHtmlSanitizer.Sanitize( input );
+            var twice = LinkListHtmlSanitizer.Sanitize( once );
+            Assert.Equal( once, twice );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 4 — BLOCKER B: a CSS declaration written back RAW
+        // must be incapable of DECODING, in the browser, into more declarations
+        // than were validated.
+        //
+        // Each payload is an ALLOWED property (`color` / `width`) whose value, in
+        // raw form, clears the property allowlist, yet decodes in the browser into
+        // a declaration separator + a second live declaration (external url()
+        // fetch, position:fixed clickjacking overlay, expression()). The fix must
+        // drop the whole declaration. Assertions run on the browser-DECODED form of
+        // the emitted output, not a raw substring — the round-3 mistake was a raw
+        // substring check that missed the entity-encoded form.
+        // ----------------------------------------------------------------------
+
+        // Browser-equivalent HTML decode of the emitted markup, so the assertion
+        // sees what a browser's CSS parser would after HTML-decoding the attribute.
+        private static string HtmlDecodeLikeBrowser( string s )
+        {
+            return System.Net.WebUtility.HtmlDecode( s );
+        }
+
+        public static IEnumerable<object[]> BlockerB_SmuggledDeclarationPayloads()
+        {
+            // allowed color; then ';' (&#59) then background:url(...) with entity
+            // parens -> live external fetch
+            yield return new object[]
+            {
+                "<div style=\"color: red&#59background:url&#40//evil&#41\">x</div>",
+                "background:"
+            };
+            // allowed color; then ';' (&#59) then position:fixed ('o' as &#111) ->
+            // full-viewport clickjacking overlay
+            yield return new object[]
+            {
+                "<div style=\"color: red&#59p&#111sition:fixed\">x</div>",
+                "position:fixed"
+            };
+            // allowed width; expression(...) with entity parens -> defeats a raw
+            // DangerousCssValue check
+            yield return new object[]
+            {
+                "<div style=\"width: expression&#40alert(1)&#41\">x</div>",
+                "expression("
+            };
+        }
+
+        [Theory]
+        [MemberData( nameof( BlockerB_SmuggledDeclarationPayloads ) )]
+        public void Smuggled_Css_Declaration_Does_Not_Survive_In_Any_Form( string payload, string forbiddenDecoded )
+        {
+            var once = LinkListHtmlSanitizer.Sanitize( payload );
+
+            // No style attribute should survive: the sole declaration is a smuggle,
+            // so the whole attribute is removed.
+            var doc = new HtmlAgilityPack.HtmlDocument();
+            doc.LoadHtml( once );
+            var div = doc.DocumentNode.Descendants( "div" ).Single();
+            Assert.Null( div.Attributes["style"] );
+
+            // And on the browser-DECODED form, none of the smuggled declaration
+            // survives (this is the assertion a raw substring check would miss).
+            var decoded = HtmlDecodeLikeBrowser( once );
+            Assert.DoesNotContain( forbiddenDecoded, decoded, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "url(", decoded, System.StringComparison.OrdinalIgnoreCase );
+            Assert.DoesNotContain( "expression(", decoded, System.StringComparison.OrdinalIgnoreCase );
+
+            Assert.Contains( ">x</div>", once );
+        }
+
+        [Theory]
+        [MemberData( nameof( BlockerB_SmuggledDeclarationPayloads ) )]
+        public void Smuggled_Css_Declaration_Payload_Is_Idempotent( string payload, string forbiddenDecoded )
+        {
+            _ = forbiddenDecoded;
+            var once = LinkListHtmlSanitizer.Sanitize( payload );
+            var twice = LinkListHtmlSanitizer.Sanitize( once );
+            Assert.Equal( once, twice );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 fix round 4 — re-confirm prod-content fixtures still round-trip
+        // under the round-4 gate (the double-encoded font stacks carry an inert ';'
+        // in their single-level decode; the gate keys on ':' / '{' / '}', so they
+        // must survive).
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public void Round4_Gate_Keeps_Real_Prod_Margin_Left()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"margin-left: 25px\">x</p>" );
+            Assert.Contains( "margin-left: 25px", result );
+        }
+
+        [Fact]
+        public void Round4_Gate_Keeps_Double_Encoded_Quot_Font_Stack()
+        {
+            // Single-level decode yields the literal `&quot;` (which contains ';'),
+            // but NO ':' — so the gate must keep it byte-faithfully.
+            const string stack =
+                "font-family: Arial, &amp;quot;Segoe UI&amp;quot;, sans-serif";
+            var result = LinkListHtmlSanitizer.Sanitize( $"<p style=\"{stack}\">x</p>" );
+            Assert.Contains( stack, result );
+        }
+
+        [Fact]
+        public void Round4_Gate_Keeps_Apple_System_Font_Stack_And_Line_Height()
+        {
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"font-family: -apple-system, &quot;Segoe UI&quot;, sans-serif; line-height: 150% !important\">x</p>" );
+            Assert.Contains( "&quot;Segoe UI&quot;", result );
+            Assert.Contains( "line-height: 150% !important", result );
+        }
+
+        // ----------------------------------------------------------------------
+        // ROCK-8880 final polish — CSS-escape attack class (documentation/coverage).
+        //
+        // WHY these tests exist and WHY the expected results are correct — do NOT
+        // "fix" a passing test here without re-reading this. The security-review
+        // established the ACTUAL mechanism by which the CSS declaration gate holds:
+        //
+        //   A new CSS declaration requires a bare <colon-token> emitted by the CSS
+        //   tokenizer. A CSS backslash escape (`\3a`) produces a colon CODE POINT
+        //   appended to an identifier — ident content, NEVER a separator token.
+        //   (Same reason `.foo\:bar` selects a class literally named `foo:bar`.)
+        //   So an escaped colon can NEVER separate a property from a value and can
+        //   NEVER form a smuggled declaration. The browser folds `position\3a fixed`
+        //   into a single invalid identifier and DROPS that declaration — only the
+        //   preceding valid declaration applies.
+        //
+        //   The gate's real job is therefore narrower than "catch any colon": it
+        //   catches LITERAL colons and ENTITY-ENCODED colons (`&#58;` `&#x3a;`
+        //   `&colon;`) — the forms a browser genuinely treats as separators —
+        //   because SafeDeEntitize decodes every colon form a browser would. It does
+        //   NOT (and need not) catch CSS escapes; those are inert.
+        //
+        // The two groups below pin BOTH halves so a future edit that changed either
+        // (started mangling inert escapes, or stopped catching real separators)
+        // fails loudly. NOTE: C# requires `\\` in source to emit a single literal
+        // backslash into the CSS text.
+        // ----------------------------------------------------------------------
+
+        // GROUP 1 — survive-but-INERT, asserted byte-faithful. These carry an
+        // ESCAPED colon (or escaped parens), which is ident content, not a
+        // separator; the sanitizer must pass the bytes through UNCHANGED (mangling
+        // them would corrupt legitimate content), and the browser then folds the
+        // escape into one invalid identifier and drops the declaration.
+
+        [Fact]
+        public void Style_CssEscaped_Colon_Survives_Byte_Faithful_But_Is_Inert()
+        {
+            // `position\3a fixed`: `\3a` is a CSS escape -> colon code point folded
+            // INTO the identifier, never a <colon-token>, so it cannot begin a new
+            // declaration. Value carries no LITERAL ':' and its SafeDeEntitize'd
+            // form (no entities present) carries none either, so the gate keeps it.
+            // Browser folds `position\3a fixed` into one invalid ident -> dropped;
+            // only `color: red` applies. Bytes must pass through verbatim.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"color: red; position\\3a fixed\">x</p>" );
+            Assert.Contains( "color: red; position\\3a fixed", result );
+        }
+
+        [Fact]
+        public void Style_CssEscaped_Colon_And_Parens_Survive_Byte_Faithful_But_Inert()
+        {
+            // `background\3aurl\28//evil\29`: escaped colon AND escaped parens all
+            // become ident chars -> no <colon-token>, no `url(` function token in
+            // the raw bytes, so DangerousCssValue's `url\(` never matches and the
+            // colon gate sees no literal ':'. Browser folds the whole run into one
+            // invalid ident -> dropped, NO fetch. Bytes must survive verbatim.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"width: 1; background\\3aurl\\28//evil\\29\">x</p>" );
+            Assert.Contains( "width: 1; background\\3aurl\\28//evil\\29", result );
+        }
+
+        [Fact]
+        public void Style_CssEscaped_Semicolon_And_Colon_Survive_Byte_Faithful_But_Inert()
+        {
+            // `red\3bposition\3afixed`: escaped `;` and escaped `:` are both ident
+            // content -> no declaration separator, no property/value separator. The
+            // raw value contains no literal ';' (so no split) and no literal ':'
+            // beyond the property's own, so it is kept whole. Browser folds it into
+            // one invalid `background-color` value -> declaration dropped.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"background-color: red\\3bposition\\3afixed\">x</p>" );
+            Assert.Contains( "background-color: red\\3bposition\\3afixed", result );
+        }
+
+        [Fact]
+        public void Style_EntityWritten_Backslash_Numeric_Colon_Escape_Survives_Byte_Faithful_But_Inert()
+        {
+            // `position&#92;3a fixed`: `&#92;` is an HTML entity the browser decodes
+            // to a backslash FIRST, yielding the CSS escape `\3a` — ident content,
+            // not a separator. SafeDeEntitize likewise decodes `&#92;` to `\`, so
+            // the gate sees `position\3a fixed` (a real backslash, NO literal ':')
+            // and keeps it. Stored bytes stay as the `&#92;` entity, verbatim.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"color: red; position&#92;3a fixed\">x</p>" );
+            Assert.Contains( "color: red; position&#92;3a fixed", result );
+        }
+
+        [Fact]
+        public void Style_EntityWritten_Backslash_Named_Colon_Escape_Survives_Byte_Faithful_But_Inert()
+        {
+            // `position&bsol;3a fixed`: `&bsol;` decodes to a backslash (same as
+            // above), producing the inert CSS escape `\3a`. SafeDeEntitize decodes
+            // `&bsol;` -> `\`, so the gate sees no literal ':' and keeps the bytes.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"color: red; position&bsol;3a fixed\">x</p>" );
+            Assert.Contains( "color: red; position&bsol;3a fixed", result );
+        }
+
+        // GROUP 2 — REJECTED, asserted stripped. These carry a REAL separator (a
+        // literal ':' or an entity-encoded colon the browser decodes to ':'), which
+        // WOULD open a smuggled declaration, so the gate must drop it.
+
+        [Fact]
+        public void Style_Literal_Colon_Smuggle_Drops_Declaration_Keeps_Color()
+        {
+            // `position:fixed` after `color: red` is a genuine second declaration
+            // with a LITERAL <colon-token>. `position` is not on the property
+            // allowlist, so that declaration is dropped and `color` is kept.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"color: red; position:fixed\">x</p>" );
+            Assert.Contains( "color: red", result );
+            Assert.DoesNotContain( "position", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Fact]
+        public void Style_EntityEncoded_Numeric_Colon_Smuggle_Strips_Style()
+        {
+            // `position&#58;fixed`: `&#58;` decodes to a real ':' in the browser AND
+            // in SafeDeEntitize. Because the raw split keeps `color: red;
+            // position&#58;fixed` as ONE declaration (the entity-encoded ';'-less
+            // colon is not a raw separator), its decoded value carries a ':' -> the
+            // smuggle gate rejects the whole `color` declaration -> style removed.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"color: red; position&#58;fixed\">x</p>" );
+            Assert.DoesNotContain( "style", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( ">x</p>", result );
+        }
+
+        [Fact]
+        public void Style_EntityEncoded_Named_Colon_Smuggle_Strips_Style()
+        {
+            // `position&colon;fixed`: `&colon;` decodes to ':' — same mechanism as
+            // the numeric form; the decoded value carries a real separator, so the
+            // smuggle gate strips the style.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"color: red; position&colon;fixed\">x</p>" );
+            Assert.DoesNotContain( "style", result, System.StringComparison.OrdinalIgnoreCase );
+            Assert.Contains( ">x</p>", result );
+        }
+
+        // GROUP 3 — per-declaration gating with NO truncation. A middle declaration
+        // that decodes to an extra separator is dropped in isolation; the valid
+        // declarations on either side must both survive (proving the drop did not
+        // truncate the rest of the value).
+
+        [Fact]
+        public void Style_EntityColon_Middle_Declaration_Dropped_Without_Truncation_Numeric()
+        {
+            // `width: 1&#58;&#58;2` decodes to `1::2` (two real colons) -> smuggle,
+            // middle declaration dropped. `color` (before) and `font-size` (after)
+            // must BOTH survive — the drop is per-declaration, not a truncation.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"color: red; width: 1&#58;&#58;2; font-size: 10px\">x</p>" );
+            Assert.Contains( "color: red", result );
+            Assert.Contains( "font-size: 10px", result );
+            Assert.DoesNotContain( "width", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        [Fact]
+        public void Style_EntityColon_Middle_Declaration_Dropped_Without_Truncation_Alpha()
+        {
+            // `width: a&#58;b` decodes to `a:b` (a real colon) -> smuggle, middle
+            // declaration dropped; `color` and `font-size` both survive.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"color: red; width: a&#58;b; font-size: 10px\">x</p>" );
+            Assert.Contains( "color: red", result );
+            Assert.Contains( "font-size: 10px", result );
+            Assert.DoesNotContain( "width", result, System.StringComparison.OrdinalIgnoreCase );
+        }
+
+        // GROUP 4 — the LATENT DangerousCssValue escape gap, pinned as a test so the
+        // behavior is visible and documented rather than surprising. This value is
+        // ACCEPTED-BECAUSE-INERT, not accepted-because-safe: `\75 rl(` is a CSS
+        // escape of the `u` in `url`, so DangerousCssValue's `url\(` regex never
+        // matches and the value survives sanitization unchanged. It is harmless
+        // ONLY because `background-color` (and every other allowlisted property)
+        // does not accept a url()/image value, so the browser — which DOES fold
+        // `\75 rl(` back into a real `url(` function token — drops the declaration.
+        // The PROPERTY ALLOWLIST is the guarantee here, not DangerousCssValue. If a
+        // URL-/image-bearing property is ever allowlisted, this test's payload
+        // becomes a live external fetch and DangerousCssValue must be made
+        // escape-aware first (see the LIMITATION note on the field).
+
+        [Fact]
+        public void Style_CssEscaped_Url_Survives_Filter_Accepted_Because_Inert_Not_Safe()
+        {
+            // Survives sanitization byte-faithfully because `\75 rl(` is not a
+            // literal `url(`; inert only because no allowlisted property accepts a
+            // url() value. NOT a guarantee provided by DangerousCssValue.
+            var result = LinkListHtmlSanitizer.Sanitize(
+                "<p style=\"background-color: \\75 rl(//evil/x)\">y</p>" );
+            Assert.Contains( "background-color: \\75 rl(//evil/x)", result );
         }
     }
 }

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/LinkListHtmlSanitizer.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/LinkListHtmlSanitizer.cs
@@ -57,6 +57,20 @@ namespace org.secc.LinkList.Utility
     /// carried a broken half-commented block; dropping them is safe and avoids
     /// re-serializing malformed comment syntax.
     ///
+    /// One attribute is ADDED rather than filtered: an <c>&lt;a&gt;</c> that keeps
+    /// its <c>target</c> gets <c>rel="noopener noreferrer"</c> forced onto it (see
+    /// <see cref="InjectTabnabbingGuard"/>), because <c>rel</c> is on no allowlist
+    /// and an author therefore cannot supply the mitigation themselves.
+    ///
+    /// BYTE-FAITHFULNESS, ONE EXCEPTION: the value is otherwise emitted with its
+    /// original bytes (entities untouched, see below), but a bare <c>&lt;</c> that
+    /// cannot open a tag is rewritten to <c>&amp;lt;</c> BEFORE parsing (see
+    /// <see cref="BareLessThan"/>). Those bytes were invalid HTML and
+    /// <c>&amp;lt;</c> is what a browser renders them as, so this is a correction,
+    /// not a mutation - and it is still idempotent, since the rewritten form has no
+    /// bare <c>&lt;</c> left to rewrite. Without it, HAP's mis-recovery silently
+    /// deleted every word after the <c>&lt;</c>.
+    ///
     /// Emits via HtmlAgilityPack's OuterHtml so HTML entities (e.g.
     /// <c>&amp;copy;</c>) are preserved verbatim - the operation is idempotent
     /// (<c>Sanitize(Sanitize(x)) == Sanitize(x)</c>), so sanitizing on read AND
@@ -100,13 +114,28 @@ namespace org.secc.LinkList.Utility
         // Tags that are allowed to survive. Everything real prod intro/footer
         // content uses: layout, inline formatting, headings, tables, lists,
         // legacy <font>, images and links.
+        //
+        // A tag missing from this set is UNWRAPPED, which silently drops the
+        // `class` it carried - so every class-bearing wrapper the email builder
+        // emits has to be listed here or the CSS scoped to it stops applying (the
+        // `class` allowance below is pointless without the element that holds it).
+        // The table sub-elements matter for a second reason: unwrapping <caption>
+        // leaves a bare text node inside <table>, which a browser's "in table"
+        // insertion mode FOSTER-PARENTS out of the table entirely, so the caption
+        // renders above the table as loose body text.
+        //
+        // Listing a tag here allows only the TAG. Its attributes are still filtered
+        // independently by FilterAttributes.
         private static readonly HashSet<string> AllowedTags = new HashSet<string>( StringComparer.OrdinalIgnoreCase )
         {
             "div", "span", "p", "a", "img", "br",
-            "b", "i", "u", "strong", "em",
+            "b", "i", "u", "strong", "em", "small", "s", "strike",
             "h1", "h2", "h3", "h4", "h5", "h6",
-            "table", "tbody", "tr", "td", "th",
-            "ul", "ol", "li",
+            "table", "thead", "tbody", "tfoot", "tr", "td", "th",
+            "caption", "colgroup", "col",
+            "ul", "ol", "li", "dl", "dt", "dd",
+            "section", "article", "header", "footer", "nav",
+            "figure", "figcaption", "pre", "code", "label",
             "font", "hr", "blockquote", "sub", "sup"
         };
 
@@ -125,18 +154,31 @@ namespace org.secc.LinkList.Utility
         // on* handler and every data-* attribute - prod email-builder markup is
         // class-based (esd-block-*, es-text-*), so `class` covers it. `style` is
         // handled specially (value-filtered) before this set is consulted.
+        // The presentational table attributes (align/valign/border/cellpadding/
+        // cellspacing/bgcolor/nowrap) are here as a set: email-builder output paints
+        // cell and table backgrounds with the legacy `bgcolor` ATTRIBUTE rather than
+        // CSS, because email clients strip <style>. Omitting one of them renders
+        // those blocks white/transparent.
         private static readonly HashSet<string> GlobalAttributes = new HashSet<string>( StringComparer.OrdinalIgnoreCase )
         {
             "class", "id", "title", "alt", "align", "width", "height",
-            "colspan", "rowspan", "valign", "border", "cellpadding", "cellspacing"
+            "colspan", "rowspan", "valign", "border", "cellpadding", "cellspacing",
+            "bgcolor", "nowrap"
         };
 
-        // Attributes allowed only on specific tags.
+        // Attributes allowed only on specific tags. Note `rel` is deliberately
+        // absent from <a>: it is not carried over from the author at all, it is
+        // FORCE-INJECTED by FilterAttributes whenever `target` survives (see
+        // InjectTabnabbingGuard).
         private static readonly Dictionary<string, HashSet<string>> PerTagAttributes = new Dictionary<string, HashSet<string>>( StringComparer.OrdinalIgnoreCase )
         {
             ["a"] = new HashSet<string>( StringComparer.OrdinalIgnoreCase ) { "href", "target" },
             ["img"] = new HashSet<string>( StringComparer.OrdinalIgnoreCase ) { "src" },
-            ["font"] = new HashSet<string>( StringComparer.OrdinalIgnoreCase ) { "color", "face", "size" }
+            ["font"] = new HashSet<string>( StringComparer.OrdinalIgnoreCase ) { "color", "face", "size" },
+            // The `span` ATTRIBUTE on <col>/<colgroup> (column count) - unrelated to
+            // the <span> tag. Kept per-tag so it cannot leak onto other elements.
+            ["col"] = new HashSet<string>( StringComparer.OrdinalIgnoreCase ) { "span" },
+            ["colgroup"] = new HashSet<string>( StringComparer.OrdinalIgnoreCase ) { "span" }
         };
 
         // Attributes whose value is a URL and must pass the scheme check. Kept in
@@ -159,6 +201,24 @@ namespace org.secc.LinkList.Utility
         };
 
         private static readonly Regex ControlAndWhitespace = new Regex( @"[\s\x00-\x1F]", RegexOptions.Compiled );
+
+        // A '<' that cannot open a tag, i.e. literal text. Per the HTML5 tokenizer's
+        // tag-open state, '<' only starts markup when followed by an ASCII letter
+        // (start tag), '/' (end tag), '!' (comment/doctype) or '?' (bogus comment);
+        // anything else - a space, a digit, end-of-input - is emitted as a literal
+        // '<' character by a browser.
+        //
+        // HAP 1.4.9.5 does NOT follow that rule. It parses `<p>Ages < 12 welcome</p>`
+        // as <p> containing the text "Ages " plus an ELEMENT WITH AN EMPTY NAME whose
+        // swallowed words become ATTRIBUTES (`12=""`, `welcome=""`). That empty name
+        // is on neither allowlist, so Clean() unwraps it - and Unwrap moves only
+        // ChildNodes, of which it has none, so the node and the words held in its
+        // attributes are DISCARDED. Real list copy ("Ages < 12", "Cost < $5") lost
+        // everything after the '<' on the next render.
+        //
+        // Escaping these up front, before HAP sees them, restores browser parity and
+        // is the one place the sanitizer is not byte-faithful (see class remarks).
+        private static readonly Regex BareLessThan = new Regex( @"<(?![a-zA-Z/!?])", RegexOptions.Compiled );
 
         // CultureInvariant is REQUIRED: IgnoreCase folds case using the current
         // thread culture, and Rock sets per-request culture from globalization
@@ -317,8 +377,12 @@ namespace org.secc.LinkList.Utility
                 return html;
             }
 
+            // Escape any '<' that a browser would treat as literal text BEFORE
+            // parsing - HAP mis-recovers those into an empty-named element whose
+            // text ends up in attributes, and the unwrap path then drops it. See
+            // the BareLessThan remarks.
             var doc = new HtmlAgilityPack.HtmlDocument();
-            doc.LoadHtml( html );
+            doc.LoadHtml( BareLessThan.Replace( html, "&lt;" ) );
             Clean( doc.DocumentNode );
             return doc.DocumentNode.OuterHtml;
         }
@@ -336,9 +400,23 @@ namespace org.secc.LinkList.Utility
 
                 if ( child.NodeType != HtmlAgilityPack.HtmlNodeType.Element )
                 {
-                    // Text nodes pass through verbatim (entities preserved). Any
-                    // other node type (declarations, processing instructions) is
-                    // not content we emit.
+                    // Text, and ONLY Text. HtmlNodeType in HAP 1.4.9.5 has exactly
+                    // four members - Document, Element, Comment, Text - so by the
+                    // time we reach here Comment is already removed above, Element
+                    // is handled below, and Document never appears as a child.
+                    //
+                    // There is NO declaration or processing-instruction node type in
+                    // this HAP version, so there is nothing extra to drop here.
+                    // Verified against the shipped 1.4.9.5 assembly: `<!DOCTYPE html>`
+                    // and `<! foo >` are parsed as COMMENT nodes (already stripped by
+                    // the branch above), and `<? php ?>` / `<?xml ... ?>` are parsed
+                    // as an ELEMENT literally named `?`, which is on neither allowlist
+                    // and so falls to the benign-unknown unwrap path below - it has no
+                    // children, so it disappears. Sanitize() emits none of them.
+                    //
+                    // So this is the text-node path, and text passes through verbatim
+                    // to keep entities byte-faithful. Adding an explicit Remove() for
+                    // "other" node types would be dead code.
                     continue;
                 }
 
@@ -406,6 +484,15 @@ namespace org.secc.LinkList.Utility
                     continue;
                 }
 
+                // KNOWN, DELIBERATELY UNFIXED: HAP 1.4.9.5 mis-tokenizes
+                // slash-separated attributes - `<img/src="x"/alt="y">` yields
+                // attributes literally named `rc` and `lt` (it eats the `/s` and
+                // `/a`), where a browser would read `src` and `alt`. Neither name
+                // is allowlisted, so both are dropped here. That is fail-CLOSED and
+                // no worse than the old blacklist, which kept the same bogus `rc`/
+                // `lt` names and so produced an equally src-less broken image.
+                // Normalizing the separators would mean rewriting raw attribute soup
+                // ahead of the parser - new mXSS surface for no visual gain.
                 if ( !IsAttributeAllowed( tag, name ) )
                 {
                     attr.Remove();
@@ -424,6 +511,42 @@ namespace org.secc.LinkList.Utility
                 // double-quote delimiter and entity-encode the break-out chars.
                 SetSafeAttribute( attr, EncodeAttributeValue( attr.Value ) );
             }
+
+            if ( tag == "a" && node.Attributes["target"] != null )
+            {
+                InjectTabnabbingGuard( node );
+            }
+        }
+
+        // rel value forced onto any <a> that keeps a target. noreferrer is included
+        // as well as noopener because the pre-Chrome-88 / pre-Firefox-79 / IE and
+        // embedded-webview engines that lack implicit noopener are largely the same
+        // ones that only honor noreferrer.
+        private const string TabnabbingRel = "noopener noreferrer";
+
+        /// <summary>
+        /// Closes reverse tabnabbing on a link that kept its <c>target</c>.
+        ///
+        /// A page opened via <c>target="_blank"</c> receives a live
+        /// <c>window.opener</c> on any engine without implicit noopener (all IE /
+        /// Edge Legacy, Chrome &lt; 88, Firefox &lt; 79, Safari &lt; 12.1, and many
+        /// in-app webviews) and can navigate the ORIGINAL tab - e.g. to a phishing
+        /// clone of the site the reader thinks they are still on.
+        ///
+        /// <c>rel</c> is on no allowlist, so the loop above has already STRIPPED any
+        /// author-supplied value; this always writes our constant rather than merging
+        /// with theirs. That is deliberate: because this sanitizer is the single
+        /// chokepoint for list content, an author cannot add the mitigation by hand
+        /// (it would just be stripped), so it cannot be left to them to remember. The
+        /// cost is that a deliberate <c>rel="nofollow"</c> is also overridden.
+        ///
+        /// Idempotent: on a second pass the injected <c>rel</c> is stripped as
+        /// non-allowlisted and re-appended here in the same trailing position, so the
+        /// bytes are identical.
+        /// </summary>
+        private static void InjectTabnabbingGuard( HtmlAgilityPack.HtmlNode node )
+        {
+            SetSafeAttribute( node.SetAttributeValue( "rel", string.Empty ), TabnabbingRel );
         }
 
         // Force a stable double-quote delimiter for a retained attribute so its

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/LinkListHtmlSanitizer.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/LinkListHtmlSanitizer.cs
@@ -14,6 +14,7 @@
 //
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -21,33 +22,293 @@ namespace org.secc.LinkList.Utility
 {
     /// <summary>
     /// Idempotent, entity-preserving HTML sanitizer for the freeform intro /
-    /// footer blobs. Drops blacklisted tags (and their subtree), strips every
-    /// on* handler, and removes javascript:/data:/vbscript:/file: URLs from
-    /// href/src - testing the DECODED, whitespace/control-char-stripped value so
-    /// entity tricks (e.g. <c>java&amp;#9;script:</c>) can't slip past.
+    /// footer blobs (ROCK-8880).
+    ///
+    /// This used to be a tag BLACKLIST (drop script/iframe/... , pass everything
+    /// else). A blacklist can only ever remove the vectors we already thought of,
+    /// so it leaked stored XSS through anything novel - mutation-XSS (mXSS) via
+    /// malformed / half-entity-encoded attribute soup, foreign-content elements,
+    /// and any tag/attribute we simply hadn't enumerated. Real prod content
+    /// exercised exactly that (e.g. item 9644's broken
+    /// <c>style=" text-align:="" left;"=""</c> attribute mess).
+    ///
+    /// It is now an ALLOWLIST: only known-safe tags survive, and on each surviving
+    /// tag only known-safe attributes survive. Anything not explicitly allowed is
+    /// removed. Non-allowlisted tags fall into two buckets:
+    ///   * dangerous / foreign-content tags (script, iframe, object, svg, math,
+    ///     ...) are removed. We call Remove() on the element, which drops the
+    ///     subtree for well-formed nesting; but the ALLOWLIST is the real
+    ///     guarantee, NOT subtree removal - HAP 1.4.9.5 marks some tags (e.g.
+    ///     <c>form</c>) CanOverlap, so their "children" can parse as siblings and
+    ///     survive the Remove(). Those orphaned children are still scrubbed
+    ///     because every surviving node must independently clear the allowlist;
+    ///     nothing relies on the subtree going away as its sole defense. And
+    ///   * benign-but-unknown tags are UNWRAPPED (tag dropped, inner text/children
+    ///     kept) so a stray wrapper never eats visible copy.
+    ///
+    /// URL-bearing attributes (href, src) are scheme-checked against the DECODED,
+    /// whitespace/control-char-stripped value so entity tricks
+    /// (e.g. <c>java&amp;#9;script:</c>) can't slip past - blocking
+    /// javascript:/data:/vbscript:/file: while allowing http/https/mailto/tel and
+    /// relative URLs. The <c>style</c> attribute is allowed but its value is run
+    /// through a CSS property allowlist (see <see cref="FilterStyle"/>).
+    ///
+    /// HTML comments are stripped - they render nothing, and one prod footer
+    /// carried a broken half-commented block; dropping them is safe and avoids
+    /// re-serializing malformed comment syntax.
     ///
     /// Emits via HtmlAgilityPack's OuterHtml so HTML entities (e.g.
-    /// <c>&amp;copy;</c>) are preserved verbatim - the operation is idempotent,
-    /// so sanitizing on read AND the editor saving the value back never
-    /// double-encodes. (Rock's own HtmlSanitizer round-trips through
-    /// XmlTextWriter, which re-encodes entities and compounds on every save.)
+    /// <c>&amp;copy;</c>) are preserved verbatim - the operation is idempotent
+    /// (<c>Sanitize(Sanitize(x)) == Sanitize(x)</c>), so sanitizing on read AND
+    /// the editor saving the value back never double-encodes. (Rock's own
+    /// HtmlSanitizer round-trips through XmlTextWriter, which re-encodes entities
+    /// and compounds on every save - which is why we don't use it.)
+    ///
+    /// CRITICAL: HAP 1.4.9.5's OuterHtml does NOT encode interior double-quotes in
+    /// an attribute value, so a smuggled unquoted-attribute payload
+    /// (<c>&lt;img src=x alt=a"onerror="alert(1)&gt;</c>) parses as a single
+    /// <c>alt</c> value <c>a"onerror="alert(1)</c> and re-serializes RAW, letting
+    /// the browser's "missing whitespace between attributes" error recovery
+    /// re-tokenize it into a live event handler (mXSS). We therefore do NOT trust
+    /// HAP re-serialization to be XSS-safe: every retained attribute (including
+    /// <c>style</c>) is written back through <see cref="SetSafeAttribute"/> /
+    /// <see cref="EncodeAttributeValue"/>, which forces a double-quote delimiter
+    /// and entity-encodes the characters that could break the value out of its
+    /// quotes or start a tag (<c>" &lt; &gt;</c>). <c>&amp;</c> is deliberately
+    /// left untouched on ALL paths so pre-existing entities survive verbatim and
+    /// stored bytes stay byte-faithful (see <see cref="FilterStyle"/>).
+    ///
+    /// SECURITY DECODE: the scheme check (<see cref="IsDangerousUrl"/>) and the
+    /// CSS dangerous-value check (<see cref="FilterStyle"/>) must see the text a
+    /// browser would after HTML-decoding, so both decode entities first - but via
+    /// <see cref="SafeDeEntitize"/>, NOT HtmlAgilityPack.HtmlEntity.DeEntitize.
+    /// HAP 1.4.9.5's DeEntitize THROWS <c>KeyNotFoundException</c> on any
+    /// semicolon-terminated named entity absent from its HTML4-era table
+    /// (<c>&amp;colon;</c>, <c>&amp;Tab;</c>, <c>&amp;lpar;</c>, a bogus
+    /// <c>&amp;foo;</c>, ...); since no call site has a try/catch, one stored
+    /// value carrying such a token would permanently 500 the public list viewer.
+    /// <see cref="SafeDeEntitize"/> never throws: it degrades undecodable tokens
+    /// to literal text while still decoding the security-relevant HTML5 named
+    /// entities HAP lacks, so an obfuscated <c>javascript&amp;colon;</c> is still
+    /// neutralized.
     ///
     /// Depends only on HtmlAgilityPack + the BCL (no Rock types) so it is
     /// unit-testable in isolation.
     /// </summary>
     public static class LinkListHtmlSanitizer
     {
-        // Tags removed wholesale (with their subtree). Superset of Rock's default
-        // blacklist + svg/style/base/noscript/applet + math/template/frame/frameset
-        // (foreign-content / mutation-XSS vectors).
-        private static readonly HashSet<string> TagBlackList = new HashSet<string>( StringComparer.OrdinalIgnoreCase )
+        // Tags that are allowed to survive. Everything real prod intro/footer
+        // content uses: layout, inline formatting, headings, tables, lists,
+        // legacy <font>, images and links.
+        private static readonly HashSet<string> AllowedTags = new HashSet<string>( StringComparer.OrdinalIgnoreCase )
+        {
+            "div", "span", "p", "a", "img", "br",
+            "b", "i", "u", "strong", "em",
+            "h1", "h2", "h3", "h4", "h5", "h6",
+            "table", "tbody", "tr", "td", "th",
+            "ul", "ol", "li",
+            "font", "hr", "blockquote", "sub", "sup"
+        };
+
+        // Non-allowlisted tags removed wholesale (with their subtree) rather than
+        // unwrapped, because for these the child content IS the attack payload or
+        // is foreign-content that browsers parse under different rules (mXSS).
+        // Superset of the old blacklist: Rock's defaults + svg/style/base/noscript/
+        // applet + math/template/frame/frameset.
+        private static readonly HashSet<string> DangerousTags = new HashSet<string>( StringComparer.OrdinalIgnoreCase )
         {
             "script", "iframe", "form", "object", "embed", "link", "head", "meta",
             "svg", "style", "base", "noscript", "applet", "math", "template", "frame", "frameset"
         };
 
+        // Attributes allowed on ANY allowlisted tag. Intentionally excludes every
+        // on* handler and every data-* attribute - prod email-builder markup is
+        // class-based (esd-block-*, es-text-*), so `class` covers it. `style` is
+        // handled specially (value-filtered) before this set is consulted.
+        private static readonly HashSet<string> GlobalAttributes = new HashSet<string>( StringComparer.OrdinalIgnoreCase )
+        {
+            "class", "id", "title", "alt", "align", "width", "height",
+            "colspan", "rowspan", "valign", "border", "cellpadding", "cellspacing"
+        };
+
+        // Attributes allowed only on specific tags.
+        private static readonly Dictionary<string, HashSet<string>> PerTagAttributes = new Dictionary<string, HashSet<string>>( StringComparer.OrdinalIgnoreCase )
+        {
+            ["a"] = new HashSet<string>( StringComparer.OrdinalIgnoreCase ) { "href", "target" },
+            ["img"] = new HashSet<string>( StringComparer.OrdinalIgnoreCase ) { "src" },
+            ["font"] = new HashSet<string>( StringComparer.OrdinalIgnoreCase ) { "color", "face", "size" }
+        };
+
+        // Attributes whose value is a URL and must pass the scheme check. Kept in
+        // sync with the URL-bearing entries actually present in the allowlist
+        // above (href on <a>, src on <img>). Other URL-bearing attributes
+        // (formaction, poster, background, xlink:href, ...) are simply absent from
+        // the allowlist and therefore stripped outright.
+        private static readonly HashSet<string> UrlAttributes = new HashSet<string>( StringComparer.OrdinalIgnoreCase )
+        {
+            "href", "src"
+        };
+
+        // CSS properties allowed to survive inside a `style` value. Chosen from a
+        // 2026-08-05 audit of the 59 prod rows that carry style=. Everything else
+        // (position, z-index, display, ...) is dropped.
+        private static readonly HashSet<string> AllowedCssProperties = new HashSet<string>( StringComparer.OrdinalIgnoreCase )
+        {
+            "color", "background-color", "font-family", "font-size",
+            "text-align", "width", "line-height", "margin-left"
+        };
+
         private static readonly Regex ControlAndWhitespace = new Regex( @"[\s\x00-\x1F]", RegexOptions.Compiled );
-        private static readonly Regex DangerousScheme = new Regex( @"^(javascript|data|vbscript|file):", RegexOptions.IgnoreCase | RegexOptions.Compiled );
+
+        // CultureInvariant is REQUIRED: IgnoreCase folds case using the current
+        // thread culture, and Rock sets per-request culture from globalization
+        // settings. Under tr-TR/az, ASCII 'I' does NOT fold to 'i', so a bare
+        // IgnoreCase would let `JAVASCRIPT:` slip past on such a request thread.
+        private static readonly Regex DangerousScheme = new Regex( @"^(javascript|data|vbscript|file):", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled );
+
+        // Defense in depth: reject any declaration whose VALUE can reach out
+        // (url(), @import) or execute (expression(), behavior:, javascript:),
+        // even when the property itself is on the allowlist. CultureInvariant for
+        // the same Turkish-i reason as DangerousScheme above.
+        //
+        // LIMITATION - THIS REGEX IS DECORATIVE, NOT A GUARANTEE. It is BYPASSABLE
+        // by CSS backslash escapes. SafeDeEntitize decodes HTML entities but does
+        // NOT canonicalize CSS escapes, so `\75 rl(` (the `u` of `url` written as
+        // the CSS escape `\75 `) never matches `url\(` here, yet the browser's CSS
+        // tokenizer folds `\75 rl(` back into a real `url(` function token. Proven:
+        // `background-color: \75 rl(//evil/x)` and `width: \75 rl(//evil/x)` both
+        // survive this filter unchanged (see the Style_CssEscaped_Url_* tests).
+        // This is NOT exploitable TODAY only because none of the 8 allowlisted
+        // properties accepts a url()/image value, so the browser drops the whole
+        // declaration - the PROPERTY ALLOWLIST is the sole real guarantee here, NOT
+        // this regex. WARNING: if AllowedCssProperties ever gains a URL- or
+        // image-bearing property (`background`, `background-image`,
+        // `list-style-image`, `cursor`, `content`), this becomes a LIVE
+        // external-fetch / exfiltration vector with no second line of defense.
+        // DangerousCssValue MUST be made escape-aware (canonicalize CSS escapes
+        // before matching) BEFORE any such property is added to the allowlist.
+        private static readonly Regex DangerousCssValue = new Regex( @"url\(|expression\(|behavior|javascript|@import", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled );
+
+        // A single HTML entity reference: numeric (decimal or hex) or a named
+        // token. Used by SafeDeEntitize to decode one token at a time so an
+        // undecodable token can degrade to literal text without failing the rest.
+        //
+        // The terminating ';' is OPTIONAL (';?'). SafeDeEntitize feeds SECURITY
+        // CHECKS ONLY, and a checking decoder must decode AT LEAST as aggressively
+        // as a browser: browsers consume and decode a numeric reference in an
+        // attribute value even without the trailing ';' (an HTML5 parse error, but
+        // the reference is still decoded), so `javascript&#58alert(1)`,
+        // `&#x3a`, and `java&#9script:` all execute if we require the ';'. Under-
+        // decoding is fail-OPEN (an exploit); over-decoding only costs a false-
+        // positive rejection (fail-CLOSED, acceptable). We therefore also decode
+        // named references without a ';' - we deliberately do NOT replicate the
+        // browser's legacy "&name not followed by '=' or alphanumeric" rule; the
+        // resulting false positive on a literal like `&copy` in a URL is harmless
+        // because the scheme regex is anchored at '^' (a decoded query string can
+        // never turn an https URL into a dangerous scheme).
+        private static readonly Regex EntityReference = new Regex(
+            @"&(#[xX][0-9a-fA-F]+|#[0-9]+|[A-Za-z][A-Za-z0-9]*);?", RegexOptions.Compiled );
+
+        // Security-relevant HTML5 named entities that HtmlAgilityPack 1.4.9.5's
+        // HTML4-era table does NOT know. A browser DOES decode these when parsing
+        // the attribute value, and several decode to characters that can spell a
+        // dangerous scheme or CSS function (&colon; -> ':' completes
+        // "javascript:", &lpar;/&rpar; -> '(' ')' completes "url(", &Tab;/&NewLine;
+        // -> control chars the URL parser strips). We MUST decode them so the
+        // security checks see what the browser will. Case-sensitive, per the HTML
+        // spec (StringComparer.Ordinal). Anything NOT here and not known to HAP is
+        // left literal - harmless for the checks, and byte-faithful on write-back.
+        private static readonly Dictionary<string, string> SupplementalEntities = new Dictionary<string, string>( StringComparer.Ordinal )
+        {
+            ["amp"] = "&", ["lt"] = "<", ["gt"] = ">", ["quot"] = "\"", ["apos"] = "'", ["nbsp"] = " ",
+            ["colon"] = ":", ["semi"] = ";", ["period"] = ".", ["sol"] = "/", ["bsol"] = "\\",
+            ["lpar"] = "(", ["rpar"] = ")", ["lbrace"] = "{", ["rbrace"] = "}", ["lcub"] = "{", ["rcub"] = "}",
+            ["lbrack"] = "[", ["rbrack"] = "]", ["lsqb"] = "[", ["rsqb"] = "]",
+            ["num"] = "#", ["percnt"] = "%", ["commat"] = "@", ["excl"] = "!", ["quest"] = "?",
+            ["equals"] = "=", ["ast"] = "*", ["comma"] = ",", ["plus"] = "+", ["lowbar"] = "_",
+            ["dollar"] = "$", ["verbar"] = "|", ["vert"] = "|", ["grave"] = "`", ["Hat"] = "^",
+            ["Tab"] = "\t", ["NewLine"] = "\n"
+        };
+
+        /// <summary>
+        /// Best-effort, single-level, NEVER-throwing HTML entity decode used ONLY
+        /// for the security decisions (URL scheme check and CSS dangerous-value
+        /// check). A drop-in safe replacement for
+        /// HtmlAgilityPack.HtmlEntity.DeEntitize, which throws
+        /// <see cref="KeyNotFoundException"/> on any semicolon-terminated named
+        /// entity outside its HTML4 table (e.g. <c>&amp;colon;</c>, <c>&amp;foo;</c>).
+        ///
+        /// Decodes one entity token at a time so one undecodable token cannot take
+        /// down the whole value: numeric references are parsed with range/surrogate
+        /// guards; named references resolve against <see cref="SupplementalEntities"/>
+        /// first (the HTML5 gaps that matter for security), then fall through to
+        /// HAP's table wrapped in try/catch, and finally degrade to the literal
+        /// token text. Like a browser's attribute-value decode, it is single-level
+        /// (<c>&amp;amp;quot;</c> -> <c>&amp;quot;</c>), which is exactly the depth
+        /// the security checks need.
+        /// </summary>
+        private static string SafeDeEntitize( string value )
+        {
+            if ( string.IsNullOrEmpty( value ) )
+            {
+                return value ?? string.Empty;
+            }
+            return EntityReference.Replace( value, DecodeEntity );
+        }
+
+        private static string DecodeEntity( Match m )
+        {
+            var token = m.Value;            // full reference incl. '&' (';' optional)
+            var body = m.Groups[1].Value;   // "colon" / "#58" / "#x3a"
+
+            if ( body[0] == '#' )
+            {
+                int code;
+                bool parsed;
+                if ( body.Length > 1 && ( body[1] == 'x' || body[1] == 'X' ) )
+                {
+                    parsed = int.TryParse( body.Substring( 2 ), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out code );
+                }
+                else
+                {
+                    parsed = int.TryParse( body.Substring( 1 ), NumberStyles.Integer, CultureInfo.InvariantCulture, out code );
+                }
+
+                // Leave the literal token on anything that is not a valid Unicode
+                // scalar value (out of range, surrogate, or an absurdly long number
+                // that overflows int) - best effort, never throw.
+                if ( !parsed || code < 0 || code > 0x10FFFF || ( code >= 0xD800 && code <= 0xDFFF ) )
+                {
+                    return token;
+                }
+                try
+                {
+                    return char.ConvertFromUtf32( code );
+                }
+                catch
+                {
+                    return token;
+                }
+            }
+
+            if ( SupplementalEntities.TryGetValue( body, out var mapped ) )
+            {
+                return mapped;
+            }
+
+            // Long tail of HTML4 names HAP does know (e.g. &copy;). DeEntitize
+            // THROWS on names it does not know, so wrap it; on throw (or a no-op
+            // result) fall back to the literal token.
+            try
+            {
+                var decoded = HtmlAgilityPack.HtmlEntity.DeEntitize( token );
+                return string.IsNullOrEmpty( decoded ) ? token : decoded;
+            }
+            catch
+            {
+                return token;
+            }
+        }
 
         public static string Sanitize( string html )
         {
@@ -66,42 +327,365 @@ namespace org.secc.LinkList.Utility
         {
             foreach ( var child in node.ChildNodes.ToList() )
             {
-                if ( child.NodeType != HtmlAgilityPack.HtmlNodeType.Element )
+                if ( child.NodeType == HtmlAgilityPack.HtmlNodeType.Comment )
                 {
+                    // Comments render nothing; strip them (see class remarks).
+                    child.Remove();
                     continue;
                 }
 
-                if ( TagBlackList.Contains( child.Name ) )
+                if ( child.NodeType != HtmlAgilityPack.HtmlNodeType.Element )
+                {
+                    // Text nodes pass through verbatim (entities preserved). Any
+                    // other node type (declarations, processing instructions) is
+                    // not content we emit.
+                    continue;
+                }
+
+                var name = child.Name.ToLowerInvariant();
+
+                if ( DangerousTags.Contains( name ) )
                 {
                     child.Remove();
                     continue;
                 }
 
-                foreach ( var attr in child.Attributes.ToList() )
+                if ( !AllowedTags.Contains( name ) )
                 {
-                    var name = attr.Name.ToLowerInvariant();
-                    if ( name.StartsWith( "on" ) )
-                    {
-                        attr.Remove();
-                        continue;
-                    }
-                    if ( name == "href" || name == "src" )
-                    {
-                        // Decode entities, then drop all whitespace/control chars
-                        // before testing the scheme so href="java&#9;script:..."
-                        // can't slip past (the browser strips the tab + executes).
-                        var url = ControlAndWhitespace.Replace(
-                            HtmlAgilityPack.HtmlEntity.DeEntitize( attr.Value ?? string.Empty ),
-                            string.Empty );
-                        if ( DangerousScheme.IsMatch( url ) )
-                        {
-                            attr.Remove();
-                        }
-                    }
+                    // Benign unknown tag: clean the subtree, then unwrap so the
+                    // inner text/children survive while the tag itself is dropped.
+                    Clean( child );
+                    Unwrap( child );
+                    continue;
                 }
 
+                FilterAttributes( child, name );
                 Clean( child );
             }
+        }
+
+        private static void Unwrap( HtmlAgilityPack.HtmlNode node )
+        {
+            var parent = node.ParentNode;
+            if ( parent == null )
+            {
+                node.Remove();
+                return;
+            }
+
+            foreach ( var moved in node.ChildNodes.ToList() )
+            {
+                moved.Remove();
+                parent.InsertBefore( moved, node );
+            }
+            node.Remove();
+        }
+
+        private static void FilterAttributes( HtmlAgilityPack.HtmlNode node, string tag )
+        {
+            foreach ( var attr in node.Attributes.ToList() )
+            {
+                var name = attr.Name.ToLowerInvariant();
+
+                if ( name == "style" )
+                {
+                    // FilterStyle returns the surviving RAW declaration bytes with
+                    // only the attribute-boundary chars (" < >) encoded and '&'
+                    // left verbatim, so it is already safe to emit; we only force
+                    // the quote delimiter here.
+                    var filtered = FilterStyle( attr.Value );
+                    if ( string.IsNullOrEmpty( filtered ) )
+                    {
+                        attr.Remove();
+                    }
+                    else
+                    {
+                        attr.QuoteType = HtmlAgilityPack.AttributeValueQuote.DoubleQuote;
+                        attr.Value = filtered;
+                    }
+                    continue;
+                }
+
+                if ( !IsAttributeAllowed( tag, name ) )
+                {
+                    attr.Remove();
+                    continue;
+                }
+
+                if ( UrlAttributes.Contains( name ) && IsDangerousUrl( attr.Value ) )
+                {
+                    attr.Remove();
+                    continue;
+                }
+
+                // Attribute survives. Write it back safely: HAP 1.4.9.5 will emit
+                // interior double-quotes RAW, so a smuggled `alt=a"onerror="...`
+                // would re-tokenize into a live handler (mXSS). Force a
+                // double-quote delimiter and entity-encode the break-out chars.
+                SetSafeAttribute( attr, EncodeAttributeValue( attr.Value ) );
+            }
+        }
+
+        // Force a stable double-quote delimiter for a retained attribute so its
+        // value can only be terminated by a literal '"' (which the encoders above
+        // have already removed). Without this, an attribute whose source was
+        // unquoted or single-quoted could still re-serialize in a way that lets
+        // the value break out.
+        private static void SetSafeAttribute( HtmlAgilityPack.HtmlAttribute attr, string encodedValue )
+        {
+            attr.QuoteType = HtmlAgilityPack.AttributeValueQuote.DoubleQuote;
+            attr.Value = encodedValue;
+        }
+
+        // Entity-encode ONLY the characters that can break a value out of its
+        // double-quoted attribute or open a tag. '&' is deliberately NOT encoded:
+        // attr.Value here is HAP's RAW (still entity-encoded) text, so touching
+        // '&' would double-encode legitimate entities (&copy;, &quot;) and break
+        // both the verbatim-entity contract and idempotency. A literal '"' in this
+        // raw text can only be a smuggled/mal-formed boundary (well-formed values
+        // carry it as &quot;), so encoding it is always safe.
+        private static string EncodeAttributeValue( string rawValue )
+        {
+            if ( string.IsNullOrEmpty( rawValue ) )
+            {
+                return rawValue;
+            }
+            return rawValue
+                .Replace( "\"", "&quot;" )
+                .Replace( "<", "&lt;" )
+                .Replace( ">", "&gt;" );
+        }
+
+        private static bool IsAttributeAllowed( string tag, string attribute )
+        {
+            if ( GlobalAttributes.Contains( attribute ) )
+            {
+                return true;
+            }
+            return PerTagAttributes.TryGetValue( tag, out var allowed ) && allowed.Contains( attribute );
+        }
+
+        private static bool IsDangerousUrl( string value )
+        {
+            // Decode entities (via the never-throwing SafeDeEntitize - HAP's
+            // DeEntitize would throw KeyNotFoundException on e.g. href="&colon;"),
+            // then drop all whitespace/control chars before testing the scheme so
+            // href="java&#9;script:..." or href="javascript&colon;..." can't slip
+            // past (the browser decodes/strips + executes).
+            var url = ControlAndWhitespace.Replace(
+                SafeDeEntitize( value ?? string.Empty ),
+                string.Empty );
+            return DangerousScheme.IsMatch( url );
+        }
+
+        /// <summary>
+        /// Filters a raw <c>style</c> attribute value down to the allowlisted CSS
+        /// properties, dropping any declaration whose value looks like it reaches
+        /// out or executes.
+        ///
+        /// The raw value HAP hands us is STILL ENTITY-ENCODED. We do NOT decode
+        /// the whole value before splitting: a single-level decode of a
+        /// DOUBLE-encoded entity (<c>&amp;amp;quot;</c> -> <c>&amp;quot;</c>) leaves
+        /// a literal ';' that <c>Split(';')</c> would then treat as a declaration
+        /// separator, silently discarding the remainder of a font stack. Instead
+        /// we split the RAW value on ';' and REATTACH (with its ';') any segment
+        /// that does not itself begin a new "property:value" declaration onto the
+        /// current declaration's value - so no bytes are ever dropped, at any
+        /// entity-nesting depth (see <see cref="StartsNewDeclaration"/>).
+        ///
+        /// Security decisions (the property-allowlist match and the
+        /// <see cref="DangerousCssValue"/> test) run on a best-effort
+        /// <see cref="SafeDeEntitize"/> decode so they see the same text the
+        /// browser will after HTML-decoding (<c>&amp;#117;rl(</c> -> <c>url(</c>
+        /// is still caught). But the STORED bytes written back are the ORIGINAL
+        /// raw declaration text - only the attribute-boundary chars (" &lt; &gt;)
+        /// are encoded, '&amp;' is left verbatim - so the value is byte-faithful
+        /// and needs no re-encoding step (this also removes the old
+        /// <c>&amp;nbsp;</c> -> U+00A0 / <c>&amp;#39;</c> -> ' round-trip mutation).
+        ///
+        /// Because the stored bytes are raw, a value that clears validation in its
+        /// raw form could still DECODE, in the browser, into a string carrying a
+        /// declaration separator plus a second <c>property:value</c> - re-splitting
+        /// past this filter into a live second declaration.
+        /// <see cref="DecodedValueSmugglesDeclaration"/> closes that: a declaration
+        /// is kept only if BOTH its raw and its aggressively-decoded forms are safe.
+        ///
+        /// Property is the text before the first ':'. Returns the surviving
+        /// declarations joined with "; ", or an empty string if none survive
+        /// (caller removes the attribute). Output is normalized so re-running the
+        /// filter over it is a no-op (idempotency).
+        /// </summary>
+        private static string FilterStyle( string style )
+        {
+            if ( string.IsNullOrWhiteSpace( style ) )
+            {
+                return string.Empty;
+            }
+
+            // Split the RAW (still entity-encoded) value on ';', then re-join any
+            // segment that is not itself a new declaration back onto the current
+            // value (restoring the ';' we split on). This is byte-faithful and
+            // immune to entity nesting depth - no DeEntitize-before-split.
+            var declarations = new List<string>();
+            string current = null;
+            foreach ( var segment in style.Split( ';' ) )
+            {
+                if ( StartsNewDeclaration( segment ) )
+                {
+                    if ( current != null )
+                    {
+                        declarations.Add( current );
+                    }
+                    current = segment;
+                }
+                else if ( current != null )
+                {
+                    // Continuation of the current value: restore the split ';'.
+                    current = current + ";" + segment;
+                }
+                // else: leading text with no property to attach to - drop it.
+            }
+            if ( current != null )
+            {
+                declarations.Add( current );
+            }
+
+            var kept = new List<string>();
+            foreach ( var declaration in declarations )
+            {
+                var trimmed = declaration.Trim();
+                var colon = trimmed.IndexOf( ':' );
+                if ( colon <= 0 )
+                {
+                    continue;
+                }
+
+                var rawProperty = trimmed.Substring( 0, colon ).Trim();
+                var rawValue = trimmed.Substring( colon + 1 ).Trim();
+                if ( rawValue.Length == 0 )
+                {
+                    continue;
+                }
+
+                // Best-effort decode ONLY for the security decisions; the browser
+                // HTML-decodes the attribute value before the CSS parser sees it,
+                // so decode to test the same text. The bytes kept are the raw ones.
+                var decodedValue = SafeDeEntitize( rawValue );
+                if ( !AllowedCssProperties.Contains( SafeDeEntitize( rawProperty ) ) )
+                {
+                    continue;
+                }
+                // NOTE: DangerousCssValue is DECORATIVE, not a guarantee - a CSS
+                // backslash escape (`\75 rl(`) slips past it (SafeDeEntitize does
+                // not canonicalize CSS escapes). The property allowlist above is
+                // what actually keeps a url()/image value from ever mattering. See
+                // the LIMITATION note on the DangerousCssValue field.
+                if ( DangerousCssValue.IsMatch( decodedValue ) )
+                {
+                    continue;
+                }
+                // The declaration bytes are written back RAW (byte-faithful). The
+                // browser HTML-decodes the attribute BEFORE the CSS parser runs, so
+                // a value that is safe in its raw form can DECODE into text that
+                // carries a declaration separator and a second "property:value" -
+                // re-splitting, in the browser, past this allowlist into a live
+                // second declaration (external url() fetch, position:fixed overlay,
+                // expression()). Reject the declaration if its DECODED value could
+                // form more declarations than we validated.
+                if ( DecodedValueSmugglesDeclaration( decodedValue ) )
+                {
+                    continue;
+                }
+
+                kept.Add( rawProperty + ": " + rawValue );
+            }
+
+            if ( kept.Count == 0 )
+            {
+                return string.Empty;
+            }
+
+            // Encode ONLY the attribute-boundary chars (" < >) so a smuggled
+            // literal quote can't break the style value out of its double quotes.
+            // '&' is left untouched, so entity-encoded content (&quot; font names,
+            // &amp;quot; double-encoded) is preserved verbatim and idempotent.
+            return EncodeAttributeValue( string.Join( "; ", kept ) );
+        }
+
+        // A style segment (post Split(';')) begins a NEW declaration only if the
+        // text before its first ':' is a plausible CSS property name (a non-empty
+        // run of ASCII letters and '-'). Segments with no ':' - or whose pre-':'
+        // text is not property-shaped, e.g. a font-family fragment like
+        // <c>Segoe UI&amp;quot</c> - are continuations of the preceding value and
+        // must be re-joined rather than parsed as their own declaration. The
+        // property name is SafeDeEntitize'd first for parity with the browser.
+        private static bool StartsNewDeclaration( string segment )
+        {
+            var colon = segment.IndexOf( ':' );
+            if ( colon <= 0 )
+            {
+                return false;
+            }
+            var beforeColon = SafeDeEntitize( segment.Substring( 0, colon ) ).Trim();
+            return beforeColon.Length > 0
+                && beforeColon.All( c => c == '-' || ( c >= 'a' && c <= 'z' ) || ( c >= 'A' && c <= 'Z' ) );
+        }
+
+        // Post-decode gate for a single declaration's VALUE (BLOCKER B). This runs
+        // on the SafeDeEntitize'd (entity-decoded) value. Its job is to reject a
+        // value that could act as a property/value SEPARATOR once the browser's
+        // CSS tokenizer sees it. The MECHANISM matters, because the tokenizer
+        // treats the different "colon" spellings very differently, and the naive
+        // reading ("a browser re-materializes a ':' out of whatever we stored, so
+        // catch a literal ':'") is BACKWARDS for CSS escapes:
+        //
+        //   * A LITERAL ':' and an ENTITY-ENCODED colon (`&#58;`, `&#x3a;`,
+        //     `&colon;`) both become a bare <colon-token> - exactly the token that
+        //     separates a property from a value and can open a smuggled second
+        //     declaration. Because the value is stored RAW (byte-faithful), an
+        //     entity-encoded colon survives write-back and the browser HTML-decodes
+        //     it back to a real ':' BEFORE the CSS parser runs. SafeDeEntitize
+        //     decodes every colon form a browser would, so testing the DECODED
+        //     value for ':' catches the literal AND every entity spelling. This is
+        //     the SOLE reason the entity-decode step must stay: without it,
+        //     `position&#58;fixed` clears this gate in raw form and then
+        //     re-materializes into a live declaration in the browser. Do NOT
+        //     "simplify away" that decode.
+        //
+        //   * A CSS BACKSLASH ESCAPE (`position\3a fixed`, or the same written as
+        //     an HTML entity `position&#92;3a fixed` / `position&bsol;3a fixed`,
+        //     which the browser decodes to a backslash FIRST) does NOT produce a
+        //     separator. `\3a` is a CSS escape that yields a colon CODE POINT
+        //     appended to the current identifier - ident content, never a
+        //     <colon-token>. (Same reason `.foo\:bar` selects a class literally
+        //     named `foo:bar`.) So an escaped colon can NEVER separate a property
+        //     from a value: the browser folds `position\3a fixed` into one invalid
+        //     identifier and drops the declaration. Escaped colons are INERT, we do
+        //     not need to catch them, and SafeDeEntitize deliberately leaves the
+        //     CSS-escape backslash untouched - so an escaped colon reaches this
+        //     gate with no literal ':' and correctly passes.
+        //
+        // So a new live CSS declaration always needs that bare <colon-token>; a
+        // rule block needs '{' or '}'. NONE of the 8 allowlisted property VALUES
+        // legitimately contain a ':' , '{' or '}' (verified against the 2026-08-05
+        // 59-row prod audit), so their presence in the DECODED value means a
+        // smuggled declaration - reject it.
+        //
+        // A bare ';' is deliberately NOT rejected: on its own (with no following
+        // property:value) it cannot form a new live declaration, and single-level
+        // decoding of legitimate DOUBLE-encoded font stacks (`&amp;quot;` -> the
+        // literal `&quot;`, `&amp;#59;` -> `&#59;`) yields inert ';' that must stay
+        // byte-faithful. Keying on the ':' (and braces) catches every confirmed
+        // smuggling payload while leaving those intact.
+        private static bool DecodedValueSmugglesDeclaration( string decodedValue )
+        {
+            if ( string.IsNullOrEmpty( decodedValue ) )
+            {
+                return false;
+            }
+            return decodedValue.IndexOf( ':' ) >= 0
+                || decodedValue.IndexOf( '{' ) >= 0
+                || decodedValue.IndexOf( '}' ) >= 0;
         }
     }
 }


### PR DESCRIPTION
Closes ROCK-8880.

## What

Replaces `LinkListHtmlSanitizer`'s tag **blacklist** with a tag + per-tag-attribute **allowlist**, built on the HtmlAgilityPack that Rock already provides. No new dependency.

This is the sole server-side XSS defense for the four freeform HTML fields (intro, footer, global header, global footer), and it is the single chokepoint every consumer flows through — the viewer block, the detail block, and the public REST controller all go through `LinkListService.BuildBag`.

## Why: two defects reproduced in the code currently on the branch

Both were measured, not inferred. The committed blacklist implementation was compiled standalone against the HtmlAgilityPack 1.4.9.5 that Rock ships in `RockWeb\Bin`, and both reproduced:

1. **Attribute-boundary mutation XSS.** A handler smuggled into the *value* of an allowlisted attribute re-serialized with its interior quote unescaped, and the browser's error recovery re-split it into a live event handler. Confirmed firing in a real browser, no user interaction required.
2. **Unhandled `KeyNotFoundException` from `HtmlEntity.DeEntitize`** on any HTML5 named entity outside its HTML4-era table. One stored value containing such an entity returns a server error from the **public** list viewer. Fails closed, so it is availability rather than disclosure — but it is reachable anonymously.

Neither mechanism depends on anything the rewrite introduced, so these are pre-existing production defects rather than regressions. That is what makes this worth merging promptly.

## How

- **Tags:** allowlist only. Dangerous tags are removed with their subtree; benign unknown tags are unwrapped so their text survives.
- **Attributes:** a global safe set plus per-tag extras (`href`/`target` on anchors, `src` on images, `color`/`face`/`size` on font). Everything else is stripped by absence — all `on*` handlers, `data-*`, and other URL-bearing attributes such as `formaction`, `poster`, `background`, `xlink:href`.
- **URL schemes:** `href` and `src` are checked against a decoded, whitespace- and control-stripped value, blocking `javascript`, `data`, `vbscript`, and `file`, including entity-obfuscated spellings. The regexes are `CultureInvariant`, so per-request Turkish/Azeri culture on a Rock thread cannot fold `I`/`i` into a bypass.
- **Serialization:** every retained attribute is written back with a forced double-quote delimiter and its break-out characters encoded, which is what closes defect 1. Output still goes through `OuterHtml`, so entities are preserved verbatim and `Sanitize` stays idempotent — load-bearing, because `BuildBag` sanitizes on every render rather than on save.
- **Entity decoding** for the security checks uses a purpose-built decoder that never throws, closing defect 2 while still decoding the security-relevant HTML5 names HtmlAgilityPack lacks.

### Two decoder-parity gates

These exist because hand-rolled parsing against a 2012-era parser keeps diverging from browsers, and each divergence is a bypass:

- **The checking decoder must decode at least as aggressively as a browser.** The trailing semicolon on a character reference is now optional, matching what browsers actually decode. The asymmetry is deliberate and documented in the code: over-decoding fails closed and costs at most a false-positive rejection, while under-decoding fails open and is an exploit.
- **A CSS declaration is rejected when its decoded form could re-split into a second declaration in the browser.** Declarations are written back as raw bytes for fidelity, so the invariant that matters is that those bytes cannot decode into more declarations than were validated.

## `style` is allowed, filtered to eight CSS properties

Banning `style` outright was the original plan and prod data reversed it. A read-only audit found **59 rows using `style=`** (52 intro, 7 footer, none global, and zero `<style>` tags), depending on it for white-on-color text, alignment, image widths, and font stacks. Stripping it would have visibly broken dozens of live lists.

The allowlist — `color`, `background-color`, `font-family`, `font-size`, `text-align`, `width`, `line-height`, `margin-left` — is exactly the set present in that content. Everything else is dropped, including `position` and `z-index` (clickjacking overlays), `url(...)`, `expression(...)`, and `behavior`. Zero production rows are visually affected.

One limitation is documented in the code rather than fixed: the dangerous-value regex is bypassable by escaping a function name, so it is decorative against CSS backslash escapes and **the property allowlist is the sole real guarantee**. Not exploitable today, because none of the eight properties accepts a URL or image value. The comment states plainly that it must be made escape-aware before any URL-bearing property is ever added.

## Testing

**189 tests** (net472, xUnit), up from 9. The nine originals are kept verbatim.

New coverage: both reproduced defects; semicolon-less entity scheme bypasses on `href` and `src`; entity-smuggled CSS declarations asserted against the **decoded** output rather than a raw substring; the CSS backslash-escape attack class; byte fidelity of real stored font stacks including double-encoded ones; a `tr-TR` culture test; malformed real-world content from a live list; bare-`<td>` fragment roots; and idempotency across every payload, including that the *first* pass is already safe.

Substring-only assertions are what let earlier bugs through a green suite, so the new tests assert on decoded and re-parsed forms.

```
dotnet test -p:RockWebPath=C:\path\to\Rock\RockWeb
```

Run it from PowerShell with an **absolute** path. A relative path or Git Bash mangles the argument, the HtmlAgilityPack `HintPath` fails to resolve, and the result looks like a compile error rather than a bad argument.

## Content-regression audit

A throwaway harness ran every stored value through the new sanitizer, comparing dropped tags, attributes, CSS properties, and visible text rather than doing a character diff (which flags nearly every row, since quoting is legitimately renormalized).

**177 stored values: 147 byte-identical, 30 differing only in quoting or ordering, and zero that lost a tag, attribute, CSS property, or any visible text.**

The harness was validated in both directions before that green was trusted — real content came back clean, and four deliberate canaries were all correctly flagged.

## Also verified locally

- Full Rock solution build in Visual Studio.
- Both defects demonstrated firing against the old code in a real browser, then confirmed gone.
- Devtools confirmed the deliberately-passed-through escaped CSS declaration is genuinely inert: the browser applies `color` and marks the smuggled declaration invalid. This was the one assumption the whole defense rested on, and it had only been reasoned from spec until it was checked in a browser.

## Scope

Two files: the sanitizer and its tests. No changes to the service, the call sites, the web component, or any project dependency. The public API `static string Sanitize(string)` is unchanged.

## Follow-ons, deliberately not here

- **Client-side sanitization (DOMPurify).** Attractive because in the browser the parser *is* the browser, so the differential is zero by construction. It does not replace this change: the REST controller hands the same bag to third-party consumers as JSON and they render it themselves, so the server chokepoint has to be correct regardless.
- **Making the dangerous-CSS-value check escape-aware**, required before the property allowlist is extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
