### PR TITLE
ROCK-9055 Merge URL partition values into RoleRequests attributes on signup

### DIFF
--- a/Plugins/org.secc.Connection/README.md
+++ b/Plugins/org.secc.Connection/README.md
@@ -71,6 +71,25 @@ Category in Rock: **SECC > Connection**.
 | Display Add Another | bool (default false) | Show "Connect and Add Another". |
 | Comment label text / Comments Required | text / bool | Comment box label and requirement. |
 
+#### How `UrlKeys` values reach a connection request
+
+Every key listed in **UrlKeys** is read off the query string / route and merged into each entry of
+the `RoleRequests` collection before the form binds. Two details matter:
+
+- **The merge always runs.** It is not limited to links that omit a `RoleRequests` JSON. A
+  `CardWizard` in `Multiple` mode sends a JSON whose `Attributes` dictionary holds only the *final*
+  partition's value, while earlier partitions (a leading DefinedType, say) arrive as plain URL
+  parameters — so both sources have to be combined or the earlier partition values never reach
+  `ConnectionRequest.AssignedGroupMemberAttributeValues`, and the wizard's remaining-spots count
+  never sees them (ROCK-9055).
+- **A non-empty JSON value wins.** The URL is consulted only where the JSON has no value for that
+  key, or has one that is blank/whitespace. Key matching is case-insensitive, matching how
+  `PageParameter` resolves route and query keys, so a camel-cased JSON key still takes precedence
+  over the same key spelled differently in the block setting.
+
+A key must also exist as an attribute on the target group member, and hold a non-empty value, to be
+applied — see `AddGroupMemberAttributes` in `VolunteerSignupFormConnections.ascx.cs`.
+
 **Connection Opportunity Search** — `Lava Template`, `Enable Debug`, `Enable Campus Context`,
 `Set Page Title`, `Display Name/Campus/Attribute Filters`, `Detail Page` (linked page),
 `Connection Type Id` (integer).
@@ -105,13 +124,17 @@ per-partition-type partials (`CardCampus`, `CardDefinedType`, `CardRole`, `CardS
 
 - **Security (medium):** *Volunteer Signup Form - Connections* is a public-facing block that, on
   submit, will **create a new `Person` and a `ConnectionRequest`** when no match is found
-  (`PersonService.SaveNewPerson` at `VolunteerSignupFormConnections.ascx.cs:321`). Person matching
+  (`PersonService.SaveNewPerson` at `VolunteerSignupFormConnections.ascx.cs:405`). Person matching
   uses name + email/birthdate, so unauthenticated form posts can both enumerate-by-side-effect and
   add records. Confirm the page is intended for anonymous use, and consider spam/rate protection
   (e.g. CAPTCHA) — worth confirming.
 - **Security (low):** The form sets group-member attributes from URL parameters via the `UrlKeys`
   setting (`PageParameter(urlKey)`). Only keys the admin lists are honored, but those values are
-  attacker-controllable in the link; review which attributes are exposed this way.
+  attacker-controllable in the link; review which attributes are exposed this way. Note this applies
+  to `CardWizard` JSON signups too, not only to plain-URL links — the merge described under
+  [How `UrlKeys` values reach a connection request](#how-urlkeys-values-reach-a-connection-request)
+  runs on every request. The JSON in the same link is equally attacker-editable, so this widens no
+  trust boundary, but it does mean a listed key can be supplied on any signup URL.
 - **Improvement:** Several services are constructed with their own `new RockContext()` inline
   (e.g. `GroupTypeRoleService`, `ScheduleService`, `DefinedTypeService`) rather than reusing one
   per request, so a single render/bind can spin up multiple contexts. Acceptable, but tidy-able.
@@ -130,3 +153,7 @@ per-partition-type partials (`CardCampus`, `CardDefinedType`, `CardRole`, `CardS
   plugin only calls into it reflectively.
 - Re-package with `BuildPlugin.ps1` (Windows + 7-Zip) — note it intentionally excludes
   `ConnectionOpportunitySearch.ascx*` from the `.plugin`.
+- If a URL-supplied attribute value isn't landing on the connection request, check the merge in the
+  `RoleRequests` getter and the apply step in `AddGroupMemberAttributes` — a key has to survive both.
+
+Last updated: 2026-08-21

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -101,16 +101,21 @@ namespace org.secc.Connection
                     }
                     foreach ( var roleRequest in _roleRequests )
                     {
+                        // The CardWizard template passes a RoleRequests JSON whose Attributes dictionary
+                        // only contains the final partition's value; earlier partitions (e.g. a leading
+                        // DefinedType) arrive as plain URL parameters. Merge URL keys into the dictionary
+                        // rather than only parsing them when it is null, or those earlier partition values
+                        // never reach the connection request. JSON-provided values keep priority.
                         if ( roleRequest.Attributes == null )
                         {
                             roleRequest.Attributes = new Dictionary<string, string>();
-                            var urlKeys = GetAttributeValues( "UrlKeys" );
-                            foreach ( string urlKey in urlKeys )
+                        }
+                        var urlKeys = GetAttributeValues( "UrlKeys" );
+                        foreach ( string urlKey in urlKeys )
+                        {
+                            if ( !roleRequest.Attributes.ContainsKey( urlKey ) && !string.IsNullOrEmpty( PageParameter( urlKey ) ) )
                             {
-                                if ( !string.IsNullOrEmpty( PageParameter( urlKey ) ) )
-                                {
-                                    roleRequest.Attributes.Add( urlKey, PageParameter( urlKey ) );
-                                }
+                                roleRequest.Attributes.Add( urlKey, PageParameter( urlKey ) );
                             }
                         }
                     }

--- a/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
+++ b/Plugins/org.secc.Connection/org_secc/Connection/VolunteerSignupFormConnections.ascx.cs
@@ -77,6 +77,24 @@ namespace org.secc.Connection
         DefinedValueCache _homePhone = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_HOME );
         DefinedValueCache _cellPhone = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_PHONE_TYPE_MOBILE );
 
+        private List<string> _urlKeys = null;
+        /// <summary>
+        /// The configured "Group Member Attribute Keys - URL" keys. De-duplicated case-insensitively:
+        /// GetAttributeValues does not de-dupe, so a "Key,Key" entry would otherwise be applied twice
+        /// and throw on the ViewState dictionary Add in AddGroupMemberAttributes.
+        /// </summary>
+        private List<string> UrlKeys
+        {
+            get
+            {
+                if ( _urlKeys == null )
+                {
+                    _urlKeys = GetAttributeValues( "UrlKeys" ).Distinct( StringComparer.OrdinalIgnoreCase ).ToList();
+                }
+                return _urlKeys;
+            }
+        }
+
         private List<ConnectionRoleRequest> _roleRequests = null;
         List<ConnectionRoleRequest> RoleRequests
         {
@@ -105,17 +123,40 @@ namespace org.secc.Connection
                         // only contains the final partition's value; earlier partitions (e.g. a leading
                         // DefinedType) arrive as plain URL parameters. Merge URL keys into the dictionary
                         // rather than only parsing them when it is null, or those earlier partition values
-                        // never reach the connection request. JSON-provided values keep priority.
-                        if ( roleRequest.Attributes == null )
+                        // never reach the connection request. A non-empty JSON value keeps priority.
+                        //
+                        // Rebuilt case-insensitively to match PageParameter, which resolves route and
+                        // query keys case-insensitively; in an ordinal dictionary a casing difference
+                        // between the JSON key and the configured setting adds a second entry and hands
+                        // the URL value priority over the volunteer's actual selection. Copied by hand
+                        // rather than through the case-insensitive copy constructor, which throws when
+                        // the caller-supplied JSON holds two keys differing only in case.
+                        var attributes = new Dictionary<string, string>( StringComparer.OrdinalIgnoreCase );
+                        if ( roleRequest.Attributes != null )
                         {
-                            roleRequest.Attributes = new Dictionary<string, string>();
-                        }
-                        var urlKeys = GetAttributeValues( "UrlKeys" );
-                        foreach ( string urlKey in urlKeys )
-                        {
-                            if ( !roleRequest.Attributes.ContainsKey( urlKey ) && !string.IsNullOrEmpty( PageParameter( urlKey ) ) )
+                            foreach ( var attribute in roleRequest.Attributes )
                             {
-                                roleRequest.Attributes.Add( urlKey, PageParameter( urlKey ) );
+                                attributes[attribute.Key] = attribute.Value;
+                            }
+                        }
+                        roleRequest.Attributes = attributes;
+
+                        foreach ( string urlKey in UrlKeys )
+                        {
+                            string jsonValue;
+                            attributes.TryGetValue( urlKey, out jsonValue );
+
+                            // A present-but-blank JSON value is not a selection - AddGroupMemberAttributes
+                            // discards it - so treat it as absent and let the URL supply the value.
+                            if ( !string.IsNullOrWhiteSpace( jsonValue ) )
+                            {
+                                continue;
+                            }
+
+                            var urlValue = PageParameter( urlKey );
+                            if ( !string.IsNullOrWhiteSpace( urlValue ) )
+                            {
+                                attributes[urlKey] = urlValue;
                             }
                         }
                     }
@@ -913,12 +954,7 @@ namespace org.secc.Connection
                     {
                         // Group Attributes
                         var formKeys = GetAttributeValues( "FormKeys" );
-                        var urlKeys = GetAttributeValues( "UrlKeys" );
-
-                        AttributeService attributeService = new AttributeService( rockContext );
-
-                        string groupQualifierValue = group.Id.ToString();
-                        string groupTypeQualifierValue = group.GroupTypeId.ToString();
+                        var urlKeys = UrlKeys;
 
                         // Make a fake group member so we can load some attributes.
                         GroupMember groupMember = new GroupMember();
@@ -938,7 +974,7 @@ namespace org.secc.Connection
                         }
                         viewStateAttributes.Add( viewStateAttribute );
 
-                        Helper.AddDisplayControls( groupMember, phAttributes, groupMember.Attributes.Where( a => !urlKeys.Contains( a.Key ) ).Select( a => a.Key ).ToList(), true, false );
+                        Helper.AddDisplayControls( groupMember, phAttributes, groupMember.Attributes.Where( a => !urlKeys.Contains( a.Key, StringComparer.OrdinalIgnoreCase ) ).Select( a => a.Key ).ToList(), true, false );
                         // ROCK-8710: render the editable Form-key controls below the Waiver Text (phFormAttributes lives outside the repeater, after lWaiverText) instead of inline with the per-role display controls in phAttributes.
                         // ROCK-8710: phFormAttributes is a single shared placeholder, so only render the Form-key edit controls for the first role. Multi-role Form-key support would require a per-role placeholder inside the repeater item (with the waiver moved in) — tracked as a follow-up. For single-role opportunities (the current food-pack use) this is a no-op guard.
                         if ( RepeaterIndex == 0 )


### PR DESCRIPTION
## Summary
The Volunteer Signup Wizard countdown never decremented on signup for the BB Christmas Event wizard (Jira ROCK-9055 / Freshservice INC-15092), while Food Pack and Shine Fall Fest counted correctly.

**Root cause:** CardWizard template in `Multiple` mode builds a `RoleRequests` JSON page parameter whose `Attributes` dictionary contains only the **last** partition's value (ShiftTime). Earlier partitions (the leading DefinedType `VolunteerCategories`) still arrive as plain URL parameters — but `VolunteerSignupFormConnections` only parsed the configured URL keys when `roleRequest.Attributes == null`. The JSON made it non-null, so the earlier partition values were silently dropped, `AssignedGroupMemberAttributeValues` was written without them, and the wizard's count filter (guid substring match) matched nothing. Completing the connection writes group member attributes through Rock core, which is why spots only disappeared at completion.

Food Pack works because its wizard uses `CardWizardMode = "Single"`, which renders plain links all the way through (no RoleRequests JSON). Latent bug for any Multiple-mode wizard with a DefinedType/Schedule partition before the last one; Campus/Role partitions are unaffected (counted by `CampusId` / `AssignedGroupMemberRoleId`).

## Change
In the `RoleRequests` getter, always merge the configured "Group Member Attribute Keys - URL" values into the attributes dictionary instead of only parsing them when the dictionary is null. JSON-provided values keep priority.

Backward compatible: pure-URL signups (Single mode, Genius, CardPage) produce the same result as before; Multiple mode now carries all partition values.

## Testing
- Cannot build .NET Framework WebForms locally (macOS); relies on pipeline build.
- Verified against live repro: Christmas wizard signup URL contains `VolunteerCategories=<guid>` as plain param plus `RoleRequests=[{...,"Attributes":{"ShiftTime":"<guid>"}}]` — old code path drops VolunteerCategories, new path merges it.
- Interim workaround already available in production: switch the wizard's `CardWizardMode` to `Single`.

## Review fixes (commit 2)

An xhigh review of the first commit found four gaps in the `!Attributes.ContainsKey( urlKey )` guard. All are fixed in `80eb57f4`:

1. **Blank JSON value still dropped the attribute.** The guard tested key *presence*, but `AddGroupMemberAttributes` also requires a non-empty value — so `Attributes:{"ShiftTime":""}` skipped the merge and then had the value discarded, leaving the ROCK-9055 symptom intact for that input shape. Now a blank/whitespace JSON value counts as absent.
2. **Case mismatch inverted the documented "JSON wins" rule.** `Attributes` is a Newtonsoft ordinal (case-sensitive) dictionary; `PageParameter` resolves route and query keys case-insensitively. A JSON key differing only in case defeated `ContainsKey`, added a second entry under the setting's casing, and that entry is the one the consumer reads — so a stale URL value silently beat the volunteer's selection. The dictionary is now rebuilt with `StringComparer.OrdinalIgnoreCase`, copied by hand rather than via the copy constructor (which throws on caller-supplied JSON holding two keys differing only in case — this is a public, anonymous block).
3. **A duplicated `UrlKeys` entry yellow-screened.** `GetAttributeValues` does not de-dupe, so a `"ShiftTime, ShiftTime"` typo passed the consumer's guards twice and threw `ArgumentException` at `viewStateAttribute.Add`. Before this PR the JSON path never populated those keys so the crash was unreachable for CardWizard signups; the first commit made it reachable on every one. The key list is now `Distinct()`-ed and the merge assigns through the indexer.
4. **Whitespace-only URL values** were admitted by `IsNullOrEmpty` and, once stored, permanently occupied the key. Now `IsNullOrWhiteSpace`.

Both Copilot comments are addressed: a memoized `UrlKeys` member removes the loop-invariant `GetAttributeValues` call, reads `PageParameter` once per key, and unifies the three sites that previously fetched the key list independently; the README now documents the always-merge behavior, the JSON-wins precedence, and case-insensitive matching, and its URL-attribute security note is widened to cover JSON signups. Also drops three write-only locals in `AddGroupMemberAttributes` and refreshes a stale README line reference.

## Deploy note

⚠️ **Consider a backfill before deploying mid-campaign.**

Earlier-partition guids now land in `ConnectionRequest.AssignedGroupMemberAttributeValues`, which is the wizard's only capacity ledger — `VolunteerSignupWizard.ascx.cs:1253`/`1260` filter subrequests by a raw `AssignedGroupMemberAttributeValues.Contains( value )` substring test, and leaf `Filled` is that count.

Requests taken *before* this deploys do not carry those guids, so an earlier-partition node's `Filled` count will omit every pre-deploy signup. Deploying into a live campaign can therefore under-count existing signups and over-allocate a node by exactly that number. Conversely, nodes that previously always reported `Filled = 0` (and so were always clickable) can begin rendering Full once counting starts working.

Worth checking any live opportunity with a multi-level `Multiple`-mode wizard for whether a backfill of the earlier-partition guids, or a one-time limit re-check, is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
