### PR TITLE
Revert PR #281 (checkin cache key-list throttle) ahead of v16 launch

### DIFF
--- a/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
+++ b/Plugins/org.secc.FamilyCheckin/Cache/CheckinCache.cs
@@ -176,11 +176,8 @@ namespace org.secc.FamilyCheckin.Cache
                 var now = DateTime.UtcNow;
                 var currentKeys = AllKeys();
 
-                // If within the throttle window, serve the cached key list (applying ensure/remove below).
-                // An empty list can be a valid answer (e.g. overnight, before the day's first check-in) and must
-                // still be throttled; otherwise every caller re-runs keyFactory(), which may be an expensive DB query
-                // (e.g., Attendance keyFactory can trigger a full Attendance scan that returns zero rows).
-                if ( ( now - _lastKeysRefreshUtc ) < KeysRefreshInterval )
+                // If within throttle window and we have existing keys
+                if ( currentKeys.Any() && ( now - _lastKeysRefreshUtc ) < KeysRefreshInterval )
                 {
                     bool modified = false;
 

--- a/Plugins/org.secc.FamilyCheckin/README.md
+++ b/Plugins/org.secc.FamilyCheckin/README.md
@@ -126,23 +126,6 @@ Quartz `IJob`s (both `[DisallowConcurrentExecution]`); scheduled in Rock, not se
 |------------|---------|
 | `CheckinGroupFieldType` | Picks a single or (configurably) multiple check-in groups; stores `Group.Guid`. Backed by `CheckinGroupPicker` and `CheckinGroupFieldAttribute`. |
 
-### Caching
-
-`CheckinCache<T>` — subclassed by `AttendanceCache`, `OccurrenceCache`, and
-`MobileCheckinRecordCache` — keeps a per-type **key list** in `RockCache` (region `AllItems`, key
-`{TypeName}:All`) next to the cached entities, so `All()` / `AllKeys()` can enumerate without a DB
-round trip. Each subclass supplies a `keyFactory` that rebuilds that list from the database.
-`CheckinKioskTypeCache` is **not** part of this layer — it uses Rock's own `ModelCache`.
-
-**Key-list refresh throttling (PR #281):** key-list refreshes are throttled to once per 10 seconds,
-per cache type, per web-farm node — **including when the cached list is empty**. An empty list is a
-valid state (overnight, before the day's first check-in), and refreshing on every call re-ran
-`keyFactory()` every time; for `AttendanceCache` that is a full `dbo.Attendance` scan returning zero
-rows. Tradeoff: after a cache clear or flush during active check-in, `AllKeys`-derived views
-(attendance / occupancy) can read empty for up to 10 seconds before self-healing. Accepted — the
-`ensureKey` / `removeKey` paths still apply inside the throttle window, so individual check-ins are
-not lost.
-
 ## Dependencies & Integrations
 
 - **Rock:** check-in engine (`CheckInState`, `CheckInActionComponent`), workflow engine,


### PR DESCRIPTION
Reverts #281. `CheckinCache.cs` is byte-identical to its pre-#281 state; the README section #281 added goes with it.

**Bug:** #281 dropped `currentKeys.Any()` from the throttle guard. That clause was also the only path that recovered from an *evicted* key list. `ToggleLocation` publishes a cache message, `CheckinCacheConsumer` removes `OccurrenceCache:All` on every node, but `_lastKeysRefreshUtc` is a process-local `static` and survives it — so the next request reads empty, the throttle serves empty without rebuilding, and rooms and service times vanish from the check-in monitor. Reported by Kids staff during room setup.

**Tradeoff:** reinstates the overnight `dbo.Attendance` scan #281 fixed. Covered for now by a future-dated sentinel row (`ForeignKey = 'ROCKSTOPGAP'`, already on prod) that keeps the key list non-empty so the throttle engages. It is `CheckedOut` with NULL group/location/schedule, so every `All()` consumer filters it out.

**Why now:** stable 13 for next week's v16 launch — restores previously-shipped code rather than shipping a new fix under time pressure.

**Next:** #286 is the real fix (distinguishes an evicted entry from a legitimately empty result), held unmerged until it can be tested. Remove the sentinel when it lands.