### PR TITLE
Rebuild the checkin cache key list when its cache entry is evicted

### DIFF
--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
@@ -21,6 +21,7 @@ namespace org.secc.FamilyCheckin.Cache
         // Throttle key refreshes to avoid excessive DB calls
         private static readonly object KeysUpdateLock = new object();
         private static DateTime _lastKeysRefreshUtc = DateTime.MinValue;
+        private static bool _lastKeysRefreshWasEmpty;
         private static readonly TimeSpan KeysRefreshInterval = TimeSpan.FromSeconds( 10 );
 
         public void PostCached()
@@ -125,7 +126,9 @@ namespace org.secc.FamilyCheckin.Cache
 
         public static void Clear( Func<List<string>> keyFactory )
         {
-            UpdateKeys( keyFactory );
+            // Force the rebuild: a throttled refresh here would flush against a stale -- or empty --
+            // key list and silently leave cached items behind.
+            UpdateKeys( keyFactory, forceRefresh: true );
 
             // Create a copy of the keys to avoid collection modification during enumeration
             foreach ( var key in AllKeys().ToList() )
@@ -169,18 +172,29 @@ namespace org.secc.FamilyCheckin.Cache
             return keys ?? new List<string>();
         }
 
-        private static List<string> UpdateKeys( Func<List<string>> keyFactory, string ensureKey = null, string removeKey = null )
+        private static List<string> UpdateKeys( Func<List<string>> keyFactory, string ensureKey = null, string removeKey = null, bool forceRefresh = false )
         {
             lock ( KeysUpdateLock )
             {
                 var now = DateTime.UtcNow;
                 var currentKeys = AllKeys();
 
-                // If within the throttle window, serve the cached key list (applying ensure/remove below).
-                // An empty list can be a valid answer (e.g. overnight, before the day's first check-in) and must
-                // still be throttled; otherwise every caller re-runs keyFactory(), which may be an expensive DB query
-                // (e.g., Attendance keyFactory can trigger a full Attendance scan that returns zero rows).
-                if ( ( now - _lastKeysRefreshUtc ) < KeysRefreshInterval )
+                // AllKeys() returns an empty list for two very different situations and cannot tell them
+                // apart: keyFactory() legitimately having nothing to return (overnight, before the day's
+                // first check-in), and the RockCache entry having been evicted. The throttle timestamp is
+                // a process-local field, so it outlives the cache entry it guards -- which means an
+                // evicted entry would otherwise be served as "empty" for the rest of the throttle window,
+                // handing every caller zero keys and blanking the check-in monitor until the window rolls.
+                //
+                // Tracking whether the last rebuild itself came back empty separates the two: an empty
+                // cache read that contradicts a non-empty rebuild means the entry went away, so rebuild
+                // now. A genuinely empty result stays throttled, which is what keeps keyFactory() -- a
+                // full scan of Attendance in the AttendanceCache case -- from running on every call.
+                var cacheEntryLooksEvicted = !currentKeys.Any() && !_lastKeysRefreshWasEmpty;
+
+                if ( !forceRefresh
+                    && !cacheEntryLooksEvicted
+                    && ( now - _lastKeysRefreshUtc ) < KeysRefreshInterval )
                 {
                     bool modified = false;
 
@@ -208,7 +222,11 @@ namespace org.secc.FamilyCheckin.Cache
 
                 var keys = keyFactory().Select( k => QualifiedKey( k ) ).ToList();
 
-                // Apply ensureKey/removeKey operations to refreshed keys                
+                // Record what the factory produced, before ensure/remove adjustments, so the next
+                // empty cache read can be classified as "still nothing" or "entry evicted".
+                _lastKeysRefreshWasEmpty = !keys.Any();
+
+                // Apply ensureKey/removeKey operations to refreshed keys
                 if ( !string.IsNullOrEmpty( ensureKey ) && !keys.Contains( ensureKey ) )
                 {
                     keys.Add( ensureKey );

--- a/Plugins/org.secc.FamilyCheckin/README.md
+++ b/Plugins/org.secc.FamilyCheckin/README.md
@@ -138,10 +138,24 @@ round trip. Each subclass supplies a `keyFactory` that rebuilds that list from t
 per cache type, per web-farm node — **including when the cached list is empty**. An empty list is a
 valid state (overnight, before the day's first check-in), and refreshing on every call re-ran
 `keyFactory()` every time; for `AttendanceCache` that is a full `dbo.Attendance` scan returning zero
-rows. Tradeoff: after a cache clear or flush during active check-in, `AllKeys`-derived views
-(attendance / occupancy) can read empty for up to 10 seconds before self-healing. Accepted — the
-`ensureKey` / `removeKey` paths still apply inside the throttle window, so individual check-ins are
-not lost.
+rows.
+
+**Eviction is not emptiness.** The key list lives in `RockCache` and can be evicted at any time; the
+throttle timestamp is a process-local `static` and cannot be. `AllKeys()` returns an empty list for
+both cases and cannot distinguish them, so throttling a post-eviction read serves **zero keys** for
+the remainder of the window. PR #281 documented that as a self-healing 10-second gap in
+attendance/occupancy views and accepted it. In practice it was worse than that reads: room setup
+toggles clear caches on every room (`CheckinKioskTypeCache.ClearForTemplateId` plus
+`KioskDeviceHelpers.Clear` per `ToggleLocation`), so with several campuses setting up at once the
+Check-in Monitor's own room and service-time list intermittently rendered empty and only came back
+on repeated refreshes.
+
+`UpdateKeys` therefore also tracks whether the **last rebuild itself** returned empty. An empty cache
+read that contradicts a non-empty rebuild means the entry was evicted, and rebuilds immediately; a
+genuinely empty result stays throttled, preserving the `keyFactory()` savings. `Clear` passes
+`forceRefresh: true`, since a throttled refresh there would flush against a stale or empty key list
+and leave cached items behind. The `ensureKey` / `removeKey` paths still apply inside the throttle
+window, so individual check-ins are never lost.
 
 ## Dependencies & Integrations
 


### PR DESCRIPTION
## The bug

PR #281 removed the `currentKeys.Any()` term from the `UpdateKeys` throttle, so a legitimately empty key list would be throttled too — re-running `keyFactory()` on every call is a full scan of `dbo.Attendance` for `AttendanceCache`. That reasoning was correct, but the term was doing a **second** job.

The key list lives in `RockCache` and can be evicted at any time. `_lastKeysRefreshUtc` is a process-local `static` and cannot. `AllKeys()` returns an empty list for both cases and cannot distinguish them:

```csharp
var keys = RockCache.Get( AllKey, AllRegion ) as List<string>;
return keys ?? new List<string>();          // evicted → EMPTY
```

With the term gone, an evicted entry is served as empty for the rest of the throttle window, and every caller gets **zero keys** until it rolls.

`AllKeys( keyFactory )` — the entry point `OccurrenceCache.All()` and `AttendanceCache.All()` use — only calls `UpdateKeys` when the list is empty, which is precisely the case that now refuses to rebuild:

```csharp
var keys = AllKeys();
if ( !keys.Any() )
    keys = UpdateKeys( keyFactory );   // throttled → returns the empty list
return keys;
```

## How it showed up

Check-in Monitor rendering no rooms and no service times during room setup, recovering only after repeated refreshes. `ToggleLocation` clears `CheckinKioskTypeCache` and `KioskDeviceHelpers` on **every room toggle**, so several campuses setting up simultaneously evict the entry every couple of minutes across all six web nodes, while the monitor re-renders on a 10-second loop.

Observed 2026-08-13: 32 room closures between 14:49 and 16:05 across Crestwood, Shelby County, La Grange, and Indiana — all for that evening's Thu 6:45 PM services.

## Why review didn't catch it

It was actually raised. PR #281's README note anticipated *"a self-healing 10-second gap in `AllKeys`-derived views (attendance / occupancy)"* and accepted it. The miss was in scope, not awareness: the gap also covers the Monitor's **own room list** — the screen staff are actively clicking — where a 10-second blank does not read as self-healing. The measured verification (150 → 5.2 rebuilds/min on RockDev) confirmed the throttle throttles; it never exercised eviction, which is what the removed term handled.

## The change

`UpdateKeys` now also records whether the **last rebuild itself** came back empty:

```csharp
var cacheEntryLooksEvicted = !currentKeys.Any() && !_lastKeysRefreshWasEmpty;

if ( !forceRefresh
    && !cacheEntryLooksEvicted
    && ( now - _lastKeysRefreshUtc ) < KeysRefreshInterval )
```

- Empty cache read that **contradicts** a non-empty rebuild → entry was evicted → rebuild now.
- Empty cache read that **agrees** with an empty rebuild → genuinely nothing → stay throttled, keeping PR #281's savings.
- `Clear()` passes `forceRefresh: true`; a throttled refresh there flushes against a stale or empty key list and silently leaves cached items behind. That was a second, separate defect.

Behaviour walkthrough:

| Situation | Before #281 | After #281 | This PR |
|---|---|---|---|
| Overnight, genuinely empty | rebuild every call (CPU burn) | throttled | throttled |
| Entry evicted mid-service | rebuild immediately | **empty for ≤10s** | rebuild immediately |
| `Clear()` within 10s of a rebuild | full flush | **partial flush** | full flush |

## Testing

**Not compiled** — no .NET toolchain in the authoring environment. Needs a real build before merge. All `UpdateKeys` call sites still bind against the added optional parameter (`UpdateKeys(keyFactory)`, `ensureKey:`, `removeKey:`, `forceRefresh:`).

Worth verifying on RockDev:
1. Overnight/empty path still throttles — rebuild rate should stay near 6/min, not 150/min.
2. Clear the cache during active check-in, then hit the Monitor immediately — rooms and service times should be present on the first request, not after 10 seconds.
3. `Clear()` during active check-in flushes every item.

## Notes

Supersedes rolling PR #281 back: this keeps the CPU fix and removes the blackout. Docs updated in `Plugins/org.secc.FamilyCheckin/README.md`.