### PR TITLE
ROCK-8987 LinkList: multiple slugs per list with primary designation

### DIFF
--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/components/linkListEditor.obs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/components/linkListEditor.obs
@@ -1,6 +1,7 @@
 <template>
     <div class="link-list-editor">
         <NotificationBox v-if="errorMessage" alertType="danger">{{ errorMessage }}</NotificationBox>
+        <NotificationBox v-if="warningMessage" alertType="warning">{{ warningMessage }}</NotificationBox>
 
         <div v-if="!detail" class="text-center p-3">
             <i class="fa fa-spinner fa-spin"></i> Loading...
@@ -17,40 +18,62 @@
             <Panel title="Details" :hasCollapse="true" v-model="detailsExpanded">
                 <div class="row">
                     <div class="col-md-6">
-                        <TextBox v-model="bag.title" label="Title" :rules="'required'" />
+                        <TextBox v-model="bag.title" label="Title" :rules="'required'" @blur="deriveSlugFromTitle" />
                     </div>
                     <div class="col-md-6">
-                        <label class="control-label">Slugs</label>
-                        <div class="ll-slugs">
-                            <div v-for="(s, i) in bag.slugs || []" :key="s.id || `new-${i}`" class="ll-slug-row">
+                        <label id="ll-slugs-label" class="control-label">Slugs</label>
+                        <div ref="slugListEl" class="ll-slugs" role="group" aria-labelledby="ll-slugs-label">
+                            <!-- Keyed by slug text, not by index: slug text is unique
+                                 within a list and never edited in place, whereas an
+                                 index key would survive a removal and hand the focused
+                                 Remove button to the NEXT row. -->
+                            <div v-for="(s, i) in bag.slugs || []" :key="s.slug" class="ll-slug-row">
                                 <button
                                     type="button"
                                     class="btn btn-link btn-xs ll-slug-primary"
                                     :class="{ 'is-primary': s.isPrimary }"
                                     :title="s.isPrimary ? 'Primary slug (used in shared links)' : 'Make primary'"
+                                    :aria-label="s.isPrimary ? `${s.slug} is the primary slug` : `Make ${s.slug} the primary slug`"
+                                    :aria-pressed="s.isPrimary"
                                     @click="setPrimary(i)">
                                     <i :class="s.isPrimary ? 'fa fa-star' : 'fa fa-star-o'"></i>
                                 </button>
                                 <code class="ll-slug-text">{{ s.slug }}</code>
-                                <span v-if="s.isPrimary" class="label label-info ll-slug-badge">Primary</span>
+                                <!-- Decorative: the star button already announces which
+                                     slug is primary, via aria-label and aria-pressed. -->
+                                <span v-if="s.isPrimary" class="label label-info ll-slug-badge" aria-hidden="true">Primary</span>
+                                <span v-if="s.slug === autoDerivedSlug" class="text-muted small ll-slug-origin">from title</span>
+                                <!-- aria-disabled rather than disabled, so the control keeps
+                                     its place in the tab order and can still explain itself;
+                                     removeSlug refuses the last slug either way. The
+                                     `disabled` CLASS is avoided too - Bootstrap gives it
+                                     pointer-events: none, which would also swallow the click
+                                     that produces the explanation. -->
                                 <button
                                     type="button"
-                                    class="btn btn-link text-danger btn-xs ms-auto"
-                                    :disabled="(bag.slugs || []).length <= 1"
+                                    class="btn btn-link btn-xs ms-auto ll-slug-remove"
+                                    :class="(bag.slugs || []).length <= 1 ? 'text-muted' : 'text-danger'"
+                                    :aria-disabled="(bag.slugs || []).length <= 1"
                                     :title="(bag.slugs || []).length <= 1 ? 'A list must have at least one slug' : 'Remove slug'"
+                                    :aria-label="`Remove slug ${s.slug}`"
+                                    aria-describedby="ll-slug-message"
                                     @click="removeSlug(i)">
                                     <i class="fa fa-times"></i>
                                 </button>
                             </div>
-                            <div v-if="!(bag.slugs || []).length" class="text-muted small">No slugs yet. Add one below.</div>
+                            <div v-if="!(bag.slugs || []).length" class="text-muted small">No slugs yet. One is created from the title when you save.</div>
                         </div>
                         <div class="ll-slug-add">
-                            <TextBox v-model="newSlug" placeholder="new-slug" @keydown.enter.prevent="addSlug" />
-                            <RockButton btnType="default" btnSize="sm" :disabled="!newSlug.trim()" @click="addSlug">
+                            <TextBox v-model="newSlug" placeholder="new-slug" aria-label="Add a slug" :maxLength="SLUG_MAX_LENGTH" @keydown.enter.prevent="addSlug" />
+                            <RockButton btnType="default" btnSize="sm" :disabled="!canonicalizeSlug(newSlug)" @click="addSlug">
                                 <i class="fa fa-plus"></i> Add
                             </RockButton>
                         </div>
-                        <span class="help-block">Lowercase letters, digits, and dashes only. The primary slug is used in shared links; keeping extra slugs preserves old URLs.</span>
+                        <!-- Slug-specific messages live here, next to the controls that
+                             produce them, so adding a slug can't clear an unresolved
+                             save failure from the banner at the top of the block. -->
+                        <span id="ll-slug-message" class="help-block text-danger ll-slug-message" role="alert">{{ slugMessage }}</span>
+                        <span class="help-block">{{ slugHelpText }}</span>
                     </div>
                 </div>
                 <div class="row">
@@ -251,7 +274,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useInvokeBlockAction } from "@Obsidian/Utility/block";
 import RockButton from "@Obsidian/Controls/rockButton.obs";
 import Panel from "@Obsidian/Controls/panel.obs";
@@ -269,6 +292,7 @@ import EditorActions from "./editorActions.obs";
 import LinkListAnalytics from "./linkListAnalytics.obs";
 import { CUSTOM_DESIGN, effectiveColor as effectiveColorOf, designSelectionValue, applyDesignChange, type ColorField } from "../linkListTheme";
 import { clearOtherFeatured, sectionNestingMeta } from "../linkListItems";
+import { canonicalizeSlug, SLUG_MAX_LENGTH } from "../slugCanonicalizer";
 import type { ListItemBag } from "@Obsidian/ViewModels/Utility/listItemBag";
 import type { LinkListBag, LinkListDetailInitializationBox, LinkItemBag, GroupMemberBag, LinkListSlugBag } from "../types";
 
@@ -284,8 +308,18 @@ const emit = defineEmits<{
 const invokeBlockAction = useInvokeBlockAction();
 
 const bag = ref<LinkListBag>(cloneBag(props.detail.linkList));
+// Block-level failures (save, delete, member actions) only. Slug-add/remove
+// messages go to slugMessage so the two can't overwrite each other.
 const errorMessage = ref("");
+// A save that partially succeeded: the list is stored but something after it
+// failed, so this is a warning to act on rather than an outright failure.
+const warningMessage = ref("");
+const slugMessage = ref("");
 const newSlug = ref("");
+// The slug derived from the title on this screen, if any - so the row can be
+// labelled "from title" and can yield primary to the first slug the user adds.
+const autoDerivedSlug = ref("");
+const slugListEl = ref<HTMLElement | null>(null);
 const isSaving = ref(false);
 const isAddingMember = ref(false);
 const memberToAdd = ref<{ value: string; text: string } | null>(null);
@@ -310,6 +344,14 @@ watch(analyticsExpanded, expanded => {
 
 watch(() => props.detail, d => {
     bag.value = cloneBag(d.linkList);
+    // Reset the per-screen scratch state too. The parent swaps `detail` in place
+    // after a create (same component instance, no :key), and stale text left in
+    // the add box would otherwise be committed to the newly loaded list.
+    newSlug.value = "";
+    errorMessage.value = "";
+    warningMessage.value = "";
+    slugMessage.value = "";
+    autoDerivedSlug.value = "";
 });
 
 const designItems = computed(() => [
@@ -384,29 +426,59 @@ function normalizeSlugs(target: LinkListBag): void {
     }
 }
 
-// Mirror the server's slug rule (LinkListService.IsValidSlug) for immediate
-// feedback; the server stays the source of truth.
-const SLUG_PATTERN = /^[a-z0-9-]+$/;
-const SLUG_MAX_LENGTH = 200;
+const slugHelpText = `A slug is built from the title automatically: lowercase, `
+    + `spaces and underscores become dashes, anything else is dropped (max `
+    + `${SLUG_MAX_LENGTH} characters). The primary slug is used in shared links; `
+    + `keeping extra slugs preserves old URLs.`;
 
+// Adds whatever is in the add box, converted to the slug Rock will actually
+// store. Always leaves the box empty. Never blocks anything: the Add button is
+// disabled unless the text yields a slug, and a slug already in the list is a
+// no-op worth only a note.
 function addSlug(): void {
-    const text = (newSlug.value || "").trim().toLowerCase();
-    if (!text) {
+    const typed = (newSlug.value || "").trim();
+    if (!typed) {
         return;
     }
-    if (text.length > SLUG_MAX_LENGTH || !SLUG_PATTERN.test(text)) {
-        errorMessage.value = `Slug "${text}" must be 1-${SLUG_MAX_LENGTH} lowercase letters, digits, or dashes.`;
+    newSlug.value = "";
+    const text = canonicalizeSlug(typed);
+    if (!text) {
+        slugMessage.value = `Ignored "${typed}" - no letters or digits to build a slug from.`;
         return;
     }
     const slugs: LinkListSlugBag[] = bag.value.slugs || (bag.value.slugs = []);
     if (slugs.some(s => s.slug === text)) {
-        errorMessage.value = `Slug "${text}" is already in the list.`;
+        slugMessage.value = `Slug "${text}" is already in the list.`;
         return;
     }
-    slugs.push({ id: 0, slug: text, isPrimary: slugs.length === 0 });
+    // A slug the user typed outranks one derived from the title: if that derived
+    // slug is all the list has, hand primary to this one.
+    const onlyAutoDerived = slugs.length > 0 && slugs.every(s => s.slug === autoDerivedSlug.value);
+    const isPrimary = slugs.length === 0 || onlyAutoDerived;
+    if (isPrimary) {
+        slugs.forEach(s => { s.isPrimary = false; });
+    }
+    slugs.push({ id: 0, slug: text, isPrimary });
     ensureOnePrimary();
-    newSlug.value = "";
-    errorMessage.value = "";
+    slugMessage.value = "";
+}
+
+// Derives the first slug from the title, the way Rock's own content channel item
+// block does: on leaving the title field, and ONLY while the list has no slug
+// yet - so editing the title of an existing list never changes its URLs. The
+// result is an ordinary slug row the user can re-star, replace or remove.
+function deriveSlugFromTitle(): string {
+    if ((bag.value.slugs || []).length) {
+        return "";
+    }
+    const derived = canonicalizeSlug(bag.value.title);
+    if (!derived) {
+        return "";
+    }
+    const slugs: LinkListSlugBag[] = bag.value.slugs || (bag.value.slugs = []);
+    slugs.push({ id: 0, slug: derived, isPrimary: true });
+    autoDerivedSlug.value = derived;
+    return derived;
 }
 
 function removeSlug(index: number): void {
@@ -417,14 +489,26 @@ function removeSlug(index: number): void {
     // A list must keep at least one slug or it becomes unreachable (the viewer
     // and web component resolve only by slug). The server enforces this too.
     if (slugs.length <= 1) {
-        errorMessage.value = "A link list must have at least one slug.";
+        slugMessage.value = "A link list must have at least one slug.";
         return;
     }
-    const wasPrimary = slugs[index]?.isPrimary;
+    const removed = slugs[index];
+    const wasPrimary = removed?.isPrimary;
     slugs.splice(index, 1);
+    if (removed?.slug === autoDerivedSlug.value) {
+        autoDerivedSlug.value = "";
+    }
     if (wasPrimary) {
         ensureOnePrimary();
     }
+    slugMessage.value = "";
+    // Removing a row destroys the button that had focus, which would otherwise
+    // drop to the document body; put it on the row that took this one's place.
+    const nextIndex = Math.min(index, slugs.length - 1);
+    nextTick(() => {
+        const buttons = slugListEl.value?.querySelectorAll<HTMLButtonElement>(".ll-slug-remove");
+        buttons?.[nextIndex]?.focus();
+    });
 }
 
 function setPrimary(index: number): void {
@@ -520,10 +604,15 @@ function moveRow(index: number, delta: number): void {
 
 async function save(): Promise<void> {
     errorMessage.value = "";
-    // A list must have at least one slug (server enforces this too); block the
-    // save with a friendly message rather than round-tripping to a 400.
-    if (!(bag.value.slugs || []).length) {
-        errorMessage.value = "Add at least one slug before saving.";
+    // Commit a slug still sitting unadded in the add box, so typing one and
+    // hitting Save can't silently drop it. addSlug always empties the box and
+    // never refuses, so this can't turn into a save that won't go through.
+    addSlug();
+    // A list must have at least one slug or it becomes unreachable. Derive one
+    // from the title (as Rock does) rather than making the user type it; only
+    // complain when the title has nothing to build a slug from.
+    if (!(bag.value.slugs || []).length && !deriveSlugFromTitle()) {
+        slugMessage.value = "Add a slug: this title has no letters or digits to build one from.";
         return;
     }
     // Keep the scalar (primary) slug aligned with the chosen primary before
@@ -535,8 +624,21 @@ async function save(): Promise<void> {
     isSaving.value = false;
 
     if (result.isSuccess && result.data) {
+        // A partial save still returns the bag, so the list keeps its identity and the
+        // next save is an update rather than a doomed re-create. Adopt it either way
+        // and surface the warning instead of claiming a clean save.
+        const warning = result.data.saveWarning;
         bag.value = cloneBag(result.data);
-        emit("saved", result.data);
+        bag.value.saveWarning = null;
+        if (warning) {
+            // Stay on the editor so the user can fix and re-save; emitting "saved"
+            // would navigate away from a list that isn't fully written yet.
+            warningMessage.value = warning;
+        }
+        else {
+            warningMessage.value = "";
+            emit("saved", result.data);
+        }
     }
     else {
         errorMessage.value = result.errorMessage || "Save failed.";
@@ -606,6 +708,9 @@ async function removeMember(groupMemberId: number): Promise<void> {
 .ll-slug-primary.is-primary { color: #f0ad4e; }
 .ll-slug-text { background: #f5f5f5; padding: 2px 6px; border-radius: 3px; }
 .ll-slug-badge { font-weight: normal; }
+/* Stays in the DOM even when empty so it can act as a live region; no margin so
+   an empty message doesn't leave a gap above the help text. */
+.ll-slug-message { margin: 0; }
 .ll-slug-add { display: flex; align-items: start; gap: 8px; }
 .ll-slug-add > :first-child { flex-grow: 1; }
 </style>

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/components/linkListEditor.obs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/components/linkListEditor.obs
@@ -2,6 +2,7 @@
     <div class="link-list-editor">
         <NotificationBox v-if="errorMessage" alertType="danger">{{ errorMessage }}</NotificationBox>
         <NotificationBox v-if="warningMessage" alertType="warning">{{ warningMessage }}</NotificationBox>
+        <NotificationBox v-if="noticeMessage" alertType="info">{{ noticeMessage }}</NotificationBox>
 
         <div v-if="!detail" class="text-center p-3">
             <i class="fa fa-spinner fa-spin"></i> Loading...
@@ -314,6 +315,9 @@ const errorMessage = ref("");
 // A save that partially succeeded: the list is stored but something after it
 // failed, so this is a warning to act on rather than an outright failure.
 const warningMessage = ref("");
+// A save that fully succeeded but merged a concurrent slug edit - informational, so it
+// does not hold the user on the page the way warningMessage does.
+const noticeMessage = ref("");
 const slugMessage = ref("");
 const newSlug = ref("");
 // The slug derived from the title on this screen, if any - so the row can be
@@ -353,6 +357,7 @@ watch(() => props.detail, d => {
     newSlug.value = "";
     errorMessage.value = "";
     warningMessage.value = "";
+    noticeMessage.value = "";
     slugMessage.value = "";
     autoDerivedSlug.value = "";
 });
@@ -649,9 +654,15 @@ async function save(): Promise<void> {
         // next save is an update rather than a doomed re-create. Adopt it either way
         // and surface the warning instead of claiming a clean save.
         const warning = result.data.saveWarning;
+        // Reports a concurrent edit this save merged. The save DID succeed, so unlike a
+        // warning it doesn't suppress "saved" - it just explains a slug list that may
+        // not match what was on screen.
+        const notice = result.data.saveNotice;
         bag.value = cloneBag(result.data);
         bag.value.saveWarning = null;
+        bag.value.saveNotice = null;
         rememberLoadedSlugIds(result.data);
+        noticeMessage.value = notice || "";
         if (warning) {
             // Stay on the editor so the user can fix and re-save; emitting "saved"
             // would navigate away from a list that isn't fully written yet.

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/components/linkListEditor.obs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/components/linkListEditor.obs
@@ -20,7 +20,37 @@
                         <TextBox v-model="bag.title" label="Title" :rules="'required'" />
                     </div>
                     <div class="col-md-6">
-                        <TextBox v-model="bag.slug" label="Slug" help="Lowercase letters, digits, and dashes only." />
+                        <label class="control-label">Slugs</label>
+                        <div class="ll-slugs">
+                            <div v-for="(s, i) in bag.slugs || []" :key="s.id || `new-${i}`" class="ll-slug-row">
+                                <button
+                                    type="button"
+                                    class="btn btn-link btn-xs ll-slug-primary"
+                                    :class="{ 'is-primary': s.isPrimary }"
+                                    :title="s.isPrimary ? 'Primary slug (used in shared links)' : 'Make primary'"
+                                    @click="setPrimary(i)">
+                                    <i :class="s.isPrimary ? 'fa fa-star' : 'fa fa-star-o'"></i>
+                                </button>
+                                <code class="ll-slug-text">{{ s.slug }}</code>
+                                <span v-if="s.isPrimary" class="label label-info ll-slug-badge">Primary</span>
+                                <button
+                                    type="button"
+                                    class="btn btn-link text-danger btn-xs ms-auto"
+                                    :disabled="(bag.slugs || []).length <= 1"
+                                    :title="(bag.slugs || []).length <= 1 ? 'A list must have at least one slug' : 'Remove slug'"
+                                    @click="removeSlug(i)">
+                                    <i class="fa fa-times"></i>
+                                </button>
+                            </div>
+                            <div v-if="!(bag.slugs || []).length" class="text-muted small">No slugs yet. Add one below.</div>
+                        </div>
+                        <div class="ll-slug-add">
+                            <TextBox v-model="newSlug" placeholder="new-slug" @keydown.enter.prevent="addSlug" />
+                            <RockButton btnType="default" btnSize="sm" :disabled="!newSlug.trim()" @click="addSlug">
+                                <i class="fa fa-plus"></i> Add
+                            </RockButton>
+                        </div>
+                        <span class="help-block">Lowercase letters, digits, and dashes only. The primary slug is used in shared links; keeping extra slugs preserves old URLs.</span>
                     </div>
                 </div>
                 <div class="row">
@@ -240,7 +270,7 @@ import LinkListAnalytics from "./linkListAnalytics.obs";
 import { CUSTOM_DESIGN, effectiveColor as effectiveColorOf, designSelectionValue, applyDesignChange, type ColorField } from "../linkListTheme";
 import { clearOtherFeatured, sectionNestingMeta } from "../linkListItems";
 import type { ListItemBag } from "@Obsidian/ViewModels/Utility/listItemBag";
-import type { LinkListBag, LinkListDetailInitializationBox, LinkItemBag, GroupMemberBag } from "../types";
+import type { LinkListBag, LinkListDetailInitializationBox, LinkItemBag, GroupMemberBag, LinkListSlugBag } from "../types";
 
 const props = defineProps<{
     detail: LinkListDetailInitializationBox;
@@ -255,6 +285,7 @@ const invokeBlockAction = useInvokeBlockAction();
 
 const bag = ref<LinkListBag>(cloneBag(props.detail.linkList));
 const errorMessage = ref("");
+const newSlug = ref("");
 const isSaving = ref(false);
 const isAddingMember = ref(false);
 const memberToAdd = ref<{ value: string; text: string } | null>(null);
@@ -327,13 +358,91 @@ const headerBackgroundImageValue = computed({
 
 function cloneBag(input: LinkListBag | null | undefined): LinkListBag {
     if (!input) {
-        return { title: "", slug: "", isPublic: true, items: [] };
+        return { title: "", slug: "", slugs: [], isPublic: true, items: [] };
     }
     const cloned = JSON.parse(JSON.stringify(input)) as LinkListBag;
     if (!cloned.items) {
         cloned.items = [];
     }
+    normalizeSlugs(cloned);
     return cloned;
+}
+
+// Ensures the bag has a usable slugs collection with exactly one primary:
+// seeds from the scalar slug when the collection is empty (defensive — the
+// server sends slugs now), and defaults the primary to the first slug for
+// legacy lists whose rows carry no IsPrimary flag.
+function normalizeSlugs(target: LinkListBag): void {
+    if (!target.slugs) {
+        target.slugs = [];
+    }
+    if (target.slugs.length === 0 && target.slug) {
+        target.slugs.push({ id: 0, slug: target.slug, isPrimary: true });
+    }
+    if (target.slugs.length && !target.slugs.some(s => s.isPrimary)) {
+        target.slugs[0].isPrimary = true;
+    }
+}
+
+// Mirror the server's slug rule (LinkListService.IsValidSlug) for immediate
+// feedback; the server stays the source of truth.
+const SLUG_PATTERN = /^[a-z0-9-]+$/;
+const SLUG_MAX_LENGTH = 200;
+
+function addSlug(): void {
+    const text = (newSlug.value || "").trim().toLowerCase();
+    if (!text) {
+        return;
+    }
+    if (text.length > SLUG_MAX_LENGTH || !SLUG_PATTERN.test(text)) {
+        errorMessage.value = `Slug "${text}" must be 1-${SLUG_MAX_LENGTH} lowercase letters, digits, or dashes.`;
+        return;
+    }
+    const slugs: LinkListSlugBag[] = bag.value.slugs || (bag.value.slugs = []);
+    if (slugs.some(s => s.slug === text)) {
+        errorMessage.value = `Slug "${text}" is already in the list.`;
+        return;
+    }
+    slugs.push({ id: 0, slug: text, isPrimary: slugs.length === 0 });
+    ensureOnePrimary();
+    newSlug.value = "";
+    errorMessage.value = "";
+}
+
+function removeSlug(index: number): void {
+    const slugs = bag.value.slugs;
+    if (!slugs) {
+        return;
+    }
+    // A list must keep at least one slug or it becomes unreachable (the viewer
+    // and web component resolve only by slug). The server enforces this too.
+    if (slugs.length <= 1) {
+        errorMessage.value = "A link list must have at least one slug.";
+        return;
+    }
+    const wasPrimary = slugs[index]?.isPrimary;
+    slugs.splice(index, 1);
+    if (wasPrimary) {
+        ensureOnePrimary();
+    }
+}
+
+function setPrimary(index: number): void {
+    const slugs = bag.value.slugs;
+    if (!slugs) {
+        return;
+    }
+    slugs.forEach((s, i) => { s.isPrimary = i === index; });
+}
+
+function ensureOnePrimary(): void {
+    const slugs = bag.value.slugs;
+    if (!slugs || !slugs.length) {
+        return;
+    }
+    if (!slugs.some(s => s.isPrimary)) {
+        slugs[0].isPrimary = true;
+    }
 }
 
 function onDesignChange(value: string | string[] | undefined): void {
@@ -411,6 +520,16 @@ function moveRow(index: number, delta: number): void {
 
 async function save(): Promise<void> {
     errorMessage.value = "";
+    // A list must have at least one slug (server enforces this too); block the
+    // save with a friendly message rather than round-tripping to a 400.
+    if (!(bag.value.slugs || []).length) {
+        errorMessage.value = "Add at least one slug before saving.";
+        return;
+    }
+    // Keep the scalar (primary) slug aligned with the chosen primary before
+    // sending; the server recomputes it from the primary row on the way back.
+    const primary = (bag.value.slugs || []).find(s => s.isPrimary);
+    bag.value.slug = primary?.slug ?? "";
     isSaving.value = true;
     const result = await invokeBlockAction<LinkListBag>("SaveList", { bag: bag.value });
     isSaving.value = false;
@@ -480,4 +599,13 @@ async function removeMember(groupMemberId: number): Promise<void> {
 .add-member { display: flex; align-items: end; gap: 8px; }
 .add-member > :first-child { flex-grow: 1; }
 .ms-auto { margin-left: auto; }
+
+.ll-slugs { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
+.ll-slug-row { display: flex; align-items: center; gap: 8px; padding: 2px 0; }
+.ll-slug-primary { padding: 0; color: #999; }
+.ll-slug-primary.is-primary { color: #f0ad4e; }
+.ll-slug-text { background: #f5f5f5; padding: 2px 6px; border-radius: 3px; }
+.ll-slug-badge { font-weight: normal; }
+.ll-slug-add { display: flex; align-items: start; gap: 8px; }
+.ll-slug-add > :first-child { flex-grow: 1; }
 </style>

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/components/linkListEditor.obs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/components/linkListEditor.obs
@@ -319,6 +319,8 @@ const newSlug = ref("");
 // The slug derived from the title on this screen, if any - so the row can be
 // labelled "from title" and can yield primary to the first slug the user adds.
 const autoDerivedSlug = ref("");
+// Slug row ids this editor loaded; see rememberLoadedSlugIds.
+const loadedSlugIds = ref<number[]>([]);
 const slugListEl = ref<HTMLElement | null>(null);
 const isSaving = ref(false);
 const isAddingMember = ref(false);
@@ -344,6 +346,7 @@ watch(analyticsExpanded, expanded => {
 
 watch(() => props.detail, d => {
     bag.value = cloneBag(d.linkList);
+    rememberLoadedSlugIds(d.linkList);
     // Reset the per-screen scratch state too. The parent swaps `detail` in place
     // after a create (same component instance, no :key), and stale text left in
     // the add box would otherwise be committed to the newly loaded list.
@@ -353,6 +356,21 @@ watch(() => props.detail, d => {
     slugMessage.value = "";
     autoDerivedSlug.value = "";
 });
+
+// Records which slug rows this editor is actually looking at. The save posts these
+// so the server can delete a slug the user removed WITHOUT deleting one that another
+// editor added since this screen loaded - by text alone the two are identical
+// ("stored, but not submitted"). Refreshed after each save so a second save in the
+// same session judges against what it now shows.
+function rememberLoadedSlugIds(source: LinkListBag): void {
+    loadedSlugIds.value = (source.slugs || [])
+        .map(s => s.id)
+        .filter(id => id > 0);
+}
+
+// The watcher above only fires when the parent swaps in a different list, so seed
+// from the list this editor mounted with.
+rememberLoadedSlugIds(props.detail.linkList);
 
 const designItems = computed(() => [
     ...(props.detail.designs || []).map(d => ({ value: d.value, text: d.text })),
@@ -620,7 +638,10 @@ async function save(): Promise<void> {
     const primary = (bag.value.slugs || []).find(s => s.isPrimary);
     bag.value.slug = primary?.slug ?? "";
     isSaving.value = true;
-    const result = await invokeBlockAction<LinkListBag>("SaveList", { bag: bag.value });
+    const result = await invokeBlockAction<LinkListBag>("SaveList", {
+        bag: bag.value,
+        loadedSlugIds: loadedSlugIds.value
+    });
     isSaving.value = false;
 
     if (result.isSuccess && result.data) {
@@ -630,6 +651,7 @@ async function save(): Promise<void> {
         const warning = result.data.saveWarning;
         bag.value = cloneBag(result.data);
         bag.value.saveWarning = null;
+        rememberLoadedSlugIds(result.data);
         if (warning) {
             // Stay on the editor so the user can fix and re-save; emitting "saved"
             // would navigate away from a list that isn't fully written yet.

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/slugCanonicalizer.ts
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/slugCanonicalizer.ts
@@ -1,0 +1,43 @@
+// Slug canonicalization for the editor, mirroring the server's
+// LinkListService.CanonicalizeSlug byte for byte. Both are in turn a mirror of
+// Rock's internal ContentChannelItemSlugService.MakeSlugValid, with one
+// deliberate difference: the dash collapse runs AFTER the charset strip so the
+// result is a FIXED POINT of MakeSlugValid (Rock's own order turns
+// "rock & roll" into "rock--roll", which a second pass changes to "rock-roll").
+// Rock re-canonicalizes whatever it is handed on save, and only a fixed point
+// guarantees the slug the editor shows is the slug that gets stored.
+//
+// Any change here MUST be made in LinkListService.CanonicalizeSlug too; the
+// parity table in tests/slugCanonicalizer.spec.ts matches the C# theory in
+// SlugValidationTests case for case.
+
+/** Longest slug Rock will store (ContentChannelItemSlug.Slug is nvarchar(200)). */
+export const SLUG_MAX_LENGTH = 200;
+
+/** What a STORED slug may look like (mirrors LinkListService.IsValidSlug). */
+export const SLUG_PATTERN = /^[a-z0-9-]+$/;
+
+// The entities Rock maps to a dash. Typed input never contains them, but pasted
+// text can, and the server handles them - so the editor must agree.
+const DASH_ENTITIES = ["&nbsp;", "&#160;", "&ndash;", "&#8211;", "&mdash;", "&#8212;"];
+
+/**
+ * Converts arbitrary text (a typed slug or a list title) into the exact slug
+ * Rock will store: lowercased, spaces/underscores/dash-entities turned into
+ * dashes, everything else removed, dash runs collapsed, trailing dashes
+ * trimmed, capped at SLUG_MAX_LENGTH. Leading dashes are kept, matching Rock.
+ * Returns "" when nothing usable survives; callers treat that as "no slug".
+ */
+export function canonicalizeSlug(value: string | null | undefined): string {
+    let slug = (value ?? "").trim().toLowerCase();
+
+    for (const entity of DASH_ENTITIES) {
+        slug = slug.split(entity).join("-");
+    }
+
+    slug = slug.replace(/_/g, "-").replace(/ /g, "-");
+    slug = slug.replace(/[^a-z0-9 -]/g, "");
+    slug = slug.replace(/-+/g, "-");
+
+    return slug.slice(0, SLUG_MAX_LENGTH).replace(/-+$/, "");
+}

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/types.ts
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/types.ts
@@ -15,6 +15,12 @@ export interface LinkItemBag {
     order?: number;
 }
 
+export interface LinkListSlugBag {
+    id: number; // ContentChannelItemSlug.Id, or 0 for a slug just added in the editor
+    slug: string;
+    isPrimary: boolean;
+}
+
 export interface GroupMemberBag {
     groupMemberId: number;
     personGuid: string;
@@ -48,7 +54,8 @@ export interface DesignOptionBag {
 export interface LinkListBag {
     guid?: string;
     id?: number | null;
-    slug?: string;
+    slug?: string; // PRIMARY slug (computed server-side; kept for back-compat consumers)
+    slugs?: LinkListSlugBag[]; // all slugs (primary + additional); the editor edits this
     title?: string;
     isPublic?: boolean;
     designId?: string | null;

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/types.ts
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/types.ts
@@ -57,6 +57,7 @@ export interface LinkListBag {
     slug?: string; // PRIMARY slug (computed server-side; kept for back-compat consumers)
     slugs?: LinkListSlugBag[]; // all slugs (primary + additional); editor payloads only
     saveWarning?: string | null; // set when a save partially succeeded (see LinkListBag.SaveWarning)
+    saveNotice?: string | null; // set when a save succeeded but merged a concurrent edit
     title?: string;
     isPublic?: boolean;
     designId?: string | null;

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/types.ts
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/src/types.ts
@@ -55,7 +55,8 @@ export interface LinkListBag {
     guid?: string;
     id?: number | null;
     slug?: string; // PRIMARY slug (computed server-side; kept for back-compat consumers)
-    slugs?: LinkListSlugBag[]; // all slugs (primary + additional); the editor edits this
+    slugs?: LinkListSlugBag[]; // all slugs (primary + additional); editor payloads only
+    saveWarning?: string | null; // set when a save partially succeeded (see LinkListBag.SaveWarning)
     title?: string;
     isPublic?: boolean;
     designId?: string | null;

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/tests/slugCanonicalizer.spec.ts
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Obsidian/tests/slugCanonicalizer.spec.ts
@@ -1,0 +1,76 @@
+import { canonicalizeSlug, SLUG_MAX_LENGTH, SLUG_PATTERN } from "../src/slugCanonicalizer";
+
+// The table below is the C#<->TS parity contract: every case here also appears in
+// SlugValidationTests.CanonicalizeSlug_Produces_The_Text_Rock_Stores. If one side
+// changes, change both - the editor must show the slug the server will store.
+
+describe("canonicalizeSlug", () => {
+    it.each([
+        ["my-list", "my-list"],
+        ["My-List", "my-list"],
+        ["  MY-LIST  ", "my-list"],
+        ["Give Now", "give-now"],
+        ["  My_List  ", "my-list"],
+        ["Summer Camp 2026", "summer-camp-2026"],
+        ["give--now", "give-now"],
+        ["a&nbsp;b", "a-b"],
+        ["a&#8212;b", "a-b"],
+        ["foo-", "foo"],
+        ["-foo", "-foo"],
+        ["café!", "caf"],
+        ["list/../etc", "listetc"],
+        ["<script>", "script"],
+        ["-", ""],
+        ["---", ""],
+        ["&", ""],
+        ["!!!", ""],
+        ["   ", ""],
+        ["", ""]
+    ])("%j -> %j", (input, expected) => {
+        expect(canonicalizeSlug(input)).toBe(expected);
+    });
+
+    it("treats null and undefined as empty", () => {
+        expect(canonicalizeSlug(null)).toBe("");
+        expect(canonicalizeSlug(undefined)).toBe("");
+    });
+
+    it("collapses dashes left behind by stripped characters", () => {
+        // Rock's own MakeSlugValid collapses before stripping and would yield
+        // "rock--roll"; we strip first so the result is a fixed point.
+        expect(canonicalizeSlug("Rock & Roll")).toBe("rock-roll");
+    });
+
+    it("caps length, trimming a dash left at the cut", () => {
+        expect(canonicalizeSlug("a".repeat(SLUG_MAX_LENGTH + 1))).toBe("a".repeat(SLUG_MAX_LENGTH));
+        expect(canonicalizeSlug("a".repeat(SLUG_MAX_LENGTH - 1) + "-b")).toBe("a".repeat(SLUG_MAX_LENGTH - 1));
+    });
+
+    it.each([
+        "Rock & Roll",
+        "Give Now",
+        "give--now",
+        "  My_List  ",
+        "-foo-",
+        "café!",
+        "a&mdash;b",
+        "-",
+        ""
+    ])("is a fixed point for %j", input => {
+        // Rock re-canonicalizes on save, so canonical text must survive a second
+        // pass unchanged or the editor shows a slug that isn't what gets stored.
+        const once = canonicalizeSlug(input);
+        expect(canonicalizeSlug(once)).toBe(once);
+    });
+
+    it.each([
+        "Rock & Roll",
+        "Summer Camp 2026",
+        "give--now",
+        "-foo-"
+    ])("produces a storable slug for %j", input => {
+        const slug = canonicalizeSlug(input);
+        expect(slug).not.toBe("");
+        expect(SLUG_PATTERN.test(slug)).toBe(true);
+    });
+});

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugReconciliationTests.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugReconciliationTests.cs
@@ -1,4 +1,4 @@
-// <copyright>
+﻿// <copyright>
 // Copyright Southeast Christian Church
 //
 // Licensed under the  Southeast Christian Church License (the "License");
@@ -28,16 +28,16 @@ namespace org.secc.LinkList.Tests
             return new ExistingSlug { Id = id, Slug = slug };
         }
 
-        private static SubmittedSlug Submitted( int id, string slug, bool isPrimary = false )
+        private static SubmittedSlug Submitted( string slug, bool isPrimary = false )
         {
-            return new SubmittedSlug { Id = id, Slug = slug, IsPrimary = isPrimary };
+            return new SubmittedSlug { Slug = slug, IsPrimary = isPrimary };
         }
 
         [Fact]
         public void Reconcile_Adds_A_New_Slug_And_Keeps_Existing()
         {
             var existing = new[] { Existing( 1, "keep" ) };
-            var submitted = new[] { Submitted( 1, "keep", isPrimary: true ), Submitted( 0, "added" ) };
+            var submitted = new[] { Submitted( "keep", isPrimary: true ), Submitted( "added" ) };
 
             var result = SlugReconciler.Reconcile( existing, submitted );
 
@@ -51,7 +51,7 @@ namespace org.secc.LinkList.Tests
         public void Reconcile_Deletes_A_Removed_Slug()
         {
             var existing = new[] { Existing( 1, "keep" ), Existing( 2, "gone" ) };
-            var submitted = new[] { Submitted( 1, "keep", isPrimary: true ) };
+            var submitted = new[] { Submitted( "keep", isPrimary: true ) };
 
             var result = SlugReconciler.Reconcile( existing, submitted );
 
@@ -66,7 +66,7 @@ namespace org.secc.LinkList.Tests
         {
             // "a" is primary today; the editor moves primary to "b".
             var existing = new[] { Existing( 1, "a" ), Existing( 2, "b" ) };
-            var submitted = new[] { Submitted( 1, "a" ), Submitted( 2, "b", isPrimary: true ) };
+            var submitted = new[] { Submitted( "a" ), Submitted( "b", isPrimary: true ) };
 
             var result = SlugReconciler.Reconcile( existing, submitted );
 
@@ -80,7 +80,7 @@ namespace org.secc.LinkList.Tests
         public void Reconcile_NoOp_Set_Produces_No_Changes()
         {
             var existing = new[] { Existing( 1, "a" ), Existing( 2, "b" ) };
-            var submitted = new[] { Submitted( 1, "a", isPrimary: true ), Submitted( 2, "b" ) };
+            var submitted = new[] { Submitted( "a", isPrimary: true ), Submitted( "b" ) };
 
             var result = SlugReconciler.Reconcile( existing, submitted );
 
@@ -98,8 +98,8 @@ namespace org.secc.LinkList.Tests
             var existing = new[] { Existing( 1, "old-name" ) };
             var submitted = new[]
             {
-                Submitted( 1, "old-name" ),
-                Submitted( 0, "new-name", isPrimary: true )
+                Submitted( "old-name" ),
+                Submitted( "new-name", isPrimary: true )
             };
 
             var result = SlugReconciler.Reconcile( existing, submitted );
@@ -114,7 +114,7 @@ namespace org.secc.LinkList.Tests
         public void Reconcile_Rejects_Duplicate_Within_Submitted_Set()
         {
             var existing = new ExistingSlug[0];
-            var submitted = new[] { Submitted( 0, "dupe", isPrimary: true ), Submitted( 0, "dupe" ) };
+            var submitted = new[] { Submitted( "dupe", isPrimary: true ), Submitted( "dupe" ) };
 
             var result = SlugReconciler.Reconcile( existing, submitted );
 
@@ -126,7 +126,7 @@ namespace org.secc.LinkList.Tests
         public void Reconcile_Rejects_Invalid_Slug_In_Set()
         {
             var existing = new ExistingSlug[0];
-            var submitted = new[] { Submitted( 0, "not valid", isPrimary: true ) };
+            var submitted = new[] { Submitted( "not valid", isPrimary: true ) };
 
             var result = SlugReconciler.Reconcile( existing, submitted );
 
@@ -137,9 +137,11 @@ namespace org.secc.LinkList.Tests
         [Fact]
         public void Reconcile_Empty_Submitted_Deletes_All_Existing_And_Has_No_Primary()
         {
-            // Pure-helper capability. The block never actually calls Reconcile with
-            // an empty set: ValidateBag rejects an explicitly-empty slug-aware set,
-            // and the legacy (upsert-only) path skips reconciliation when empty.
+            // Pure-helper capability, deliberately NOT acted on: the block CAN reach
+            // Reconcile with an empty set (a slug-aware client that submitted none,
+            // leaving the slug to Rock's title-derived one), and it suppresses the
+            // delete pass in exactly that case - see the mayDelete guard in
+            // LinkListDetailBlock. A list must never be left with no slug.
             var existing = new[] { Existing( 1, "a" ), Existing( 2, "b" ) };
             var submitted = new SubmittedSlug[0];
 
@@ -157,7 +159,7 @@ namespace org.secc.LinkList.Tests
             // Legacy lists have no IsPrimary flag set anywhere; the first submitted
             // slug becomes primary so a list with slugs always has exactly one.
             var existing = new[] { Existing( 1, "a" ), Existing( 2, "b" ) };
-            var submitted = new[] { Submitted( 1, "a" ), Submitted( 2, "b" ) };
+            var submitted = new[] { Submitted( "a" ), Submitted( "b" ) };
 
             var result = SlugReconciler.Reconcile( existing, submitted );
 
@@ -173,7 +175,7 @@ namespace org.secc.LinkList.Tests
             // treat them as the same row: no add, no delete. (An Ordinal comparison
             // would wrongly add + delete here.)
             var existing = new[] { Existing( 5, "Already-Here" ) };
-            var submitted = new[] { Submitted( 5, "already-here", isPrimary: true ) };
+            var submitted = new[] { Submitted( "already-here", isPrimary: true ) };
 
             var result = SlugReconciler.Reconcile( existing, submitted );
 
@@ -210,9 +212,10 @@ namespace org.secc.LinkList.Tests
         [Fact]
         public void BuildSubmission_Provided_Empty_List_Is_FullReconcile_Empty()
         {
-            // A slug-aware client that cleared every slug: full reconcile with an
-            // empty set. ValidateBag rejects this ("at least one slug"), but the
-            // submission itself must report FullReconcile so that rejection fires.
+            // A slug-aware client that submitted no slugs: full reconcile with an
+            // empty set, which the block reads as "leave the slug to Rock" - its save
+            // hook derives one from the title. FullReconcile must still be true so
+            // the block can tell this apart from a legacy scalar-only client.
             var submission = SlugReconciler.BuildSubmission( new SubmittedSlug[0], "ignored-scalar" );
 
             Assert.True( submission.FullReconcile );
@@ -224,9 +227,9 @@ namespace org.secc.LinkList.Tests
         {
             var provided = new[]
             {
-                new SubmittedSlug { Id = 1, Slug = "  Keep-Me  ", IsPrimary = true },
-                new SubmittedSlug { Id = 0, Slug = "ADDED" },
-                new SubmittedSlug { Id = 0, Slug = "   " } // blank -> dropped
+                new SubmittedSlug { Slug = "  Keep-Me  ", IsPrimary = true },
+                new SubmittedSlug { Slug = "ADDED" },
+                new SubmittedSlug { Slug = "   " } // blank -> dropped
             };
 
             var submission = SlugReconciler.BuildSubmission( provided, null );
@@ -234,6 +237,182 @@ namespace org.secc.LinkList.Tests
             Assert.True( submission.FullReconcile );
             Assert.Equal( new[] { "keep-me", "added" }, submission.Slugs.Select( s => s.Slug ).ToArray() );
             Assert.True( submission.Slugs[0].IsPrimary );
+        }
+
+        [Fact]
+        public void BuildSubmission_Canonicalizes_To_The_Text_Rock_Stores()
+        {
+            var provided = new[]
+            {
+                new SubmittedSlug { Slug = "Give Now", IsPrimary = true },
+                new SubmittedSlug { Slug = "fall--retreat" },
+                new SubmittedSlug { Slug = "trailing-" }
+            };
+
+            var submission = SlugReconciler.BuildSubmission( provided, null );
+
+            Assert.Equal(
+                new[] { "give-now", "fall-retreat", "trailing" },
+                submission.Slugs.Select( s => s.Slug ).ToArray() );
+        }
+
+        [Theory]
+        [InlineData( "-" )]
+        [InlineData( "---" )]
+        [InlineData( "!!!" )]
+        public void BuildSubmission_Drops_Slugs_Canonicalization_Empties( string emptied )
+        {
+            var provided = new[]
+            {
+                new SubmittedSlug { Slug = emptied },
+                new SubmittedSlug { Slug = "keep", IsPrimary = true }
+            };
+
+            var submission = SlugReconciler.BuildSubmission( provided, null );
+
+            Assert.Equal( new[] { "keep" }, submission.Slugs.Select( s => s.Slug ).ToArray() );
+        }
+
+        [Fact]
+        public void BuildSubmission_All_Slugs_Emptied_Leaves_The_Slug_To_Rock()
+        {
+            // Every entry canonicalized to nothing: the same empty full-reconcile
+            // submission a client that sent no slugs produces, so the block leaves
+            // the list's slugs alone and Rock derives one from the title.
+            var provided = new[]
+            {
+                new SubmittedSlug { Slug = "-" },
+                new SubmittedSlug { Slug = "!!!" }
+            };
+
+            var submission = SlugReconciler.BuildSubmission( provided, null );
+
+            Assert.True( submission.FullReconcile );
+            Assert.Empty( submission.Slugs );
+        }
+
+        [Fact]
+        public void BuildSubmission_Merges_Slugs_That_Canonicalize_The_Same()
+        {
+            // The user typed these differently, so erroring on a "duplicate" would
+            // name text they never entered. Merge instead: first position wins and a
+            // primary flag anywhere in the group wins.
+            var provided = new[]
+            {
+                new SubmittedSlug { Slug = "Give_Now" },
+                new SubmittedSlug { Slug = "give now", IsPrimary = true },
+                new SubmittedSlug { Slug = "other" }
+            };
+
+            var submission = SlugReconciler.BuildSubmission( provided, null );
+
+            Assert.Equal( new[] { "give-now", "other" }, submission.Slugs.Select( s => s.Slug ).ToArray() );
+            Assert.True( submission.Slugs[0].IsPrimary );
+            Assert.False( submission.Slugs[1].IsPrimary );
+        }
+
+        [Fact]
+        public void BuildSubmission_Merge_Keeps_Primary_Flagged_On_The_First_Entry()
+        {
+            var provided = new[]
+            {
+                new SubmittedSlug { Slug = "Give Now", IsPrimary = true },
+                new SubmittedSlug { Slug = "give--now" }
+            };
+
+            var submission = SlugReconciler.BuildSubmission( provided, null );
+
+            Assert.Single( submission.Slugs );
+            Assert.Equal( "give-now", submission.Slugs[0].Slug );
+            Assert.True( submission.Slugs[0].IsPrimary );
+        }
+
+        [Fact]
+        public void BuildSubmission_Scalar_Slug_Is_Canonicalized_Too()
+        {
+            var submission = SlugReconciler.BuildSubmission( null, "Summer Camp 2026" );
+
+            Assert.False( submission.FullReconcile );
+            Assert.Single( submission.Slugs );
+            Assert.Equal( "summer-camp-2026", submission.Slugs[0].Slug );
+            Assert.True( submission.Slugs[0].IsPrimary );
+        }
+
+        // ---- Empty set + title: the "let Rock derive the slug" precondition ----
+
+        [Theory]
+        [InlineData( "Summer Camp" )]
+        [InlineData( "2026" )]
+        [InlineData( "Rock & Roll" )]
+        public void ValidateSubmissionAgainstTitle_Allows_An_Empty_Set_When_The_Title_Yields_A_Slug( string title )
+        {
+            var submission = SlugReconciler.BuildSubmission( new SubmittedSlug[0], null );
+
+            Assert.Null( SlugReconciler.ValidateSubmissionAgainstTitle( submission, title ) );
+        }
+
+        [Theory]
+        [InlineData( "!!!" )]
+        [InlineData( "---" )]
+        [InlineData( "&" )]
+        [InlineData( null )]
+        public void ValidateSubmissionAgainstTitle_Rejects_An_Empty_Set_When_The_Title_Yields_Nothing( string title )
+        {
+            // Nothing submitted and nothing derivable would leave the list with no
+            // slug at all - unreachable by the viewer, web component and REST.
+            var submission = SlugReconciler.BuildSubmission( new SubmittedSlug[0], null );
+
+            var error = SlugReconciler.ValidateSubmissionAgainstTitle( submission, title );
+
+            Assert.NotNull( error );
+            Assert.Contains( "needs a slug", error );
+        }
+
+        [Fact]
+        public void ValidateSubmissionAgainstTitle_Ignores_The_Title_When_Slugs_Were_Submitted()
+        {
+            var submission = SlugReconciler.BuildSubmission( new[] { Submitted( "explicit" ) }, null );
+
+            Assert.Null( SlugReconciler.ValidateSubmissionAgainstTitle( submission, "!!!" ) );
+        }
+
+        [Fact]
+        public void ValidateSubmissionAgainstTitle_Ignores_A_Legacy_ScalarOnly_Submission()
+        {
+            // FullReconcile false: the client can't manage slugs and never deletes, so
+            // an empty set means "leave them alone", not "derive one".
+            var submission = SlugReconciler.BuildSubmission( null, null );
+
+            Assert.False( submission.FullReconcile );
+            Assert.Null( SlugReconciler.ValidateSubmissionAgainstTitle( submission, "!!!" ) );
+        }
+
+        // ---- Set size cap (keeps the conflict query under SQL's parameter limit) ----
+
+        [Fact]
+        public void ValidateSubmissionSize_Allows_A_Set_At_The_Cap()
+        {
+            var provided = Enumerable.Range( 0, SlugReconciler.MaxSlugsPerList )
+                .Select( i => Submitted( $"slug-{i}" ) )
+                .ToArray();
+            var submission = SlugReconciler.BuildSubmission( provided, null );
+
+            Assert.Equal( SlugReconciler.MaxSlugsPerList, submission.Slugs.Count );
+            Assert.Null( SlugReconciler.ValidateSubmissionSize( submission ) );
+        }
+
+        [Fact]
+        public void ValidateSubmissionSize_Rejects_A_Set_Over_The_Cap()
+        {
+            var provided = Enumerable.Range( 0, SlugReconciler.MaxSlugsPerList + 1 )
+                .Select( i => Submitted( $"slug-{i}" ) )
+                .ToArray();
+            var submission = SlugReconciler.BuildSubmission( provided, null );
+
+            var error = SlugReconciler.ValidateSubmissionSize( submission );
+
+            Assert.NotNull( error );
+            Assert.Contains( SlugReconciler.MaxSlugsPerList.ToString(), error );
         }
     }
 }

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugReconciliationTests.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugReconciliationTests.cs
@@ -387,6 +387,65 @@ namespace org.secc.LinkList.Tests
             Assert.Null( SlugReconciler.ValidateSubmissionAgainstTitle( submission, "!!!" ) );
         }
 
+        // ---- Delete gate: only rows the editor actually saw may be deleted ----
+
+        [Fact]
+        public void FilterDeletableIds_Keeps_Rows_The_Editor_Loaded()
+        {
+            // The user removed slug row 2, which was on screen when they loaded.
+            Assert.Equal( new[] { 2 }, SlugReconciler.FilterDeletableIds( new[] { 2 }, new[] { 1, 2 } ).ToArray() );
+        }
+
+        [Fact]
+        public void FilterDeletableIds_Spares_A_Row_The_Editor_Never_Saw()
+        {
+            // Row 9 was added by another editor after this one loaded [1, 2]. The diff
+            // wants it gone only because it isn't in this payload - it is not something
+            // this user removed, so it must survive.
+            var deletable = SlugReconciler.FilterDeletableIds( new[] { 2, 9 }, new[] { 1, 2 } );
+
+            Assert.Equal( new[] { 2 }, deletable.ToArray() );
+        }
+
+        [Fact]
+        public void FilterDeletableIds_Untracked_Caller_Keeps_Full_Reconcile()
+        {
+            // null = a client that doesn't report what it loaded (old bundle or API
+            // caller); it keeps today's behavior rather than silently failing to delete.
+            Assert.Equal( new[] { 2, 9 }, SlugReconciler.FilterDeletableIds( new[] { 2, 9 }, null ).ToArray() );
+        }
+
+        [Fact]
+        public void FilterDeletableIds_Empty_Loaded_Set_Deletes_Nothing()
+        {
+            // An editor that loaded no slug rows can't have removed any.
+            Assert.Empty( SlugReconciler.FilterDeletableIds( new[] { 2, 9 }, new int[0] ) );
+        }
+
+        [Fact]
+        public void FilterDeletableIds_Handles_A_Null_Plan()
+        {
+            Assert.Empty( SlugReconciler.FilterDeletableIds( null, new[] { 1 } ) );
+        }
+
+        [Fact]
+        public void FilterDeletableIds_Composes_With_Reconcile_To_Merge_Concurrent_Adds()
+        {
+            // End to end on the reported bug. Tab B loaded ["keep"] (row 1), then tab A
+            // added "a" (row 9). Tab B now saves ["keep", "b"].
+            var existing = new[] { Existing( 1, "keep" ), Existing( 9, "a" ) };
+            var submitted = new[] { Submitted( "keep", isPrimary: true ), Submitted( "b" ) };
+
+            var plan = SlugReconciler.Reconcile( existing, submitted );
+            var deletable = SlugReconciler.FilterDeletableIds( plan.SlugIdsToDelete, new[] { 1 } );
+
+            // The diff alone would have deleted tab A's slug...
+            Assert.Equal( new[] { 9 }, plan.SlugIdsToDelete.ToArray() );
+            // ...but tab B never saw row 9, so nothing is deleted and "b" is just added.
+            Assert.Empty( deletable );
+            Assert.Equal( new[] { "b" }, plan.SlugsToAdd.ToArray() );
+        }
+
         // ---- Set size cap (keeps the conflict query under SQL's parameter limit) ----
 
         [Fact]

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugReconciliationTests.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugReconciliationTests.cs
@@ -28,9 +28,9 @@ namespace org.secc.LinkList.Tests
             return new ExistingSlug { Id = id, Slug = slug };
         }
 
-        private static SubmittedSlug Submitted( string slug, bool isPrimary = false )
+        private static SubmittedSlug Submitted( string slug, bool isPrimary = false, int clientRowId = 0 )
         {
-            return new SubmittedSlug { Slug = slug, IsPrimary = isPrimary };
+            return new SubmittedSlug { Slug = slug, IsPrimary = isPrimary, ClientRowId = clientRowId };
         }
 
         [Fact]
@@ -444,6 +444,194 @@ namespace org.secc.LinkList.Tests
             // ...but tab B never saw row 9, so nothing is deleted and "b" is just added.
             Assert.Empty( deletable );
             Assert.Equal( new[] { "b" }, plan.SlugsToAdd.ToArray() );
+        }
+
+        // ---- Resurrect guard: a slug another editor deleted must not come back ----
+
+        [Fact]
+        public void FilterConcurrentlyDeleted_Drops_A_Slug_Whose_Row_Is_Gone()
+        {
+            // The client still shows "x" as row 2, but row 2 no longer exists: another
+            // editor deleted it. Re-adding it would undo their deletion.
+            var submitted = new[] { Submitted( "orig", isPrimary: true, clientRowId: 1 ), Submitted( "x", clientRowId: 2 ) };
+            var current = new[] { Existing( 1, "orig" ) };
+
+            var result = SlugReconciler.FilterConcurrentlyDeleted( submitted, current );
+
+            Assert.Equal( new[] { "orig" }, result.Kept.Select( s => s.Slug ).ToArray() );
+            Assert.Equal( new[] { "x" }, result.DroppedSlugs.ToArray() );
+        }
+
+        [Fact]
+        public void FilterConcurrentlyDeleted_Keeps_Slugs_Whose_Rows_Still_Exist()
+        {
+            var submitted = new[] { Submitted( "orig", clientRowId: 1 ), Submitted( "x", clientRowId: 2 ) };
+            var current = new[] { Existing( 1, "orig" ), Existing( 2, "x" ) };
+
+            var result = SlugReconciler.FilterConcurrentlyDeleted( submitted, current );
+
+            Assert.Equal( 2, result.Kept.Count );
+            Assert.Empty( result.DroppedSlugs );
+        }
+
+        [Fact]
+        public void FilterConcurrentlyDeleted_Always_Keeps_A_Slug_The_User_Typed()
+        {
+            // Id 0 is explicit intent - including deliberately re-typing a slug someone
+            // else just deleted. The user's action wins over the merge rule.
+            var submitted = new[] { Submitted( "x" ), Submitted( "brand-new" ) };
+
+            var result = SlugReconciler.FilterConcurrentlyDeleted( submitted, new ExistingSlug[0] );
+
+            Assert.Equal( new[] { "x", "brand-new" }, result.Kept.Select( s => s.Slug ).ToArray() );
+            Assert.Empty( result.DroppedSlugs );
+        }
+
+        [Fact]
+        public void FilterConcurrentlyDeleted_Keeps_A_Slug_Deleted_And_Recreated_Under_A_New_Id()
+        {
+            // The client knew "x" as row 2; someone deleted row 2 and recreated the same
+            // text as row 15. Dropping it would make row 15 look unsubmitted to Reconcile
+            // and queue a LIVE slug for deletion - so the text has to win over the id.
+            var submitted = new[] { Submitted( "orig", clientRowId: 1 ), Submitted( "x", clientRowId: 2 ) };
+            var current = new[] { Existing( 1, "orig" ), Existing( 15, "x" ) };
+
+            var result = SlugReconciler.FilterConcurrentlyDeleted( submitted, current );
+
+            Assert.Equal( 2, result.Kept.Count );
+            Assert.Empty( result.DroppedSlugs );
+        }
+
+        [Fact]
+        public void FilterConcurrentlyDeleted_Null_Current_Rows_Keeps_Everything()
+        {
+            // Mirrors FilterDeletableIds: null means "caller can't tell us", which must
+            // differ from an empty set (a list that genuinely has no slug rows).
+            var submitted = new[] { Submitted( "x", clientRowId: 2 ) };
+
+            var result = SlugReconciler.FilterConcurrentlyDeleted( submitted, null );
+
+            Assert.Single( result.Kept );
+            Assert.Empty( result.DroppedSlugs );
+        }
+
+        [Fact]
+        public void FilterConcurrentlyDeleted_No_Ids_Anywhere_Is_A_NoOp()
+        {
+            // A pre-fix editor bundle or hand-rolled API caller sends no ids at all;
+            // it keeps the old behavior rather than having its payload gutted.
+            var submitted = new[] { Submitted( "a" ), Submitted( "b" ) };
+
+            var result = SlugReconciler.FilterConcurrentlyDeleted( submitted, new[] { Existing( 7, "unrelated" ) } );
+
+            Assert.Equal( 2, result.Kept.Count );
+            Assert.Empty( result.DroppedSlugs );
+        }
+
+        [Fact]
+        public void FilterConcurrentlyDeleted_Reports_When_Everything_Known_Is_Gone()
+        {
+            // The block turns this into "reload the list": there is nothing left to
+            // reconcile against, so proceeding would wipe the list or invent a slug.
+            var submitted = new[] { Submitted( "x", isPrimary: true, clientRowId: 2 ) };
+            var current = new[] { Existing( 3, "z" ) };
+
+            var result = SlugReconciler.FilterConcurrentlyDeleted( submitted, current );
+
+            Assert.Empty( result.Kept );
+            Assert.Equal( new[] { "x" }, result.DroppedSlugs.ToArray() );
+        }
+
+        [Fact]
+        public void FilterConcurrentlyDeleted_Composes_With_Reconcile_On_The_Reported_Bug()
+        {
+            // End to end. List was [orig(1), x(2)]; tab A removed x; tab B, still showing
+            // x, adds y. Without the filter Reconcile would re-add x.
+            var submitted = new[]
+            {
+                Submitted( "orig", isPrimary: true, clientRowId: 1 ),
+                Submitted( "x", clientRowId: 2 ),
+                Submitted( "y" )
+            };
+            var current = new[] { Existing( 1, "orig" ) };
+
+            var naive = SlugReconciler.Reconcile( current, submitted );
+            Assert.Equal( new[] { "x", "y" }, naive.SlugsToAdd.ToArray() ); // the bug
+
+            var filtered = SlugReconciler.FilterConcurrentlyDeleted( submitted, current );
+            var plan = SlugReconciler.Reconcile( current, filtered.Kept );
+
+            Assert.Equal( new[] { "y" }, plan.SlugsToAdd.ToArray() );
+            Assert.Empty( plan.SlugIdsToDelete );
+            Assert.Equal( "orig", plan.PrimarySlug );
+        }
+
+        [Fact]
+        public void FilterConcurrentlyDeleted_Recreated_Row_Is_Never_A_Delete_Candidate()
+        {
+            // Composition of the two guards: the text guard keeps "x", so the recreated
+            // row 15 is never queued for deletion - which matters because a caller that
+            // omits loadedSlugIds has nothing to spare it (FilterDeletableIds(_, null)
+            // passes every planned id through).
+            var submitted = new[] { Submitted( "orig", isPrimary: true, clientRowId: 1 ), Submitted( "x", clientRowId: 2 ) };
+            var current = new[] { Existing( 1, "orig" ), Existing( 15, "x" ) };
+
+            var filtered = SlugReconciler.FilterConcurrentlyDeleted( submitted, current );
+            var plan = SlugReconciler.Reconcile( current, filtered.Kept );
+
+            Assert.Empty( plan.SlugIdsToDelete );
+            Assert.Empty( SlugReconciler.FilterDeletableIds( plan.SlugIdsToDelete, null ) );
+        }
+
+        [Fact]
+        public void FilterConcurrentlyDeleted_Dropping_The_Flagged_Primary_Promotes_The_First_Survivor()
+        {
+            // Accepted behavior: primary is last-writer-wins, so a stale save whose chosen
+            // primary is gone falls back to its first surviving slug rather than failing.
+            var submitted = new[] { Submitted( "keep", clientRowId: 1 ), Submitted( "x", isPrimary: true, clientRowId: 2 ) };
+            var current = new[] { Existing( 1, "keep" ) };
+
+            var filtered = SlugReconciler.FilterConcurrentlyDeleted( submitted, current );
+            var plan = SlugReconciler.Reconcile( current, filtered.Kept );
+
+            Assert.Equal( "keep", plan.PrimarySlug );
+        }
+
+        [Fact]
+        public void BuildSubmission_Carries_The_Client_Row_Id_Through_Canonicalization()
+        {
+            var provided = new[] { Submitted( "Give Now", clientRowId: 4 ) };
+
+            var submission = SlugReconciler.BuildSubmission( provided, null );
+
+            Assert.Equal( "give-now", submission.Slugs[0].Slug );
+            Assert.Equal( 4, submission.Slugs[0].ClientRowId );
+        }
+
+        [Fact]
+        public void BuildSubmission_Merged_Group_Prefers_A_Typed_Entry()
+        {
+            // A stored row plus the user re-typing the same slug: the merged entry must be
+            // treated as typed (id 0), or a concurrent deletion of that row would discard
+            // what the user deliberately entered.
+            var provided = new[]
+            {
+                Submitted( "Already-Here", clientRowId: 5 ),
+                Submitted( "already-here" )
+            };
+
+            var submission = SlugReconciler.BuildSubmission( provided, null );
+
+            Assert.Single( submission.Slugs );
+            Assert.Equal( 0, submission.Slugs[0].ClientRowId );
+        }
+
+        [Fact]
+        public void BuildSubmission_Scalar_Slug_Has_No_Client_Row_Id()
+        {
+            var submission = SlugReconciler.BuildSubmission( null, "Give Now" );
+
+            Assert.Equal( 0, submission.Slugs[0].ClientRowId );
         }
 
         // ---- Set size cap (keeps the conflict query under SQL's parameter limit) ----

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugReconciliationTests.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugReconciliationTests.cs
@@ -1,0 +1,239 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License should be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System.Collections.Generic;
+using System.Linq;
+
+using org.secc.LinkList.Utility;
+
+using Xunit;
+
+namespace org.secc.LinkList.Tests
+{
+    public class SlugReconciliationTests
+    {
+        private static ExistingSlug Existing( int id, string slug )
+        {
+            return new ExistingSlug { Id = id, Slug = slug };
+        }
+
+        private static SubmittedSlug Submitted( int id, string slug, bool isPrimary = false )
+        {
+            return new SubmittedSlug { Id = id, Slug = slug, IsPrimary = isPrimary };
+        }
+
+        [Fact]
+        public void Reconcile_Adds_A_New_Slug_And_Keeps_Existing()
+        {
+            var existing = new[] { Existing( 1, "keep" ) };
+            var submitted = new[] { Submitted( 1, "keep", isPrimary: true ), Submitted( 0, "added" ) };
+
+            var result = SlugReconciler.Reconcile( existing, submitted );
+
+            Assert.True( result.IsValid );
+            Assert.Equal( new[] { "added" }, result.SlugsToAdd.ToArray() );
+            Assert.Empty( result.SlugIdsToDelete );
+            Assert.Equal( "keep", result.PrimarySlug );
+        }
+
+        [Fact]
+        public void Reconcile_Deletes_A_Removed_Slug()
+        {
+            var existing = new[] { Existing( 1, "keep" ), Existing( 2, "gone" ) };
+            var submitted = new[] { Submitted( 1, "keep", isPrimary: true ) };
+
+            var result = SlugReconciler.Reconcile( existing, submitted );
+
+            Assert.True( result.IsValid );
+            Assert.Empty( result.SlugsToAdd );
+            Assert.Equal( new[] { 2 }, result.SlugIdsToDelete.ToArray() );
+            Assert.Equal( "keep", result.PrimarySlug );
+        }
+
+        [Fact]
+        public void Reconcile_Changes_The_Primary_Without_Add_Or_Delete()
+        {
+            // "a" is primary today; the editor moves primary to "b".
+            var existing = new[] { Existing( 1, "a" ), Existing( 2, "b" ) };
+            var submitted = new[] { Submitted( 1, "a" ), Submitted( 2, "b", isPrimary: true ) };
+
+            var result = SlugReconciler.Reconcile( existing, submitted );
+
+            Assert.True( result.IsValid );
+            Assert.Empty( result.SlugsToAdd );
+            Assert.Empty( result.SlugIdsToDelete );
+            Assert.Equal( "b", result.PrimarySlug );
+        }
+
+        [Fact]
+        public void Reconcile_NoOp_Set_Produces_No_Changes()
+        {
+            var existing = new[] { Existing( 1, "a" ), Existing( 2, "b" ) };
+            var submitted = new[] { Submitted( 1, "a", isPrimary: true ), Submitted( 2, "b" ) };
+
+            var result = SlugReconciler.Reconcile( existing, submitted );
+
+            Assert.True( result.IsValid );
+            Assert.Empty( result.SlugsToAdd );
+            Assert.Empty( result.SlugIdsToDelete );
+            Assert.Equal( "a", result.PrimarySlug );
+        }
+
+        [Fact]
+        public void Reconcile_Renaming_By_Adding_And_Keeping_Old_Preserves_Old_Row()
+        {
+            // Rename = add the new slug, keep the old one. The old row is neither
+            // deleted nor re-added, so the old URL keeps resolving.
+            var existing = new[] { Existing( 1, "old-name" ) };
+            var submitted = new[]
+            {
+                Submitted( 1, "old-name" ),
+                Submitted( 0, "new-name", isPrimary: true )
+            };
+
+            var result = SlugReconciler.Reconcile( existing, submitted );
+
+            Assert.True( result.IsValid );
+            Assert.Equal( new[] { "new-name" }, result.SlugsToAdd.ToArray() );
+            Assert.Empty( result.SlugIdsToDelete );
+            Assert.Equal( "new-name", result.PrimarySlug );
+        }
+
+        [Fact]
+        public void Reconcile_Rejects_Duplicate_Within_Submitted_Set()
+        {
+            var existing = new ExistingSlug[0];
+            var submitted = new[] { Submitted( 0, "dupe", isPrimary: true ), Submitted( 0, "dupe" ) };
+
+            var result = SlugReconciler.Reconcile( existing, submitted );
+
+            Assert.False( result.IsValid );
+            Assert.Contains( "dupe", result.Error );
+        }
+
+        [Fact]
+        public void Reconcile_Rejects_Invalid_Slug_In_Set()
+        {
+            var existing = new ExistingSlug[0];
+            var submitted = new[] { Submitted( 0, "not valid", isPrimary: true ) };
+
+            var result = SlugReconciler.Reconcile( existing, submitted );
+
+            Assert.False( result.IsValid );
+            Assert.NotNull( result.Error );
+        }
+
+        [Fact]
+        public void Reconcile_Empty_Submitted_Deletes_All_Existing_And_Has_No_Primary()
+        {
+            // Pure-helper capability. The block never actually calls Reconcile with
+            // an empty set: ValidateBag rejects an explicitly-empty slug-aware set,
+            // and the legacy (upsert-only) path skips reconciliation when empty.
+            var existing = new[] { Existing( 1, "a" ), Existing( 2, "b" ) };
+            var submitted = new SubmittedSlug[0];
+
+            var result = SlugReconciler.Reconcile( existing, submitted );
+
+            Assert.True( result.IsValid );
+            Assert.Empty( result.SlugsToAdd );
+            Assert.Equal( new[] { 1, 2 }, result.SlugIdsToDelete.OrderBy( i => i ).ToArray() );
+            Assert.Null( result.PrimarySlug );
+        }
+
+        [Fact]
+        public void Reconcile_Falls_Back_To_First_Submitted_When_None_Flagged_Primary()
+        {
+            // Legacy lists have no IsPrimary flag set anywhere; the first submitted
+            // slug becomes primary so a list with slugs always has exactly one.
+            var existing = new[] { Existing( 1, "a" ), Existing( 2, "b" ) };
+            var submitted = new[] { Submitted( 1, "a" ), Submitted( 2, "b" ) };
+
+            var result = SlugReconciler.Reconcile( existing, submitted );
+
+            Assert.True( result.IsValid );
+            Assert.Equal( "a", result.PrimarySlug );
+        }
+
+        [Fact]
+        public void Reconcile_Matches_Existing_By_Text_Case_Insensitively()
+        {
+            // The existing row's text differs from the submitted text only by case
+            // (submitted is a valid lowercase slug). OrdinalIgnoreCase matching must
+            // treat them as the same row: no add, no delete. (An Ordinal comparison
+            // would wrongly add + delete here.)
+            var existing = new[] { Existing( 5, "Already-Here" ) };
+            var submitted = new[] { Submitted( 5, "already-here", isPrimary: true ) };
+
+            var result = SlugReconciler.Reconcile( existing, submitted );
+
+            Assert.True( result.IsValid );
+            Assert.Empty( result.SlugsToAdd );
+            Assert.Empty( result.SlugIdsToDelete );
+        }
+
+        // ---- BuildSubmission: null (legacy scalar-only) vs provided (slug-aware) ----
+
+        [Fact]
+        public void BuildSubmission_Null_Slugs_With_Scalar_Is_UpsertOnly_Single_Primary()
+        {
+            var submission = SlugReconciler.BuildSubmission( null, "My-Slug" );
+
+            Assert.False( submission.FullReconcile ); // legacy client: never deletes
+            Assert.Single( submission.Slugs );
+            Assert.Equal( "my-slug", submission.Slugs[0].Slug ); // normalized
+            Assert.True( submission.Slugs[0].IsPrimary );
+        }
+
+        [Theory]
+        [InlineData( null )]
+        [InlineData( "" )]
+        [InlineData( "   " )]
+        public void BuildSubmission_Null_Slugs_With_Blank_Scalar_Is_UpsertOnly_Empty( string scalar )
+        {
+            var submission = SlugReconciler.BuildSubmission( null, scalar );
+
+            Assert.False( submission.FullReconcile );
+            Assert.Empty( submission.Slugs ); // nothing to upsert -> block leaves slugs untouched
+        }
+
+        [Fact]
+        public void BuildSubmission_Provided_Empty_List_Is_FullReconcile_Empty()
+        {
+            // A slug-aware client that cleared every slug: full reconcile with an
+            // empty set. ValidateBag rejects this ("at least one slug"), but the
+            // submission itself must report FullReconcile so that rejection fires.
+            var submission = SlugReconciler.BuildSubmission( new SubmittedSlug[0], "ignored-scalar" );
+
+            Assert.True( submission.FullReconcile );
+            Assert.Empty( submission.Slugs );
+        }
+
+        [Fact]
+        public void BuildSubmission_Provided_Slugs_Normalizes_And_Drops_Blanks()
+        {
+            var provided = new[]
+            {
+                new SubmittedSlug { Id = 1, Slug = "  Keep-Me  ", IsPrimary = true },
+                new SubmittedSlug { Id = 0, Slug = "ADDED" },
+                new SubmittedSlug { Id = 0, Slug = "   " } // blank -> dropped
+            };
+
+            var submission = SlugReconciler.BuildSubmission( provided, null );
+
+            Assert.True( submission.FullReconcile );
+            Assert.Equal( new[] { "keep-me", "added" }, submission.Slugs.Select( s => s.Slug ).ToArray() );
+            Assert.True( submission.Slugs[0].IsPrimary );
+        }
+    }
+}

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugValidationTests.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugValidationTests.cs
@@ -64,6 +64,90 @@ namespace org.secc.LinkList.Tests
             Assert.False( LinkListService.IsValidSlug( new string( 'a', LinkListService.MaxSlugLength + 1 ) ) );
         }
 
+        // ---- Write-path canonicalization (mirrors Rock's MakeSlugValid) ----
+
+        [Theory]
+        [InlineData( "my-list", "my-list" )]           // already canonical
+        [InlineData( "My-List", "my-list" )]
+        [InlineData( "  MY-LIST  ", "my-list" )]
+        [InlineData( "Give Now", "give-now" )]          // space -> dash
+        [InlineData( "  My_List  ", "my-list" )]        // underscore -> dash
+        [InlineData( "Summer Camp 2026", "summer-camp-2026" )] // the title-derived case
+        [InlineData( "give--now", "give-now" )]         // dash run collapsed
+        [InlineData( "a&nbsp;b", "a-b" )]               // dash entities
+        [InlineData( "a&#8212;b", "a-b" )]
+        [InlineData( "foo-", "foo" )]                   // trailing dash trimmed
+        [InlineData( "-foo", "-foo" )]                  // leading dash KEPT (Rock parity)
+        [InlineData( "café!", "caf" )]             // non-ASCII dropped, not folded
+        [InlineData( "list/../etc", "listetc" )]
+        [InlineData( "<script>", "script" )]
+        [InlineData( "-", "" )]                         // nothing usable survives
+        [InlineData( "---", "" )]
+        [InlineData( "&", "" )]
+        [InlineData( "!!!", "" )]
+        [InlineData( "   ", "" )]
+        [InlineData( "", "" )]
+        [InlineData( null, "" )]
+        public void CanonicalizeSlug_Produces_The_Text_Rock_Stores( string input, string expected )
+        {
+            Assert.Equal( expected, LinkListService.CanonicalizeSlug( input ) );
+        }
+
+        [Fact]
+        public void CanonicalizeSlug_Collapses_Dashes_Left_By_Stripped_Characters()
+        {
+            // Rock's MakeSlugValid collapses dash runs BEFORE stripping invalid
+            // characters, so its single pass yields "rock--roll" here. We strip
+            // first so the result survives a second pass unchanged - see
+            // CanonicalizeSlug_Is_A_Fixed_Point for why that matters.
+            Assert.Equal( "rock-roll", LinkListService.CanonicalizeSlug( "Rock & Roll" ) );
+        }
+
+        [Fact]
+        public void CanonicalizeSlug_Enforces_Max_Length()
+        {
+            var overLength = new string( 'a', LinkListService.MaxSlugLength + 1 );
+            Assert.Equal( new string( 'a', LinkListService.MaxSlugLength ), LinkListService.CanonicalizeSlug( overLength ) );
+
+            // Truncation happens before the trailing dash is trimmed, so a cut
+            // landing on a dash yields one character less.
+            var cutOnDash = new string( 'a', LinkListService.MaxSlugLength - 1 ) + "-b";
+            Assert.Equal( new string( 'a', LinkListService.MaxSlugLength - 1 ), LinkListService.CanonicalizeSlug( cutOnDash ) );
+        }
+
+        [Theory]
+        [InlineData( "Rock & Roll" )]
+        [InlineData( "Give Now" )]
+        [InlineData( "give--now" )]
+        [InlineData( "  My_List  " )]
+        [InlineData( "-foo-" )]
+        [InlineData( "café!" )]
+        [InlineData( "a&mdash;b" )]
+        [InlineData( "-" )]
+        [InlineData( null )]
+        public void CanonicalizeSlug_Is_A_Fixed_Point( string input )
+        {
+            // The guarantee the whole write path rests on: Rock's SaveSlug re-runs
+            // MakeSlugValid on whatever it is given, so the text validated here must
+            // survive canonicalization again unchanged - otherwise stored text
+            // diverges from validated text and the conflict check, reconcile diff and
+            // primary-flag match all compare the wrong thing.
+            var once = LinkListService.CanonicalizeSlug( input );
+            Assert.Equal( once, LinkListService.CanonicalizeSlug( once ) );
+        }
+
+        [Theory]
+        [InlineData( "Rock & Roll" )]
+        [InlineData( "Summer Camp 2026" )]
+        [InlineData( "give--now" )]
+        [InlineData( "-foo-" )]
+        public void CanonicalizeSlug_Output_Passes_IsValidSlug( string input )
+        {
+            var slug = LinkListService.CanonicalizeSlug( input );
+            Assert.NotEqual( string.Empty, slug );
+            Assert.True( LinkListService.IsValidSlug( slug ) );
+        }
+
         // ---- Multi-slug set validation (every slug in the set is validated) ----
 
         [Fact]

--- a/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugValidationTests.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList.Tests/SlugValidationTests.cs
@@ -12,7 +12,10 @@
 // limitations under the License.
 // </copyright>
 //
+using System.Collections.Generic;
+
 using org.secc.LinkList.Services;
+using org.secc.LinkList.Utility;
 
 using Xunit;
 
@@ -59,6 +62,52 @@ namespace org.secc.LinkList.Tests
         {
             Assert.True( LinkListService.IsValidSlug( new string( 'a', LinkListService.MaxSlugLength ) ) );
             Assert.False( LinkListService.IsValidSlug( new string( 'a', LinkListService.MaxSlugLength + 1 ) ) );
+        }
+
+        // ---- Multi-slug set validation (every slug in the set is validated) ----
+
+        [Fact]
+        public void ValidateSubmitted_Accepts_A_Set_Of_Valid_Slugs()
+        {
+            var submitted = new List<SubmittedSlug>
+            {
+                new SubmittedSlug { Slug = "my-list", IsPrimary = true },
+                new SubmittedSlug { Slug = "list-2024" },
+                new SubmittedSlug { Slug = "0" }
+            };
+            Assert.Null( SlugReconciler.ValidateSubmitted( submitted ) );
+        }
+
+        [Fact]
+        public void ValidateSubmitted_Rejects_When_Any_Slug_In_Set_Is_Invalid()
+        {
+            var submitted = new List<SubmittedSlug>
+            {
+                new SubmittedSlug { Slug = "good-slug", IsPrimary = true },
+                new SubmittedSlug { Slug = "bad slug" } // whitespace -> invalid
+            };
+            var error = SlugReconciler.ValidateSubmitted( submitted );
+            Assert.NotNull( error );
+            Assert.Contains( "bad slug", error );
+        }
+
+        [Fact]
+        public void ValidateSubmitted_Rejects_Duplicate_Slug_In_Set()
+        {
+            var submitted = new List<SubmittedSlug>
+            {
+                new SubmittedSlug { Slug = "dupe", IsPrimary = true },
+                new SubmittedSlug { Slug = "dupe" }
+            };
+            var error = SlugReconciler.ValidateSubmitted( submitted );
+            Assert.NotNull( error );
+            Assert.Contains( "dupe", error );
+        }
+
+        [Fact]
+        public void ValidateSubmitted_Empty_Set_Is_Valid()
+        {
+            Assert.Null( SlugReconciler.ValidateSubmitted( new List<SubmittedSlug>() ) );
         }
     }
 }

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Blocks/LinkListDetailBlock.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Blocks/LinkListDetailBlock.cs
@@ -1,4 +1,4 @@
-// <copyright>
+﻿// <copyright>
 // Copyright Southeast Christian Church
 //
 // Licensed under the  Southeast Christian Church License (the "License");
@@ -124,7 +124,7 @@ namespace org.secc.LinkList.Blocks
                     return ActionForbidden();
                 }
 
-                var bag = service.BuildBag( item, RequestContext.CurrentPerson, requirePublic: false, includeMembers: true );
+                var bag = service.BuildBag( item, RequestContext.CurrentPerson, requirePublic: false, includeMembers: true, includeSlugs: true );
                 if ( bag == null )
                 {
                     return ActionNotFound();
@@ -153,10 +153,13 @@ namespace org.secc.LinkList.Blocks
             {
                 return ActionBadRequest( "Link list payload is required." );
             }
-            // Slugs are canonicalized (trim + lowercase) inside ValidateBag /
-            // EffectiveSubmittedSlugs so mixed-case input typed in the editor is
-            // accepted and stored in the same form every other entry point resolves.
-            var validation = ValidateBag( bag );
+            // Slugs are canonicalized inside BuildSlugSubmission (via
+            // SlugReconciler.BuildSubmission -> LinkListService.CanonicalizeSlug) to
+            // exactly the text Rock will store, so what ValidateBag checks, what the
+            // conflict check queries, and what every entry point resolves all match.
+            // Built once here and threaded through the whole save.
+            var slugSubmission = BuildSlugSubmission( bag );
+            var validation = ValidateBag( bag, slugSubmission );
             if ( validation != null )
             {
                 return ActionBadRequest( validation );
@@ -186,6 +189,22 @@ namespace org.secc.LinkList.Blocks
                     {
                         return ActionForbidden();
                     }
+
+                    // Optimistic concurrency. A slug-aware save reconciles the posted
+                    // slug set as authoritative, so an editor left open while someone
+                    // else adds a slug would delete that slug on save - and the same
+                    // staleness silently reverts their title/link/colour edits. Compare
+                    // what the client loaded against what is stored; a null value means
+                    // a client that doesn't round-trip it, which is left alone.
+                    // Tolerance: SQL datetime resolution and the JSON round-trip don't
+                    // preserve exact ticks.
+                    if ( bag.ModifiedDateTime.HasValue && item.ModifiedDateTime.HasValue
+                        && Math.Abs( ( item.ModifiedDateTime.Value - bag.ModifiedDateTime.Value ).TotalSeconds ) > 1 )
+                    {
+                        return ActionBadRequest(
+                            "This list was changed by someone else since you opened it. "
+                            + "Reload the list and make your changes again." );
+                    }
                 }
                 else
                 {
@@ -207,9 +226,20 @@ namespace org.secc.LinkList.Blocks
                 // Reject any slug already used by ANOTHER list in the channel with a
                 // clear, named error - Rock's SaveSlug would silently suffix instead.
                 // item.Id is 0 for a new (unsaved) item, which excludes nothing here.
-                var slugSubmission = BuildSlugSubmission( bag );
-                var conflictingSlug = service.FindConflictingSlug(
-                    slugSubmission.Slugs.Select( s => s.Slug ), item.Id );
+                // Wrapped because this runs BEFORE the save's own try: the query
+                // parameterizes one value per slug, so without the count cap in
+                // ValidateBag an oversized payload would surface as a raw 500.
+                string conflictingSlug;
+                try
+                {
+                    conflictingSlug = service.FindConflictingSlug(
+                        slugSubmission.Slugs.Select( s => s.Slug ), item.Id );
+                }
+                catch ( Exception ex )
+                {
+                    ExceptionLogService.LogException( ex, System.Web.HttpContext.Current );
+                    return ActionBadRequest( "Could not check the slugs for conflicts. The error has been logged." );
+                }
                 if ( conflictingSlug != null )
                 {
                     return ActionBadRequest(
@@ -227,8 +257,11 @@ namespace org.secc.LinkList.Blocks
                 // a self-deadlock that surfaces as "The wait operation timed out." So these
                 // writes commit individually (as Rock's own detail blocks do). The matrix
                 // rebuild stays atomic on its own: PersistMatrixItems wraps its
-                // delete+upsert in a transaction. The slug catch below rethrows only to
-                // surface a clearer message, not to roll back.
+                // delete+upsert in a transaction.
+                //
+                // Because writes commit as they go, ORDER MATTERS in the slug section
+                // below: it must never delete a slug row until every add has succeeded,
+                // or a later failure leaves a list with dead URLs and no way back.
                 try
                 {
                     rockContext.SaveChanges();
@@ -271,59 +304,114 @@ namespace org.secc.LinkList.Blocks
                     // Multi-slug reconciliation. Only touch slugs when the client
                     // sent slug data - a legacy client that sent neither a Slugs
                     // array nor a scalar slug leaves the list's slugs untouched.
+                    var slugService = new ContentChannelItemSlugService( rockContext );
+                    var slugRowsToDelete = new List<ContentChannelItemSlug>();
                     if ( slugSubmission.FullReconcile || slugSubmission.Slugs.Count > 0 )
                     {
                         // Load the item's slug rows EXPLICITLY (a query, not the lazy
-                        // nav) so the diff sees the committed set. No WrapTransaction
-                        // here (same deadlock reason as above): SaveSlug opens/commits
-                        // on its own as it goes.
-                        var slugService = new ContentChannelItemSlugService( rockContext );
-                        var existingSlugs = slugService.Queryable()
+                        // nav) so the diff sees the committed set - which for a brand
+                        // new list already includes the slug Rock derived from the
+                        // title: ContentChannelItem's save hook mints one on any save
+                        // of an item that has no slug rows, and the SaveChanges above
+                        // is not wrapped in a transaction, so it has already run.
+                        // Tracked entities (not a projection) so this one query serves
+                        // the diff, the primary flag and the deletes alike.
+                        // No WrapTransaction here (same deadlock reason as above):
+                        // SaveSlug opens/commits on its own as it goes.
+                        var slugRows = slugService.Queryable()
                             .Where( s => s.ContentChannelItemId == item.Id )
-                            .Select( s => new { s.Id, s.Slug } )
-                            .ToList()
-                            .Select( s => new ExistingSlug { Id = s.Id, Slug = s.Slug } )
                             .ToList();
 
-                        var slugPlan = SlugReconciler.Reconcile( existingSlugs, slugSubmission.Slugs );
+                        var slugPlan = SlugReconciler.Reconcile(
+                            slugRows.Select( s => new ExistingSlug { Id = s.Id, Slug = s.Slug } ),
+                            slugSubmission.Slugs );
                         if ( !slugPlan.IsValid )
                         {
-                            // ValidateBag already ran; fail loudly rather than silently
-                            // persist a bad set (surfaced by the outer catch).
-                            throw new InvalidOperationException( slugPlan.Error );
+                            // ValidateBag already ran, so this is an invariant breach
+                            // rather than user error - but it is still the user's set,
+                            // so name the problem instead of logging "Save failed".
+                            return ActionBadRequest( slugPlan.Error );
                         }
 
-                        // Add new slugs (SaveSlug normalizes + persists each row).
+                        // Add new slugs. SaveSlug persists each row and RETURNS it,
+                        // which is the only reliable way to learn the STORED text: on
+                        // a collision that appeared after FindConflictingSlug ran it
+                        // silently suffixes "-1", and it returns null without writing
+                        // anything when Rock reduces the text to nothing.
+                        var rowIdBySlug = new Dictionary<string, int>( StringComparer.OrdinalIgnoreCase );
                         foreach ( var slug in slugPlan.SlugsToAdd )
                         {
-                            slugService.SaveSlug( item.Id, channel.Id, slug, null );
-                        }
-
-                        // Delete removed slugs ONLY for a slug-aware (full reconcile)
-                        // client. A legacy scalar-only client upserts without deleting,
-                        // so it can never silently orphan a list's other slugs.
-                        if ( slugSubmission.FullReconcile && slugPlan.SlugIdsToDelete.Count > 0 )
-                        {
-                            var idsToDelete = slugPlan.SlugIdsToDelete;
-                            var rowsToDelete = slugService.Queryable()
-                                .Where( s => idsToDelete.Contains( s.Id ) )
-                                .ToList();
-                            foreach ( var row in rowsToDelete )
+                            var savedRow = slugService.SaveSlug( item.Id, channel.Id, slug, null );
+                            if ( savedRow == null )
                             {
-                                slugService.Delete( row );
+                                // Shouldn't happen: CanonicalizeSlug output is a fixed
+                                // point of Rock's MakeSlugValid, so Rock can't reduce it
+                                // to nothing. Bail out before anything is deleted so the
+                                // list keeps the slugs it still has. Adds that already
+                                // committed stay; a retry is idempotent because the
+                                // reconcile diffs by slug text.
+                                throw new InvalidOperationException(
+                                    $"Rock stored no row for slug '{slug}'; aborted before deleting any slugs." );
                             }
-                            rockContext.SaveChanges();
+                            rowIdBySlug[slug] = savedRow.Id;
+                            slugRows.Add( savedRow );
                         }
 
-                        // Set the primary flag on the chosen row and clear it on the rest.
-                        var currentSlugRows = slugService.Queryable()
-                            .Where( s => s.ContentChannelItemId == item.Id )
-                            .ToList();
-                        var primaryChanged = false;
-                        foreach ( var row in currentSlugRows )
+                        // Deletions are DEFERRED until after the matrix rebuild (see
+                        // below): removing a slug kills a public URL for good, so it
+                        // must be the last thing this save does. Only a slug-aware
+                        // client that sent a non-empty set may delete - a legacy
+                        // scalar-only client upserts without deleting, and an empty set
+                        // means "leave the slugs to Rock" (see ValidateBag).
+                        var mayDelete = slugSubmission.FullReconcile && slugSubmission.Slugs.Count > 0;
+                        if ( mayDelete )
                         {
-                            var shouldBePrimary = slugPlan.PrimarySlug != null
-                                && string.Equals( row.Slug, slugPlan.PrimarySlug, StringComparison.OrdinalIgnoreCase );
+                            slugRowsToDelete = slugRows
+                                .Where( s => slugPlan.SlugIdsToDelete.Contains( s.Id ) )
+                                .ToList();
+                        }
+
+                        if ( slugRows.Count == 0 )
+                        {
+                            // Only reachable if Rock's save-hook slug write failed - it
+                            // logs and swallows its own exceptions. A list with no slug
+                            // is unreachable by the viewer, web component and REST, so
+                            // say so rather than reporting a clean save.
+                            throw new InvalidOperationException(
+                                "The list has no slug: Rock could not derive one from the title. Add a slug and save again." );
+                        }
+
+                        // Match the primary row by ID, never by text: SaveSlug may have
+                        // stored a "-1"-suffixed variant of what was submitted, and a
+                        // text comparison would then match nothing and silently clear
+                        // every primary flag. Rows the reconcile kept map to themselves.
+                        int? primaryRowId = null;
+                        if ( slugPlan.PrimarySlug != null )
+                        {
+                            primaryRowId = rowIdBySlug.TryGetValue( slugPlan.PrimarySlug, out var addedRowId )
+                                ? addedRowId
+                                : slugRows
+                                    .Where( r => string.Equals( r.Slug, slugPlan.PrimarySlug, StringComparison.OrdinalIgnoreCase ) )
+                                    .Select( r => ( int? ) r.Id )
+                                    .FirstOrDefault();
+                        }
+                        if ( primaryRowId == null )
+                        {
+                            // Nothing was submitted (Rock derived the slug from the
+                            // title), so keep the list's existing primary if it has one
+                            // and otherwise promote its oldest row - a list with slugs
+                            // always ends up with exactly one primary. Rows queued for
+                            // deletion are never candidates.
+                            var doomedIds = slugRowsToDelete.Select( r => r.Id ).ToList();
+                            var survivors = slugRows.Where( r => !doomedIds.Contains( r.Id ) ).ToList();
+                            primaryRowId = survivors.FirstOrDefault( r => r.IsPrimary )?.Id
+                                ?? survivors.OrderBy( r => r.Id ).First().Id;
+                        }
+
+                        var primaryChanged = false;
+                        foreach ( var row in slugRows )
+                        {
+                            var shouldBePrimary = row.Id == primaryRowId.Value;
                             if ( row.IsPrimary != shouldBePrimary )
                             {
                                 row.IsPrimary = shouldBePrimary;
@@ -339,6 +427,20 @@ namespace org.secc.LinkList.Blocks
                     // Persist link rows: upserts by row Guid, deletes rows missing
                     // from the incoming list, and reorders by list position.
                     service.PersistMatrixItems( item, bag.Items );
+
+                    // Slug deletions go LAST. Everything above commits as it goes, so a
+                    // failure anywhere earlier used to leave a slug's URL permanently
+                    // dead while the user was told the save failed. Deferring them means
+                    // the worst case is a slug that outlives its removal - recoverable by
+                    // saving again - instead of a URL that can never be recovered.
+                    if ( slugRowsToDelete.Count > 0 )
+                    {
+                        foreach ( var row in slugRowsToDelete )
+                        {
+                            slugService.Delete( row );
+                        }
+                        rockContext.SaveChanges();
+                    }
                 }
                 catch ( Exception ex )
                 {
@@ -346,6 +448,19 @@ namespace org.secc.LinkList.Blocks
                     // goes to Rock's exception log; the client gets a generic message
                     // so database/schema details never leak to the browser.
                     ExceptionLogService.LogException( ex, System.Web.HttpContext.Current );
+
+                    // The writes above commit as they go, so the list itself may already
+                    // exist. Hand the saved bag back with a warning rather than a bare
+                    // error: otherwise a new list's editor keeps a null id, the retry
+                    // looks like another new list, and it is rejected forever for
+                    // conflicting with the slugs the failed attempt just created.
+                    if ( item.Id > 0 )
+                    {
+                        var partial = service.BuildBag( item, RequestContext.CurrentPerson, requirePublic: false, includeMembers: true, includeSlugs: true );
+                        partial.SaveWarning = "Some of your changes could not be saved. "
+                            + "The error has been logged; review the list and save again.";
+                        return ActionOk( partial );
+                    }
                     return ActionBadRequest( "Save failed. The error has been logged; contact an administrator if it persists." );
                 }
 
@@ -363,11 +478,15 @@ namespace org.secc.LinkList.Blocks
                     catch ( Exception ex )
                     {
                         // The list itself is saved; only the edit-access group failed.
-                        // Log it and tell the user to re-save to (idempotently) create it.
+                        // Return the saved bag with a warning (not a bare error) so the
+                        // editor keeps the new list's identity - re-saving is idempotent
+                        // and finishes the setup, whereas a retry that looked like a new
+                        // list would collide with the slugs this attempt already created.
                         ExceptionLogService.LogException( ex, System.Web.HttpContext.Current );
-                        return ActionBadRequest(
-                            "The list was saved, but setting up edit access failed. "
-                            + "The error has been logged. Re-open the list and save again to finish access setup." );
+                        var partial = service.BuildBag( item, RequestContext.CurrentPerson, requirePublic: false, includeMembers: true, includeSlugs: true );
+                        partial.SaveWarning = "The list was saved, but setting up edit access failed. "
+                            + "The error has been logged. Save again to finish access setup.";
+                        return ActionOk( partial );
                     }
                 }
                 else
@@ -384,7 +503,7 @@ namespace org.secc.LinkList.Blocks
                     }
                 }
 
-                var saved = service.BuildBag( item, RequestContext.CurrentPerson, requirePublic: false, includeMembers: true );
+                var saved = service.BuildBag( item, RequestContext.CurrentPerson, requirePublic: false, includeMembers: true, includeSlugs: true );
                 return ActionOk( saved );
             }
         }
@@ -639,35 +758,21 @@ namespace org.secc.LinkList.Blocks
             }
         }
 
-        private static string ValidateBag( LinkListBag bag )
+        private static string ValidateBag( LinkListBag bag, SlugSubmission submission )
         {
             if ( bag.Title.IsNullOrWhiteSpace() || bag.Title.Trim().Length < 1 || bag.Title.Trim().Length > 250 )
             {
                 return "Title is required and must be 1-250 characters.";
             }
 
-            var submission = BuildSlugSubmission( bag );
-
-            // Validate EVERY submitted slug (charset) and reject duplicates within
-            // the submitted set. Channel-wide uniqueness is checked separately (it
-            // needs a DB query). Slug charset/normalization rules live in
-            // LinkListService - the single source of truth.
-            var slugError = SlugReconciler.ValidateSubmitted( submission.Slugs );
-            if ( slugError != null )
-            {
-                return slugError;
-            }
-
-            // A slug-aware client must keep at least one slug: a zero-slug list is
-            // unreachable by the viewer and public web component (both resolve a
-            // list only by its slug). A legacy scalar-only client (FullReconcile
-            // false) is not held to this - it can't manage slugs, and its update
-            // never deletes, so it can't create a zero-slug list.
-            if ( submission.FullReconcile && submission.Slugs.Count == 0 )
-            {
-                return "A link list must have at least one slug.";
-            }
-            return null;
+            // Validate EVERY submitted slug (charset), reject duplicates within the
+            // submitted set, cap the count, and require the title to yield a slug when
+            // the set is empty. Channel-wide uniqueness is checked separately (it needs
+            // a DB query). Slug rules live in LinkListService/SlugReconciler - the
+            // single source of truth.
+            return SlugReconciler.ValidateSubmitted( submission.Slugs )
+                ?? SlugReconciler.ValidateSubmissionSize( submission )
+                ?? SlugReconciler.ValidateSubmissionAgainstTitle( submission, bag.Title );
         }
 
         /// <summary>
@@ -676,17 +781,19 @@ namespace org.secc.LinkList.Blocks
         /// when the collection is omitted (null - a legacy scalar-only client) it
         /// becomes an upsert-only submission seeded from the scalar
         /// <see cref="LinkListBag.Slug"/> that never deletes other slugs. All
-        /// normalization/blank-dropping happens in
+        /// canonicalization, blank-dropping and de-duplication happens in
         /// <see cref="SlugReconciler.BuildSubmission"/>.
         /// </summary>
         private static SlugSubmission BuildSlugSubmission( LinkListBag bag )
         {
             // Map the bag's slugs to the helper's POCO, preserving null (omitted)
-            // vs non-null (provided) so BuildSubmission can tell them apart.
+            // vs non-null (provided) so BuildSubmission can tell them apart. Null
+            // ELEMENTS are dropped first - a hand-rolled "slugs":[null] payload
+            // would otherwise throw here, outside the save's try/catch.
             var provided = bag.Slugs?
+                .Where( s => s != null )
                 .Select( s => new SubmittedSlug
                 {
-                    Id = s.Id,
                     Slug = s.Slug,
                     IsPrimary = s.IsPrimary
                 } )

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Blocks/LinkListDetailBlock.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Blocks/LinkListDetailBlock.cs
@@ -153,10 +153,9 @@ namespace org.secc.LinkList.Blocks
             {
                 return ActionBadRequest( "Link list payload is required." );
             }
-            // Canonicalize the slug (trim + lowercase) before validation so a
-            // mixed-case slug typed in the editor is accepted and stored in the
-            // same form every other entry point resolves.
-            bag.Slug = LinkListService.NormalizeSlug( bag.Slug );
+            // Slugs are canonicalized (trim + lowercase) inside ValidateBag /
+            // EffectiveSubmittedSlugs so mixed-case input typed in the editor is
+            // accepted and stored in the same form every other entry point resolves.
             var validation = ValidateBag( bag );
             if ( validation != null )
             {
@@ -203,6 +202,18 @@ namespace org.secc.LinkList.Blocks
                         StartDateTime = RockDateTime.Now
                     };
                     itemService.Add( item );
+                }
+
+                // Reject any slug already used by ANOTHER list in the channel with a
+                // clear, named error - Rock's SaveSlug would silently suffix instead.
+                // item.Id is 0 for a new (unsaved) item, which excludes nothing here.
+                var slugSubmission = BuildSlugSubmission( bag );
+                var conflictingSlug = service.FindConflictingSlug(
+                    slugSubmission.Slugs.Select( s => s.Slug ), item.Id );
+                if ( conflictingSlug != null )
+                {
+                    return ActionBadRequest(
+                        $"The slug '{conflictingSlug}' is already used by another list. Choose a different slug." );
                 }
 
                 item.Title = bag.Title.Trim();
@@ -257,21 +268,71 @@ namespace org.secc.LinkList.Blocks
                     PersistBinaryFile( rockContext, bag.HeaderBackgroundImage );
                     rockContext.SaveChanges();
 
-                    // Slug upsert (uniqueness within the channel is enforced by Rock).
-                    if ( !bag.Slug.IsNullOrWhiteSpace() )
+                    // Multi-slug reconciliation. Only touch slugs when the client
+                    // sent slug data - a legacy client that sent neither a Slugs
+                    // array nor a scalar slug leaves the list's slugs untouched.
+                    if ( slugSubmission.FullReconcile || slugSubmission.Slugs.Count > 0 )
                     {
-                        var existingSlug = item.ContentChannelItemSlugs?
-                            .OrderBy( s => s.Id )
-                            .FirstOrDefault();
+                        // Load the item's slug rows EXPLICITLY (a query, not the lazy
+                        // nav) so the diff sees the committed set. No WrapTransaction
+                        // here (same deadlock reason as above): SaveSlug opens/commits
+                        // on its own as it goes.
                         var slugService = new ContentChannelItemSlugService( rockContext );
-                        try
+                        var existingSlugs = slugService.Queryable()
+                            .Where( s => s.ContentChannelItemId == item.Id )
+                            .Select( s => new { s.Id, s.Slug } )
+                            .ToList()
+                            .Select( s => new ExistingSlug { Id = s.Id, Slug = s.Slug } )
+                            .ToList();
+
+                        var slugPlan = SlugReconciler.Reconcile( existingSlugs, slugSubmission.Slugs );
+                        if ( !slugPlan.IsValid )
                         {
-                            slugService.SaveSlug( item.Id, channel.Id, bag.Slug, existingSlug?.Id );
+                            // ValidateBag already ran; fail loudly rather than silently
+                            // persist a bad set (surfaced by the outer catch).
+                            throw new InvalidOperationException( slugPlan.Error );
                         }
-                        catch ( Exception ex )
+
+                        // Add new slugs (SaveSlug normalizes + persists each row).
+                        foreach ( var slug in slugPlan.SlugsToAdd )
                         {
-                            // Rethrow to roll back the transaction; surfaced below.
-                            throw new InvalidOperationException( "Slug error: " + ex.Message, ex );
+                            slugService.SaveSlug( item.Id, channel.Id, slug, null );
+                        }
+
+                        // Delete removed slugs ONLY for a slug-aware (full reconcile)
+                        // client. A legacy scalar-only client upserts without deleting,
+                        // so it can never silently orphan a list's other slugs.
+                        if ( slugSubmission.FullReconcile && slugPlan.SlugIdsToDelete.Count > 0 )
+                        {
+                            var idsToDelete = slugPlan.SlugIdsToDelete;
+                            var rowsToDelete = slugService.Queryable()
+                                .Where( s => idsToDelete.Contains( s.Id ) )
+                                .ToList();
+                            foreach ( var row in rowsToDelete )
+                            {
+                                slugService.Delete( row );
+                            }
+                            rockContext.SaveChanges();
+                        }
+
+                        // Set the primary flag on the chosen row and clear it on the rest.
+                        var currentSlugRows = slugService.Queryable()
+                            .Where( s => s.ContentChannelItemId == item.Id )
+                            .ToList();
+                        var primaryChanged = false;
+                        foreach ( var row in currentSlugRows )
+                        {
+                            var shouldBePrimary = slugPlan.PrimarySlug != null
+                                && string.Equals( row.Slug, slugPlan.PrimarySlug, StringComparison.OrdinalIgnoreCase );
+                            if ( row.IsPrimary != shouldBePrimary )
+                            {
+                                row.IsPrimary = shouldBePrimary;
+                                primaryChanged = true;
+                            }
+                        }
+                        if ( primaryChanged )
+                        {
+                            rockContext.SaveChanges();
                         }
                     }
 
@@ -584,11 +645,53 @@ namespace org.secc.LinkList.Blocks
             {
                 return "Title is required and must be 1-250 characters.";
             }
-            if ( !bag.Slug.IsNullOrWhiteSpace() && !LinkListService.IsValidSlug( bag.Slug ) )
+
+            var submission = BuildSlugSubmission( bag );
+
+            // Validate EVERY submitted slug (charset) and reject duplicates within
+            // the submitted set. Channel-wide uniqueness is checked separately (it
+            // needs a DB query). Slug charset/normalization rules live in
+            // LinkListService - the single source of truth.
+            var slugError = SlugReconciler.ValidateSubmitted( submission.Slugs );
+            if ( slugError != null )
             {
-                return "Slug must be 1-200 chars of letters, digits, or dashes.";
+                return slugError;
+            }
+
+            // A slug-aware client must keep at least one slug: a zero-slug list is
+            // unreachable by the viewer and public web component (both resolve a
+            // list only by its slug). A legacy scalar-only client (FullReconcile
+            // false) is not held to this - it can't manage slugs, and its update
+            // never deletes, so it can't create a zero-slug list.
+            if ( submission.FullReconcile && submission.Slugs.Count == 0 )
+            {
+                return "A link list must have at least one slug.";
             }
             return null;
+        }
+
+        /// <summary>
+        /// The slug set this save should apply. When the client sent a Slugs
+        /// collection (slug-aware editor) it drives a delete-capable reconcile;
+        /// when the collection is omitted (null - a legacy scalar-only client) it
+        /// becomes an upsert-only submission seeded from the scalar
+        /// <see cref="LinkListBag.Slug"/> that never deletes other slugs. All
+        /// normalization/blank-dropping happens in
+        /// <see cref="SlugReconciler.BuildSubmission"/>.
+        /// </summary>
+        private static SlugSubmission BuildSlugSubmission( LinkListBag bag )
+        {
+            // Map the bag's slugs to the helper's POCO, preserving null (omitted)
+            // vs non-null (provided) so BuildSubmission can tell them apart.
+            var provided = bag.Slugs?
+                .Select( s => new SubmittedSlug
+                {
+                    Id = s.Id,
+                    Slug = s.Slug,
+                    IsPrimary = s.IsPrimary
+                } )
+                .ToList();
+            return SlugReconciler.BuildSubmission( provided, bag.Slug );
         }
 
         private static void SetIfPresent( ContentChannelItem item, string key, string value )

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Blocks/LinkListDetailBlock.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Blocks/LinkListDetailBlock.cs
@@ -236,6 +236,47 @@ namespace org.secc.LinkList.Blocks
                     itemService.Add( item );
                 }
 
+                // Discard submitted slugs whose rows another editor deleted while this
+                // client had the list open, so saving a stale screen can't resurrect them.
+                //
+                // This has to happen BEFORE the conflict check below: if the other editor
+                // moved that slug to a different list, the stale submission would collide
+                // with it and the save would be refused over a slug this user never
+                // touched and that is about to be discarded anyway. (The conflict check
+                // itself must stay here, ahead of every write - moving it later would
+                // commit the title and attributes and only then refuse.)
+                //
+                // Deliberately a SECOND, cheap read: the authoritative slug query lower
+                // down has to stay there, because for a new list Rock's save hook mints a
+                // title-derived row during the first SaveChanges that this read can't see.
+                // The gap between the two reads is harmless - this filter is best-effort
+                // by nature.
+                var droppedSlugs = new List<string>();
+                if ( !isNew )
+                {
+                    var currentRows = new ContentChannelItemSlugService( rockContext ).Queryable()
+                        .Where( s => s.ContentChannelItemId == item.Id )
+                        .Select( s => new { s.Id, s.Slug } )
+                        .ToList()
+                        .Select( s => new ExistingSlug { Id = s.Id, Slug = s.Slug } );
+
+                    var filtered = SlugReconciler.FilterConcurrentlyDeleted( slugSubmission.Slugs, currentRows );
+                    if ( filtered.DroppedSlugs.Count > 0 && filtered.Kept.Count == 0 )
+                    {
+                        // Every slug this client knew about is gone. There is nothing left
+                        // to reconcile against, and proceeding would either wipe the list's
+                        // current slugs or invent one from the title, so stop and say so.
+                        return ActionBadRequest(
+                            "This list's slugs were changed by someone else since you opened it. "
+                            + "Reload the list and make your changes again." );
+                    }
+                    // REPLACE the submission: the delete pass keys off Slugs.Count, so a
+                    // filtered copy kept on the side would leave deletes enabled against a
+                    // set that no longer justifies them.
+                    slugSubmission.Slugs = filtered.Kept;
+                    droppedSlugs = filtered.DroppedSlugs;
+                }
+
                 // Reject any slug already used by ANOTHER list in the channel with a
                 // clear, named error - Rock's SaveSlug would silently suffix instead.
                 // item.Id is 0 for a new (unsaved) item, which excludes nothing here.
@@ -263,9 +304,17 @@ namespace org.secc.LinkList.Blocks
                 // Intro content lives in the native Content field (legacy parity).
                 item.Content = bag.IntroContent ?? string.Empty;
 
-                // Set when this save kept a slug another editor added; reported on the
-                // response so the user knows why the list has a slug they didn't add.
-                string concurrentSlugWarning = null;
+                // Notes about slugs this save merged rather than overwrote - a row another
+                // editor added and this save kept, or one they deleted and this save did
+                // not resurrect. Reported together on the response so the user isn't
+                // surprised by a slug list that doesn't match what was on their screen.
+                var concurrentSlugNotes = new List<string>();
+                if ( droppedSlugs.Count > 0 )
+                {
+                    concurrentSlugNotes.Add( droppedSlugs.Count == 1
+                        ? $"Another editor deleted the slug '{droppedSlugs[0]}' while you had this list open, so it was not restored."
+                        : $"Another editor deleted these slugs while you had this list open, so they were not restored: {string.Join( ", ", droppedSlugs )}." );
+                }
 
                 // NOTE: intentionally NOT wrapped in rockContext.WrapTransaction. Rock
                 // helpers used below (ContentChannelItemSlugService.SaveSlug and the
@@ -404,9 +453,9 @@ namespace org.secc.LinkList.Blocks
                                 .ToList();
                             if ( sparedSlugs.Count > 0 )
                             {
-                                concurrentSlugWarning = sparedSlugs.Count == 1
+                                concurrentSlugNotes.Add( sparedSlugs.Count == 1
                                     ? $"Another editor added the slug '{sparedSlugs[0]}' while you had this list open. It was kept."
-                                    : $"Another editor added these slugs while you had this list open, and they were kept: {string.Join( ", ", sparedSlugs )}.";
+                                    : $"Another editor added these slugs while you had this list open, and they were kept: {string.Join( ", ", sparedSlugs )}." );
                             }
                         }
 
@@ -559,7 +608,9 @@ namespace org.secc.LinkList.Blocks
                 }
 
                 var saved = service.BuildBag( item, RequestContext.CurrentPerson, requirePublic: false, includeMembers: true, includeSlugs: true );
-                saved.SaveWarning = concurrentSlugWarning;
+                saved.SaveNotice = concurrentSlugNotes.Count > 0
+                    ? string.Join( " ", concurrentSlugNotes )
+                    : null;
                 return ActionOk( saved );
             }
         }
@@ -851,7 +902,10 @@ namespace org.secc.LinkList.Blocks
                 .Select( s => new SubmittedSlug
                 {
                     Slug = s.Slug,
-                    IsPrimary = s.IsPrimary
+                    IsPrimary = s.IsPrimary,
+                    // Carried for concurrency detection only - see SubmittedSlug.ClientRowId.
+                    // 0 means the user typed this slug in the editor.
+                    ClientRowId = s.Id
                 } )
                 .ToList();
             return SlugReconciler.BuildSubmission( provided, bag.Slug );

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Blocks/LinkListDetailBlock.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Blocks/LinkListDetailBlock.cs
@@ -142,8 +142,17 @@ namespace org.secc.LinkList.Blocks
             }
         }
 
+        /// <summary>
+        /// Saves a list. <paramref name="loadedSlugIds"/> is the set of slug row ids the
+        /// editor had on screen when it loaded, which is what lets a save DELETE a slug
+        /// without clobbering one another editor added in the meantime - see
+        /// <see cref="SlugReconciler.FilterDeletableIds"/>. It is request-scoped intent
+        /// rather than list state, so it is a separate parameter instead of a bag field
+        /// (the bag doubles as the read model serialized to anonymous callers). Null when
+        /// the caller doesn't track it.
+        /// </summary>
         [BlockAction]
-        public BlockActionResult SaveList( LinkListBag bag )
+        public BlockActionResult SaveList( LinkListBag bag, List<int> loadedSlugIds = null )
         {
             if ( RequestContext.CurrentPerson == null )
             {
@@ -190,12 +199,16 @@ namespace org.secc.LinkList.Blocks
                         return ActionForbidden();
                     }
 
-                    // Optimistic concurrency. A slug-aware save reconciles the posted
-                    // slug set as authoritative, so an editor left open while someone
-                    // else adds a slug would delete that slug on save - and the same
-                    // staleness silently reverts their title/link/colour edits. Compare
-                    // what the client loaded against what is stored; a null value means
-                    // a client that doesn't round-trip it, which is left alone.
+                    // Optimistic concurrency for the item ROW: reject a save whose view
+                    // of the list predates someone else's, so a stale tab can't silently
+                    // revert their title or intro content.
+                    //
+                    // Scope, precisely: Rock stamps ModifiedDateTime only when the item
+                    // row itself is Added/Modified. Slugs, colours and link rows live in
+                    // other tables and never touch it, so this check CANNOT see those
+                    // edits - the slug case is handled instead by restricting deletions
+                    // to rows the editor actually loaded (see loadedSlugIds below).
+                    // A null value means a client that doesn't round-trip it: left alone.
                     // Tolerance: SQL datetime resolution and the JSON round-trip don't
                     // preserve exact ticks.
                     if ( bag.ModifiedDateTime.HasValue && item.ModifiedDateTime.HasValue
@@ -249,6 +262,10 @@ namespace org.secc.LinkList.Blocks
                 item.Title = bag.Title.Trim();
                 // Intro content lives in the native Content field (legacy parity).
                 item.Content = bag.IntroContent ?? string.Empty;
+
+                // Set when this save kept a slug another editor added; reported on the
+                // response so the user knows why the list has a slug they didn't add.
+                string concurrentSlugWarning = null;
 
                 // NOTE: intentionally NOT wrapped in rockContext.WrapTransaction. Rock
                 // helpers used below (ContentChannelItemSlugService.SaveSlug and the
@@ -309,11 +326,14 @@ namespace org.secc.LinkList.Blocks
                     if ( slugSubmission.FullReconcile || slugSubmission.Slugs.Count > 0 )
                     {
                         // Load the item's slug rows EXPLICITLY (a query, not the lazy
-                        // nav) so the diff sees the committed set - which for a brand
-                        // new list already includes the slug Rock derived from the
-                        // title: ContentChannelItem's save hook mints one on any save
-                        // of an item that has no slug rows, and the SaveChanges above
-                        // is not wrapped in a transaction, so it has already run.
+                        // nav) so the diff sees the committed set - which for a NEW list
+                        // already includes the slug Rock derived from the title: its save
+                        // hook mints one for an item with no slug rows, and the
+                        // SaveChanges above is not wrapped in a transaction, so it has
+                        // already run. That hook does NOT fire for an existing item whose
+                        // own row didn't change (Rock skips hooks for an Unchanged
+                        // entity), which is why the title slug is also derived explicitly
+                        // below rather than assumed.
                         // Tracked entities (not a projection) so this one query serves
                         // the diff, the primary flag and the deletes alike.
                         // No WrapTransaction here (same deadlock reason as above):
@@ -366,19 +386,54 @@ namespace org.secc.LinkList.Blocks
                         var mayDelete = slugSubmission.FullReconcile && slugSubmission.Slugs.Count > 0;
                         if ( mayDelete )
                         {
+                            // Restricted to rows the editor actually loaded, so a slug
+                            // another editor added since then is kept rather than read as
+                            // one this user removed. Deliberate removal is unaffected.
+                            var deletableIds = SlugReconciler.FilterDeletableIds(
+                                slugPlan.SlugIdsToDelete, loadedSlugIds );
                             slugRowsToDelete = slugRows
-                                .Where( s => slugPlan.SlugIdsToDelete.Contains( s.Id ) )
+                                .Where( s => deletableIds.Contains( s.Id ) )
                                 .ToList();
+
+                            // Tell the user when that actually spared something, so
+                            // neither editor is surprised by a slug they didn't add.
+                            var sparedSlugs = slugRows
+                                .Where( s => slugPlan.SlugIdsToDelete.Contains( s.Id )
+                                    && !deletableIds.Contains( s.Id ) )
+                                .Select( s => s.Slug )
+                                .ToList();
+                            if ( sparedSlugs.Count > 0 )
+                            {
+                                concurrentSlugWarning = sparedSlugs.Count == 1
+                                    ? $"Another editor added the slug '{sparedSlugs[0]}' while you had this list open. It was kept."
+                                    : $"Another editor added these slugs while you had this list open, and they were kept: {string.Join( ", ", sparedSlugs )}.";
+                            }
                         }
 
                         if ( slugRows.Count == 0 )
                         {
-                            // Only reachable if Rock's save-hook slug write failed - it
-                            // logs and swallows its own exceptions. A list with no slug
-                            // is unreachable by the viewer, web component and REST, so
-                            // say so rather than reporting a clean save.
+                            // Derive a slug from the title, the way Rock's own content
+                            // channel item block does. Rock's save hook does this too,
+                            // but ONLY when the item row itself changed - hooks are
+                            // skipped for an Unchanged entity - so a slug-only or no-op
+                            // save on a slug-less list would otherwise leave it
+                            // unreachable. Doing it here makes it deterministic.
+                            var derived = slugService.SaveSlug( item.Id, channel.Id, item.Title, null );
+                            if ( derived != null )
+                            {
+                                slugRows.Add( derived );
+                            }
+                        }
+
+                        if ( slugRows.Count == 0 )
+                        {
+                            // Unreachable: ValidateBag rejects an empty submitted set
+                            // whose title yields no slug, so either a slug was added
+                            // above or one was just derived. A list with no slug is
+                            // unreachable by the viewer, web component and REST, so say
+                            // so rather than reporting a clean save.
                             throw new InvalidOperationException(
-                                "The list has no slug: Rock could not derive one from the title. Add a slug and save again." );
+                                "The list has no slug and none could be derived from the title. Add a slug and save again." );
                         }
 
                         // Match the primary row by ID, never by text: SaveSlug may have
@@ -504,6 +559,7 @@ namespace org.secc.LinkList.Blocks
                 }
 
                 var saved = service.BuildBag( item, RequestContext.CurrentPerson, requirePublic: false, includeMembers: true, includeSlugs: true );
+                saved.SaveWarning = concurrentSlugWarning;
                 return ActionOk( saved );
             }
         }

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Services/LinkListService.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Services/LinkListService.cs
@@ -459,6 +459,9 @@ namespace org.secc.LinkList.Services
                 Title = item.Title ?? "Untitled",
                 Slug = PrimarySlug( item ),
                 Slugs = includeSlugs ? BuildSlugBags( item ) : null,
+                // Round-tripped by the editor and checked on save (see SaveList) so a
+                // stale tab can't silently revert someone else's title edit.
+                ModifiedDateTime = item.ModifiedDateTime,
                 IsPublic = isPublic,
                 ContentTextColor = item.GetAttributeValue( LinkListGuids.TypeAttributeKey.ContentTextColor ),
                 BackgroundColor = item.GetAttributeValue( LinkListGuids.TypeAttributeKey.BackgroundColor ),

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Services/LinkListService.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Services/LinkListService.cs
@@ -162,10 +162,68 @@ namespace org.secc.LinkList.Services
             {
                 return null;
             }
+            // Primary wins; among unflagged rows fall back to the lowest Id (today's
+            // behavior), so existing single-flag-less lists resolve exactly as before
+            // - no data migration needed.
             return item.ContentChannelItemSlugs?
-                .OrderBy( s => s.Id )
+                .OrderByDescending( s => s.IsPrimary )
+                .ThenBy( s => s.Id )
                 .Select( s => s.Slug )
                 .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Every slug for the item (primary first, then lowest-Id), mapped to bags
+        /// for the editor. Same ordering as <see cref="PrimarySlug"/> so the first
+        /// entry is always the primary.
+        /// </summary>
+        private static List<LinkListSlugBag> BuildSlugBags( ContentChannelItem item )
+        {
+            if ( item?.ContentChannelItemSlugs == null )
+            {
+                return new List<LinkListSlugBag>();
+            }
+            return item.ContentChannelItemSlugs
+                .OrderByDescending( s => s.IsPrimary )
+                .ThenBy( s => s.Id )
+                .Select( s => new LinkListSlugBag
+                {
+                    Id = s.Id,
+                    Slug = s.Slug,
+                    IsPrimary = s.IsPrimary
+                } )
+                .ToList();
+        }
+
+        /// <summary>
+        /// Returns the first of <paramref name="normalizedSlugs"/> that already
+        /// belongs to a DIFFERENT item in the LinkList channel (case-insensitive),
+        /// or null when they're all free. Used for a clear pre-save conflict error:
+        /// Rock's SaveSlug/GetUniqueSlug never throws on collision - it silently
+        /// suffixes -1/-2 - so uniqueness must be checked explicitly.
+        /// </summary>
+        public string FindConflictingSlug( IEnumerable<string> normalizedSlugs, int excludeItemId )
+        {
+            var slugs = ( normalizedSlugs ?? Enumerable.Empty<string>() )
+                .Where( s => !s.IsNullOrWhiteSpace() )
+                .Distinct( StringComparer.OrdinalIgnoreCase )
+                .ToList();
+            if ( slugs.Count == 0 )
+            {
+                return null;
+            }
+
+            var channelGuid = LinkListGuids.LinkListChannel.AsGuid();
+            var taken = new ContentChannelItemSlugService( _rockContext )
+                .Queryable()
+                .Where( s => s.ContentChannelItem.ContentChannel.Guid == channelGuid
+                    && s.ContentChannelItemId != excludeItemId
+                    && slugs.Contains( s.Slug ) )
+                .Select( s => s.Slug )
+                .ToList();
+
+            var takenSet = new HashSet<string>( taken, StringComparer.OrdinalIgnoreCase );
+            return slugs.FirstOrDefault( s => takenSet.Contains( s ) );
         }
 
         /// <summary>
@@ -288,6 +346,7 @@ namespace org.secc.LinkList.Services
                     Guid = item.Guid.ToString(),
                     Title = item.Title ?? "Untitled",
                     Slug = PrimarySlug( item ),
+                    Slugs = BuildSlugBags( item ),
                     IsPublic = ReadIsPublic( item ),
                     DesignName = ResolveDesignName( item ),
                     ModifiedDateTime = item.ModifiedDateTime,
@@ -356,6 +415,7 @@ namespace org.secc.LinkList.Services
                 Guid = item.Guid.ToString(),
                 Title = item.Title ?? "Untitled",
                 Slug = PrimarySlug( item ),
+                Slugs = BuildSlugBags( item ),
                 IsPublic = isPublic,
                 ContentTextColor = item.GetAttributeValue( LinkListGuids.TypeAttributeKey.ContentTextColor ),
                 BackgroundColor = item.GetAttributeValue( LinkListGuids.TypeAttributeKey.BackgroundColor ),

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Services/LinkListService.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Services/LinkListService.cs
@@ -97,25 +97,71 @@ namespace org.secc.LinkList.Services
         // ---------------------------------------------------------------------
 
         // Slugs are lowercase-only: Rock's SaveSlug/MakeSlugValid lowercases on
-        // write, so stored slugs never contain uppercase. Every entry point
-        // (editor validation, viewer, public REST) normalizes through
-        // NormalizeSlug and validates with IsValidSlug so mixed-case input in a
-        // URL still resolves while the canonical form stays consistent.
+        // write, so stored slugs never contain uppercase. Read paths (viewer,
+        // public REST, ResolveItem) run inbound URL text through NormalizeSlug
+        // and IsValidSlug so mixed-case input still resolves. WRITE paths run
+        // CanonicalizeSlug, which produces exactly the text Rock will store.
         private static readonly System.Text.RegularExpressions.Regex SlugPattern =
             new System.Text.RegularExpressions.Regex( @"^[a-z0-9-]+$", System.Text.RegularExpressions.RegexOptions.Compiled );
 
+        private static readonly System.Text.RegularExpressions.Regex SlugStripPattern =
+            new System.Text.RegularExpressions.Regex( @"[^a-zA-Z0-9 -]", System.Text.RegularExpressions.RegexOptions.Compiled );
+
+        private static readonly System.Text.RegularExpressions.Regex SlugCollapseDashPattern =
+            new System.Text.RegularExpressions.Regex( @"-+", System.Text.RegularExpressions.RegexOptions.Compiled );
+
         public const int MaxSlugLength = 200;
 
-        /// <summary>Canonical slug form: trimmed and lowercased (null stays null).</summary>
+        /// <summary>Read-path slug form: trimmed and lowercased (null stays null).</summary>
         public static string NormalizeSlug( string slug )
         {
             return slug?.Trim().ToLowerInvariant();
         }
 
         /// <summary>
-        /// True when the value is a valid canonical slug: 1-200 chars of
-        /// lowercase letters, digits, or dashes. Callers should pass the
-        /// <see cref="NormalizeSlug"/> form.
+        /// Write-path canonicalization, mirroring Rock's ContentChannelItemSlugService
+        /// .MakeSlugValid (internal, so a plugin can't call it) with one deliberate
+        /// difference: the dash collapse runs AFTER the charset strip so the result is
+        /// a FIXED POINT of MakeSlugValid. SaveSlug re-runs MakeSlugValid on whatever
+        /// it is given, and only a fixed point guarantees the text validated here is
+        /// the text stored - which every slug conflict check, reconcile diff and
+        /// primary-flag match depends on. (Rock's own order turns "rock &amp; roll" into
+        /// "rock--roll", which a second pass then changes to "rock-roll".) For input
+        /// without that quirk the two orders produce identical output.
+        /// Returns "" (never null) when nothing usable survives; callers drop blanks.
+        /// Leading dashes are kept, matching Rock.
+        /// </summary>
+        public static string CanonicalizeSlug( string slug )
+        {
+            if ( slug == null )
+            {
+                return string.Empty;
+            }
+
+            slug = slug
+                .Trim()
+                .ToLowerInvariant()
+                .Replace( "&nbsp;", "-" )
+                .Replace( "&#160;", "-" )
+                .Replace( "&ndash;", "-" )
+                .Replace( "&#8211;", "-" )
+                .Replace( "&mdash;", "-" )
+                .Replace( "&#8212;", "-" )
+                .Replace( "_", "-" )
+                .Replace( " ", "-" );
+
+            slug = SlugStripPattern.Replace( slug, string.Empty );
+            slug = SlugCollapseDashPattern.Replace( slug, "-" );
+
+            return slug.Left( MaxSlugLength ).TrimEnd( '-' );
+        }
+
+        /// <summary>
+        /// True when the value could be a stored slug: 1-200 chars of lowercase
+        /// letters, digits, or dashes. Write paths pass <see cref="CanonicalizeSlug"/>
+        /// output; read paths pass <see cref="NormalizeSlug"/> output. Deliberately
+        /// looser than CanonicalizeSlug: Rock's own UI can store slugs containing "--"
+        /// or a leading dash, and those rows must still resolve.
         /// </summary>
         public static bool IsValidSlug( string slug )
         {
@@ -156,36 +202,31 @@ namespace org.secc.LinkList.Services
                 .Where( i => i.ContentChannel != null && i.ContentChannel.Guid == channelGuid );
         }
 
+        /// <summary>
+        /// The item's slug rows, primary first, then lowest Id. Falling back to the
+        /// lowest Id among unflagged rows preserves today's behavior, so lists that
+        /// predate the primary flag resolve exactly as before - no data migration.
+        /// Single definition of the order: everything slug-facing reads entry 0 as the
+        /// primary, so the ordering must not be restated anywhere else.
+        /// </summary>
+        private static IEnumerable<ContentChannelItemSlug> OrderedSlugs( ContentChannelItem item )
+        {
+            return ( item?.ContentChannelItemSlugs ?? Enumerable.Empty<ContentChannelItemSlug>() )
+                .OrderByDescending( s => s.IsPrimary )
+                .ThenBy( s => s.Id );
+        }
+
         private static string PrimarySlug( ContentChannelItem item )
         {
-            if ( item == null )
-            {
-                return null;
-            }
-            // Primary wins; among unflagged rows fall back to the lowest Id (today's
-            // behavior), so existing single-flag-less lists resolve exactly as before
-            // - no data migration needed.
-            return item.ContentChannelItemSlugs?
-                .OrderByDescending( s => s.IsPrimary )
-                .ThenBy( s => s.Id )
-                .Select( s => s.Slug )
-                .FirstOrDefault();
+            return OrderedSlugs( item ).Select( s => s.Slug ).FirstOrDefault();
         }
 
         /// <summary>
-        /// Every slug for the item (primary first, then lowest-Id), mapped to bags
-        /// for the editor. Same ordering as <see cref="PrimarySlug"/> so the first
-        /// entry is always the primary.
+        /// Every slug for the item, mapped to bags for the editor, primary first.
         /// </summary>
         private static List<LinkListSlugBag> BuildSlugBags( ContentChannelItem item )
         {
-            if ( item?.ContentChannelItemSlugs == null )
-            {
-                return new List<LinkListSlugBag>();
-            }
-            return item.ContentChannelItemSlugs
-                .OrderByDescending( s => s.IsPrimary )
-                .ThenBy( s => s.Id )
+            return OrderedSlugs( item )
                 .Select( s => new LinkListSlugBag
                 {
                     Id = s.Id,
@@ -239,39 +280,36 @@ namespace org.secc.LinkList.Services
 
             var query = ChannelItemQuery();
 
-            var asInt = idOrSlugOrGuid.AsIntegerOrNull();
-            if ( asInt.HasValue )
-            {
-                var byId = query.FirstOrDefault( i => i.Id == asInt.Value );
-                if ( byId != null )
-                {
-                    return byId;
-                }
-            }
-
+            // A guid is unambiguous, so it resolves first and costs nothing else.
             var asGuid = idOrSlugOrGuid.AsGuidOrNull();
             if ( asGuid.HasValue )
             {
-                var byGuid = query.FirstOrDefault( i => i.Guid == asGuid.Value );
-                if ( byGuid != null )
+                return query.FirstOrDefault( i => i.Guid == asGuid.Value );
+            }
+
+            // SLUG BEFORE ID. A slug may be all digits ("2024" is a legal slug) and it
+            // is the public contract - the URL people share - whereas resolving by Id is
+            // a convenience for internal callers. Trying the Id first let an item whose
+            // Id happened to equal a numeric slug silently hijack that slug's URL.
+            // Normalized to the canonical lowercase form (stored slugs are always
+            // lowercase); the caller owns charset validation, and the length cap here is
+            // defense in depth.
+            var slug = NormalizeSlug( idOrSlugOrGuid );
+            if ( slug.Length <= MaxSlugLength )
+            {
+                var bySlug = query
+                    .Where( i => i.ContentChannelItemSlugs.Any( s => s.Slug == slug ) )
+                    .FirstOrDefault();
+                if ( bySlug != null )
                 {
-                    return byGuid;
+                    return bySlug;
                 }
             }
 
-            // Slug lookup, normalized to the canonical lowercase form (stored
-            // slugs are always lowercase). Caller is responsible for
-            // slug-charset validation; we still hard-cap length here as a
-            // defense-in-depth measure.
-            var slug = NormalizeSlug( idOrSlugOrGuid );
-            if ( slug.Length > MaxSlugLength )
-            {
-                return null;
-            }
-
-            return query
-                .Where( i => i.ContentChannelItemSlugs.Any( s => s.Slug == slug ) )
-                .FirstOrDefault();
+            var asInt = idOrSlugOrGuid.AsIntegerOrNull();
+            return asInt.HasValue
+                ? query.FirstOrDefault( i => i.Id == asInt.Value )
+                : null;
         }
 
         // ---------------------------------------------------------------------
@@ -345,8 +383,9 @@ namespace org.secc.LinkList.Services
                     Id = item.Id,
                     Guid = item.Guid.ToString(),
                     Title = item.Title ?? "Untitled",
+                    // Scalar (primary) slug only - the grid shows one slug column, so
+                    // building a bag per slug row for every list would be wasted work.
                     Slug = PrimarySlug( item ),
-                    Slugs = BuildSlugBags( item ),
                     IsPublic = ReadIsPublic( item ),
                     DesignName = ResolveDesignName( item ),
                     ModifiedDateTime = item.ModifiedDateTime,
@@ -382,12 +421,16 @@ namespace org.secc.LinkList.Services
             return BuildBag( item, currentPerson, requirePublic );
         }
 
-        public LinkListBag BuildBag( ContentChannelItem item, Person currentPerson, bool requirePublic )
-        {
-            return BuildBag( item, currentPerson, requirePublic, includeMembers: false );
-        }
-
-        public LinkListBag BuildBag( ContentChannelItem item, Person currentPerson, bool requirePublic, bool includeMembers )
+        /// <summary>
+        /// Hydrates a bag for the given item. <paramref name="includeMembers"/> and
+        /// <paramref name="includeSlugs"/> add editor-only data and default to false,
+        /// because this same bag is serialized to ANONYMOUS callers by the public REST
+        /// controller: the full slug list would expose retired/alternate URLs and raw
+        /// row ids that no public consumer reads (the web component and viewer use only
+        /// the scalar <see cref="LinkListBag.Slug"/>).
+        /// </summary>
+        public LinkListBag BuildBag( ContentChannelItem item, Person currentPerson, bool requirePublic,
+            bool includeMembers = false, bool includeSlugs = false )
         {
             if ( item == null )
             {
@@ -415,7 +458,7 @@ namespace org.secc.LinkList.Services
                 Guid = item.Guid.ToString(),
                 Title = item.Title ?? "Untitled",
                 Slug = PrimarySlug( item ),
-                Slugs = BuildSlugBags( item ),
+                Slugs = includeSlugs ? BuildSlugBags( item ) : null,
                 IsPublic = isPublic,
                 ContentTextColor = item.GetAttributeValue( LinkListGuids.TypeAttributeKey.ContentTextColor ),
                 BackgroundColor = item.GetAttributeValue( LinkListGuids.TypeAttributeKey.BackgroundColor ),

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/SlugReconciler.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/SlugReconciler.cs
@@ -28,11 +28,14 @@ namespace org.secc.LinkList.Utility
         public string Slug { get; set; }
     }
 
-    /// <summary>A slug submitted by the editor: id (0 = new), text, and whether it's the chosen primary.</summary>
+    /// <summary>
+    /// A slug submitted by the editor: canonical text plus whether it's the chosen
+    /// primary. Deliberately carries no row id - reconciliation matches on slug text
+    /// (the natural key), so an id here would be decoration that later readers could
+    /// mistake for the thing being matched on.
+    /// </summary>
     public class SubmittedSlug
     {
-        public int Id { get; set; }
-
         public string Slug { get; set; }
 
         public bool IsPrimary { get; set; }
@@ -91,7 +94,12 @@ namespace org.secc.LinkList.Utility
         /// upsert-only submission (<see cref="SlugSubmission.FullReconcile"/> false)
         /// seeded from <paramref name="scalarSlug"/> so it can never delete other
         /// slugs. A non-null collection (even empty) yields a full reconcile. Every
-        /// slug is normalized (trim + lowercase) and blanks are dropped.
+        /// slug is canonicalized to the text Rock will store (see
+        /// <see cref="LinkListService.CanonicalizeSlug"/>), slugs left empty by that
+        /// are dropped, and slugs that canonicalize to the same text are merged -
+        /// keeping the first position and any primary flag.
+        /// An empty result set means "leave this list's slugs alone"; for a list with
+        /// no slug rows Rock's own save hook then mints one from the title.
         /// </summary>
         public static SlugSubmission BuildSubmission( IEnumerable<SubmittedSlug> providedSlugs, string scalarSlug )
         {
@@ -104,29 +112,39 @@ namespace org.secc.LinkList.Utility
                         .Where( s => s != null )
                         .Select( s => new SubmittedSlug
                         {
-                            Id = s.Id,
-                            Slug = LinkListService.NormalizeSlug( s.Slug ),
+                            Slug = LinkListService.CanonicalizeSlug( s.Slug ),
                             IsPrimary = s.IsPrimary
                         } )
                         .Where( s => !string.IsNullOrWhiteSpace( s.Slug ) )
+                        // Two entries the user typed differently ("Give_Now", "give now")
+                        // can canonicalize to the same text; merge them rather than
+                        // erroring on a duplicate the user never typed.
+                        .GroupBy( s => s.Slug, StringComparer.OrdinalIgnoreCase )
+                        .Select( g => new SubmittedSlug
+                        {
+                            Slug = g.Key,
+                            IsPrimary = g.Any( s => s.IsPrimary )
+                        } )
                         .ToList()
                 };
             }
 
             var submission = new SlugSubmission { FullReconcile = false };
-            var scalar = LinkListService.NormalizeSlug( scalarSlug );
+            var scalar = LinkListService.CanonicalizeSlug( scalarSlug );
             if ( !string.IsNullOrWhiteSpace( scalar ) )
             {
-                submission.Slugs.Add( new SubmittedSlug { Id = 0, Slug = scalar, IsPrimary = true } );
+                submission.Slugs.Add( new SubmittedSlug { Slug = scalar, IsPrimary = true } );
             }
             return submission;
         }
 
         /// <summary>
-        /// Validates the submitted set: every slug must be a valid canonical slug
+        /// Validates the submitted set: every slug must be a valid stored slug
         /// (via <see cref="LinkListService.IsValidSlug"/>) and the set must contain
         /// no duplicate slug texts. Returns null when valid, else an error naming
-        /// the offending slug. Callers pass NORMALIZED slug text.
+        /// the offending slug. Callers pass CANONICALIZED slug text, which
+        /// <see cref="BuildSubmission"/> also de-duplicates - so both failures here
+        /// are invariant backstops rather than expected user-facing errors.
         /// </summary>
         public static string ValidateSubmitted( IEnumerable<SubmittedSlug> submitted )
         {
@@ -142,7 +160,7 @@ namespace org.secc.LinkList.Utility
                 }
                 if ( !LinkListService.IsValidSlug( slug ) )
                 {
-                    return $"Slug '{slug}' must be 1-200 chars of lowercase letters, digits, or dashes.";
+                    return $"Slug '{slug}' must be 1-{LinkListService.MaxSlugLength} chars of lowercase letters, digits, or dashes.";
                 }
                 if ( !seen.Add( slug ) )
                 {
@@ -152,13 +170,51 @@ namespace org.secc.LinkList.Utility
             return null;
         }
 
+        /// <summary>The most slugs one list may carry. See <see cref="ValidateSubmissionSize"/>.</summary>
+        public const int MaxSlugsPerList = 50;
+
+        /// <summary>
+        /// Rejects an absurd number of slugs. Well above any real list (they exist to
+        /// preserve old URLs), and the point is the conflict check: it parameterizes one
+        /// value per slug, so an unbounded set would hit SQL Server's ~2100 parameter
+        /// limit and surface as an opaque failure instead of a clear message.
+        /// </summary>
+        public static string ValidateSubmissionSize( SlugSubmission submission )
+        {
+            var count = submission?.Slugs?.Count ?? 0;
+            return count > MaxSlugsPerList
+                ? $"A link list can have at most {MaxSlugsPerList} slugs; this one has {count}."
+                : null;
+        }
+
+        /// <summary>
+        /// A slug-aware client may submit an EMPTY set: Rock's ContentChannelItem save
+        /// hook then derives a slug from the title, exactly as Rock's own content channel
+        /// item block does, and the save leaves the resulting row alone. That only works
+        /// if the title yields a usable slug - when it doesn't, the list would be left
+        /// unreachable by the viewer, the public web component and REST (all of which
+        /// resolve a list only by slug), so it must be rejected before anything is
+        /// written. A legacy scalar-only client (<see cref="SlugSubmission.FullReconcile"/>
+        /// false) is not held to this: it can't manage slugs and never deletes.
+        /// </summary>
+        public static string ValidateSubmissionAgainstTitle( SlugSubmission submission, string title )
+        {
+            if ( submission == null || !submission.FullReconcile || submission.Slugs.Count > 0 )
+            {
+                return null;
+            }
+            return string.IsNullOrWhiteSpace( LinkListService.CanonicalizeSlug( title ) )
+                ? "A link list needs a slug, and this title has no letters or digits to build one from. Add a slug."
+                : null;
+        }
+
         /// <summary>
         /// Diffs <paramref name="submitted"/> against <paramref name="existing"/>.
         /// Validates first (see <see cref="ValidateSubmitted"/>); on failure returns
         /// a result with <see cref="SlugReconciliationResult.IsValid"/> = false.
-        /// The chosen primary is the submitted entry flagged primary; if none (or
-        /// several) are flagged, the first submitted slug wins so a list with any
-        /// slugs always has exactly one primary.
+        /// The chosen primary is the FIRST submitted entry flagged primary, or the
+        /// first submitted slug when none is flagged - so a list with any slugs
+        /// always has exactly one primary.
         /// </summary>
         public static SlugReconciliationResult Reconcile( IEnumerable<ExistingSlug> existing, IEnumerable<SubmittedSlug> submitted )
         {

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/SlugReconciler.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/SlugReconciler.cs
@@ -30,15 +30,25 @@ namespace org.secc.LinkList.Utility
 
     /// <summary>
     /// A slug submitted by the editor: canonical text plus whether it's the chosen
-    /// primary. Deliberately carries no row id - reconciliation matches on slug text
-    /// (the natural key), so an id here would be decoration that later readers could
-    /// mistake for the thing being matched on.
+    /// primary.
     /// </summary>
     public class SubmittedSlug
     {
         public string Slug { get; set; }
 
         public bool IsPrimary { get; set; }
+
+        /// <summary>
+        /// The slug row the CLIENT believes this text is stored as, or 0 when the user
+        /// typed it in this session.
+        /// <para>
+        /// NOT the match key. Reconciliation matches on slug text and nothing else; this
+        /// exists solely so <see cref="SlugReconciler.FilterConcurrentlyDeleted"/> can
+        /// tell "I still want this stored slug" apart from "this was on screen when I
+        /// loaded and I never touched it". Keep that method its only reader.
+        /// </para>
+        /// </summary>
+        public int ClientRowId { get; set; }
     }
 
     /// <summary>
@@ -54,6 +64,18 @@ namespace org.secc.LinkList.Utility
         public List<SubmittedSlug> Slugs { get; set; } = new List<SubmittedSlug>();
 
         public bool FullReconcile { get; set; }
+    }
+
+    /// <summary>
+    /// The outcome of <see cref="SlugReconciler.FilterConcurrentlyDeleted"/>: the slugs
+    /// the save should act on, and the texts it discarded because another editor deleted
+    /// them (reported to the user so a slug vanishing from their screen is explained).
+    /// </summary>
+    public class SlugFilterResult
+    {
+        public List<SubmittedSlug> Kept { get; set; } = new List<SubmittedSlug>();
+
+        public List<string> DroppedSlugs { get; set; } = new List<string>();
     }
 
     /// <summary>
@@ -114,7 +136,8 @@ namespace org.secc.LinkList.Utility
                         .Select( s => new SubmittedSlug
                         {
                             Slug = LinkListService.CanonicalizeSlug( s.Slug ),
-                            IsPrimary = s.IsPrimary
+                            IsPrimary = s.IsPrimary,
+                            ClientRowId = s.ClientRowId
                         } )
                         .Where( s => !string.IsNullOrWhiteSpace( s.Slug ) )
                         // Two entries the user typed differently ("Give_Now", "give now")
@@ -124,7 +147,14 @@ namespace org.secc.LinkList.Utility
                         .Select( g => new SubmittedSlug
                         {
                             Slug = g.Key,
-                            IsPrimary = g.Any( s => s.IsPrimary )
+                            IsPrimary = g.Any( s => s.IsPrimary ),
+                            // A typed entry (id 0) anywhere in the group makes the whole
+                            // group explicit: a user re-typing a slug that also exists as
+                            // a stored row must not inherit that row's id, or a concurrent
+                            // deletion of it would silently discard what they typed.
+                            ClientRowId = g.Any( s => s.ClientRowId == 0 )
+                                ? 0
+                                : g.Select( s => s.ClientRowId ).First()
                         } )
                         .ToList()
                 };
@@ -280,6 +310,57 @@ namespace org.secc.LinkList.Utility
         /// pre-ROCK-8987 editor bundle, or a hand-rolled API caller); those keep the
         /// plain full-reconcile behaviour.
         /// </summary>
+        /// <summary>
+        /// Drops submitted slugs that another editor deleted after this client loaded, so
+        /// saving a stale screen doesn't resurrect them.
+        /// <para>
+        /// The mirror image of <see cref="FilterDeletableIds"/>. Reconciliation matches on
+        /// text, so a submitted slug carries no evidence of whether the user wants it or
+        /// merely still has it on screen - <see cref="SubmittedSlug.ClientRowId"/> is that
+        /// evidence: an entry whose row the client named is gone from the list was deleted
+        /// by someone else, and re-adding it would undo an explicit deletion.
+        /// </para>
+        /// Kept regardless: entries with no row id (the user typed them this session, which
+        /// includes deliberately re-typing a slug someone else deleted), and entries whose
+        /// TEXT still exists under a different row id - a delete-and-recreate. That text
+        /// guard matters: dropping such an entry would make its live row look unsubmitted
+        /// to <see cref="Reconcile"/> and queue it for deletion.
+        /// A null <paramref name="currentRows"/> keeps everything, as in
+        /// <see cref="FilterDeletableIds"/>.
+        /// </summary>
+        public static SlugFilterResult FilterConcurrentlyDeleted(
+            IEnumerable<SubmittedSlug> submitted, IEnumerable<ExistingSlug> currentRows )
+        {
+            var submittedList = ( submitted ?? Enumerable.Empty<SubmittedSlug>() ).ToList();
+            if ( currentRows == null )
+            {
+                return new SlugFilterResult { Kept = submittedList };
+            }
+
+            var rows = currentRows.Where( r => r != null ).ToList();
+            var currentIds = new HashSet<int>( rows.Select( r => r.Id ) );
+            var currentTexts = new HashSet<string>(
+                rows.Select( r => r.Slug ).Where( s => !string.IsNullOrWhiteSpace( s ) ),
+                StringComparer.OrdinalIgnoreCase );
+
+            var result = new SlugFilterResult();
+            foreach ( var s in submittedList )
+            {
+                var keep = s.ClientRowId == 0
+                    || currentIds.Contains( s.ClientRowId )
+                    || currentTexts.Contains( s.Slug );
+                if ( keep )
+                {
+                    result.Kept.Add( s );
+                }
+                else
+                {
+                    result.DroppedSlugs.Add( s.Slug );
+                }
+            }
+            return result;
+        }
+
         public static List<int> FilterDeletableIds( IEnumerable<int> plannedIds, IEnumerable<int> loadedIds )
         {
             var planned = ( plannedIds ?? Enumerable.Empty<int>() ).ToList();

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/SlugReconciler.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/SlugReconciler.cs
@@ -98,8 +98,9 @@ namespace org.secc.LinkList.Utility
         /// <see cref="LinkListService.CanonicalizeSlug"/>), slugs left empty by that
         /// are dropped, and slugs that canonicalize to the same text are merged -
         /// keeping the first position and any primary flag.
-        /// An empty result set means "leave this list's slugs alone"; for a list with
-        /// no slug rows Rock's own save hook then mints one from the title.
+        /// An empty result set means "leave this list's slugs alone"; a list left with no
+        /// slug rows gets one derived from its title by the save (see LinkListDetailBlock
+        /// - Rock's own save hook does the same, but only when the item row changed).
         /// </summary>
         public static SlugSubmission BuildSubmission( IEnumerable<SubmittedSlug> providedSlugs, string scalarSlug )
         {
@@ -260,6 +261,34 @@ namespace org.secc.LinkList.Utility
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Narrows <paramref name="plannedIds"/> (from
+        /// <see cref="SlugReconciliationResult.SlugIdsToDelete"/>) to the rows the
+        /// editor actually had on screen when it loaded the list.
+        /// <para>
+        /// Reconciliation diffs by slug TEXT, so a row another editor added after this
+        /// one loaded looks exactly like a row this user deliberately removed - both are
+        /// simply "stored but not submitted". Comparing against the ids the client
+        /// loaded tells them apart: an id the client never saw cannot be something it
+        /// removed, so it is spared and the two edits merge instead of one clobbering
+        /// the other. Deliberate removal still works, because the loaded ids come from
+        /// the ORIGINAL load rather than the submitted set.
+        /// </para>
+        /// A null <paramref name="loadedIds"/> means the caller doesn't track them (a
+        /// pre-ROCK-8987 editor bundle, or a hand-rolled API caller); those keep the
+        /// plain full-reconcile behaviour.
+        /// </summary>
+        public static List<int> FilterDeletableIds( IEnumerable<int> plannedIds, IEnumerable<int> loadedIds )
+        {
+            var planned = ( plannedIds ?? Enumerable.Empty<int>() ).ToList();
+            if ( loadedIds == null )
+            {
+                return planned;
+            }
+            var loaded = new HashSet<int>( loadedIds );
+            return planned.Where( id => loaded.Contains( id ) ).ToList();
         }
     }
 }

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/SlugReconciler.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/Utility/SlugReconciler.cs
@@ -1,0 +1,209 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License should be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using org.secc.LinkList.Services;
+
+namespace org.secc.LinkList.Utility
+{
+    /// <summary>An existing ContentChannelItemSlug row (id + text) as read from the DB.</summary>
+    public class ExistingSlug
+    {
+        public int Id { get; set; }
+
+        public string Slug { get; set; }
+    }
+
+    /// <summary>A slug submitted by the editor: id (0 = new), text, and whether it's the chosen primary.</summary>
+    public class SubmittedSlug
+    {
+        public int Id { get; set; }
+
+        public string Slug { get; set; }
+
+        public bool IsPrimary { get; set; }
+    }
+
+    /// <summary>
+    /// The normalized slug set a save should apply, plus whether the client is
+    /// slug-aware. <see cref="FullReconcile"/> true = a slug-aware client sent its
+    /// complete set, so the save may DELETE slugs the client dropped. False = a
+    /// legacy client that only sent the scalar slug; the save upserts that one
+    /// slug and NEVER deletes, so an old cached editor bundle can't silently wipe
+    /// a list's other slugs.
+    /// </summary>
+    public class SlugSubmission
+    {
+        public List<SubmittedSlug> Slugs { get; set; } = new List<SubmittedSlug>();
+
+        public bool FullReconcile { get; set; }
+    }
+
+    /// <summary>
+    /// The computed slug reconciliation: which slug texts to add, which existing
+    /// rows to delete, and which slug should be primary. <see cref="IsValid"/> is
+    /// false (with <see cref="Error"/> set) when the submitted set is invalid.
+    /// </summary>
+    public class SlugReconciliationResult
+    {
+        public bool IsValid { get; set; } = true;
+
+        public string Error { get; set; }
+
+        /// <summary>Slug texts present in the submitted set but not in the existing rows.</summary>
+        public List<string> SlugsToAdd { get; set; } = new List<string>();
+
+        /// <summary>Ids of existing rows whose slug text is absent from the submitted set.</summary>
+        public List<int> SlugIdsToDelete { get; set; } = new List<int>();
+
+        /// <summary>The slug text that should carry IsPrimary, or null when the set is empty.</summary>
+        public string PrimarySlug { get; set; }
+    }
+
+    /// <summary>
+    /// Pure (no RockContext) diff between an item's current slug rows and the set
+    /// the editor submitted. The block does the actual DB add/delete/flag; keeping
+    /// the diff here makes it unit-testable. Matching is by canonical slug text
+    /// (the natural key - a slug is unique within a channel), so an existing slug
+    /// that stays in the submitted set is never deleted and re-added ("rename by
+    /// adding a new slug and keeping the old" preserves the old URL's row + id).
+    /// </summary>
+    public static class SlugReconciler
+    {
+        /// <summary>
+        /// Builds the slug set a save should apply from the raw editor payload.
+        /// <paramref name="providedSlugs"/> is null ONLY when the client omitted
+        /// the slugs collection (a legacy scalar-only client) - that yields an
+        /// upsert-only submission (<see cref="SlugSubmission.FullReconcile"/> false)
+        /// seeded from <paramref name="scalarSlug"/> so it can never delete other
+        /// slugs. A non-null collection (even empty) yields a full reconcile. Every
+        /// slug is normalized (trim + lowercase) and blanks are dropped.
+        /// </summary>
+        public static SlugSubmission BuildSubmission( IEnumerable<SubmittedSlug> providedSlugs, string scalarSlug )
+        {
+            if ( providedSlugs != null )
+            {
+                return new SlugSubmission
+                {
+                    FullReconcile = true,
+                    Slugs = providedSlugs
+                        .Where( s => s != null )
+                        .Select( s => new SubmittedSlug
+                        {
+                            Id = s.Id,
+                            Slug = LinkListService.NormalizeSlug( s.Slug ),
+                            IsPrimary = s.IsPrimary
+                        } )
+                        .Where( s => !string.IsNullOrWhiteSpace( s.Slug ) )
+                        .ToList()
+                };
+            }
+
+            var submission = new SlugSubmission { FullReconcile = false };
+            var scalar = LinkListService.NormalizeSlug( scalarSlug );
+            if ( !string.IsNullOrWhiteSpace( scalar ) )
+            {
+                submission.Slugs.Add( new SubmittedSlug { Id = 0, Slug = scalar, IsPrimary = true } );
+            }
+            return submission;
+        }
+
+        /// <summary>
+        /// Validates the submitted set: every slug must be a valid canonical slug
+        /// (via <see cref="LinkListService.IsValidSlug"/>) and the set must contain
+        /// no duplicate slug texts. Returns null when valid, else an error naming
+        /// the offending slug. Callers pass NORMALIZED slug text.
+        /// </summary>
+        public static string ValidateSubmitted( IEnumerable<SubmittedSlug> submitted )
+        {
+            var seen = new HashSet<string>( StringComparer.OrdinalIgnoreCase );
+            foreach ( var s in submitted ?? Enumerable.Empty<SubmittedSlug>() )
+            {
+                var slug = s?.Slug;
+                if ( string.IsNullOrWhiteSpace( slug ) )
+                {
+                    // Blank entries are dropped by the caller before reconciliation;
+                    // treat a blank that reaches here as a no-op skip.
+                    continue;
+                }
+                if ( !LinkListService.IsValidSlug( slug ) )
+                {
+                    return $"Slug '{slug}' must be 1-200 chars of lowercase letters, digits, or dashes.";
+                }
+                if ( !seen.Add( slug ) )
+                {
+                    return $"Duplicate slug '{slug}'. Each slug in a list must be unique.";
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Diffs <paramref name="submitted"/> against <paramref name="existing"/>.
+        /// Validates first (see <see cref="ValidateSubmitted"/>); on failure returns
+        /// a result with <see cref="SlugReconciliationResult.IsValid"/> = false.
+        /// The chosen primary is the submitted entry flagged primary; if none (or
+        /// several) are flagged, the first submitted slug wins so a list with any
+        /// slugs always has exactly one primary.
+        /// </summary>
+        public static SlugReconciliationResult Reconcile( IEnumerable<ExistingSlug> existing, IEnumerable<SubmittedSlug> submitted )
+        {
+            var submittedList = ( submitted ?? Enumerable.Empty<SubmittedSlug>() )
+                .Where( s => s != null && !string.IsNullOrWhiteSpace( s.Slug ) )
+                .ToList();
+
+            var validationError = ValidateSubmitted( submittedList );
+            if ( validationError != null )
+            {
+                return new SlugReconciliationResult { IsValid = false, Error = validationError };
+            }
+
+            var existingList = ( existing ?? Enumerable.Empty<ExistingSlug>() )
+                .Where( s => s != null && !string.IsNullOrWhiteSpace( s.Slug ) )
+                .ToList();
+
+            var submittedTexts = new HashSet<string>(
+                submittedList.Select( s => s.Slug ), StringComparer.OrdinalIgnoreCase );
+            var existingTexts = new HashSet<string>(
+                existingList.Select( s => s.Slug ), StringComparer.OrdinalIgnoreCase );
+
+            var result = new SlugReconciliationResult();
+
+            // Add: submitted texts not already stored.
+            result.SlugsToAdd = submittedList
+                .Select( s => s.Slug )
+                .Where( slug => !existingTexts.Contains( slug ) )
+                .Distinct( StringComparer.OrdinalIgnoreCase )
+                .ToList();
+
+            // Delete: existing rows whose text the editor dropped.
+            result.SlugIdsToDelete = existingList
+                .Where( s => !submittedTexts.Contains( s.Slug ) )
+                .Select( s => s.Id )
+                .ToList();
+
+            // Primary: the flagged submitted slug, else the first submitted slug.
+            if ( submittedList.Count > 0 )
+            {
+                var primary = submittedList.FirstOrDefault( s => s.IsPrimary ) ?? submittedList[0];
+                result.PrimarySlug = primary.Slug;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/ViewModels/LinkListBag.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/ViewModels/LinkListBag.cs
@@ -23,7 +23,31 @@ namespace org.secc.LinkList.ViewModels
 
         public int? Id { get; set; }
 
+        /// <summary>
+        /// The PRIMARY slug (computed, read-only for consumers). Kept for
+        /// back-compat: the web component's <c>secc-link-list-loaded</c> event
+        /// payload and the fallback title still read this scalar. The editor
+        /// edits <see cref="Slugs"/>; the save path recomputes this from the
+        /// primary row.
+        /// </summary>
         public string Slug { get; set; }
+
+        /// <summary>
+        /// All slugs for the list (primary + additional). The editor adds,
+        /// removes, and designates the primary here; the save path reconciles
+        /// this set against the item's ContentChannelItemSlug rows. Every entry
+        /// resolves to the list, so keeping an old slug preserves old URLs.
+        /// <para>
+        /// NOTE: intentionally NOT initialized. On the save (deserialization)
+        /// path, null means "the client omitted this collection" - a legacy
+        /// scalar-only client (e.g. a browser holding the pre-multi-slug editor
+        /// bundle) - which the block treats as an upsert-only update that never
+        /// deletes other slugs. A non-null value (even empty) means a slug-aware
+        /// client sent its full set, so the block does a delete-capable reconcile.
+        /// The read path (BuildBag / QueryListSummaries) always assigns it.
+        /// </para>
+        /// </summary>
+        public List<LinkListSlugBag> Slugs { get; set; }
 
         public string Title { get; set; }
 

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/ViewModels/LinkListBag.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/ViewModels/LinkListBag.cs
@@ -60,10 +60,21 @@ namespace org.secc.LinkList.ViewModels
         public string DesignName { get; set; }
 
         /// <summary>
-        /// Last modified timestamp of the underlying ContentChannelItem
-        /// (for the management grid's "Modified" column).
+        /// Last modified timestamp of the underlying ContentChannelItem. Drives the
+        /// management grid's "Modified" column AND the save's optimistic-concurrency
+        /// check: a save whose value no longer matches the stored one is rejected, so
+        /// a stale editor can't revert - or delete the slugs of - someone else's edit.
         /// </summary>
         public System.DateTime? ModifiedDateTime { get; set; }
+
+        /// <summary>
+        /// Set when a save PARTIALLY succeeded: the list itself is stored but a
+        /// follow-on step (link rows, edit-access group) failed. The response still
+        /// carries the saved bag so the editor keeps the list's identity and can retry
+        /// as an update - without this, a retry would look like a brand new list and be
+        /// rejected for conflicting with the slugs it just created. Null on a clean save.
+        /// </summary>
+        public string SaveWarning { get; set; }
 
         /// <summary>
         /// True when the current person may delete this list (ADMINISTRATE on

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/ViewModels/LinkListBag.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/ViewModels/LinkListBag.cs
@@ -77,6 +77,14 @@ namespace org.secc.LinkList.ViewModels
         public string SaveWarning { get; set; }
 
         /// <summary>
+        /// Set when a save fully SUCCEEDED but merged a concurrent edit - a slug another
+        /// editor added that this save kept, or one they deleted that it did not restore.
+        /// Purely informational: unlike <see cref="SaveWarning"/> nothing needs redoing,
+        /// so the editor reports it without treating the save as incomplete.
+        /// </summary>
+        public string SaveNotice { get; set; }
+
+        /// <summary>
         /// True when the current person may delete this list (ADMINISTRATE on
         /// the item - the same check the Delete block action enforces).
         /// Populated only for the management grid; false elsewhere.

--- a/Plugins/org.secc.LinkList/org.secc.LinkList/ViewModels/LinkListSlugBag.cs
+++ b/Plugins/org.secc.LinkList/org.secc.LinkList/ViewModels/LinkListSlugBag.cs
@@ -1,0 +1,34 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the  Southeast Christian Church License (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License should be included with this file.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+namespace org.secc.LinkList.ViewModels
+{
+    /// <summary>
+    /// One slug for a Link List (a ContentChannelItemSlug row). A list may have
+    /// several: the primary is what shared/printed links use, and every slug
+    /// (primary or additional) resolves to the same list so renaming never
+    /// orphans an old URL. Mirrors the editor's per-slug add/remove/primary UI.
+    /// </summary>
+    public class LinkListSlugBag
+    {
+        /// <summary>ContentChannelItemSlug.Id, or 0 for a slug the editor just added.</summary>
+        public int Id { get; set; }
+
+        /// <summary>The slug text (canonical lowercase form; callers normalize).</summary>
+        public string Slug { get; set; }
+
+        /// <summary>True for the single primary slug (used by the grid, viewer, and web-component payload).</summary>
+        public bool IsPrimary { get; set; }
+    }
+}


### PR DESCRIPTION
LinkList's read path already resolves a list by any of its slugs, but the editor could only hold one — renaming orphaned every shared/printed URL. This brings the editor/save path to parity with native content channel items.

- Bag gains a `Slugs` collection (each: id/slug/isPrimary); scalar `Slug` kept as the computed primary for back-compat (web-component event payload, fallback title).
- Save path reconciles the submitted slug set against `ContentChannelItemSlugs`: adds new, deletes removed, sets the `IsPrimary` flag. Reconciliation diff extracted to a pure, unit-tested helper (`SlugReconciler`). No `WrapTransaction` (preserves the existing deadlock-avoidance).
- An omitted `slugs` collection (legacy scalar-only client, e.g. a cached pre-deploy editor bundle) is upsert-only and **never deletes**; an explicitly provided set does a full reconcile. Verified against Rock 16.12's `BlockActionsController` deserialization (omitted key → null, no collection auto-instantiation).
- Every slug normalized/validated by the existing single-source rules; duplicate slugs (within the set and across the channel) rejected with a clear, named error — Rock's `SaveSlug` silently suffixes collisions, so uniqueness is pre-validated, not caught. A slug-aware save requires at least one slug; the editor guards removing the last one.
- `PrimarySlug` now orders `IsPrimary DESC, Id ASC`; legacy no-flag lists keep today's lowest-Id behavior — no data migration.
- Obsidian editor gets a multi-slug control (list/add/remove/set-primary) with client-side charset validation. Grid + web component keep showing the primary slug.

Tests: extended `SlugValidationTests`, new `SlugReconciliationTests` (add/remove/change-primary/no-op/rename/dup/empty/fallback/case-insensitive). xUnit 255 passed / 0 failed; Obsidian typecheck/build + 94 jest passed.

Verification trail on the JIRA ticket (two verifier rounds; both round-1 majors resolved). Before deploy: check prod for existing zero-slug lists (see ticket comment) and smoke-test add/set-primary/rename-by-add in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)