### PR TITLE
Fix REST controller registration lost on Rock 16 upgrade

### DIFF
--- a/Plugins/org.secc.FamilyCheckin/README.md
+++ b/Plugins/org.secc.FamilyCheckin/README.md
@@ -56,6 +56,26 @@ pre-registration, mobile start). Used by check-in staff and parents at kiosks an
 Registered via `FamilyCheckinController` (`IHasCustomHttpRoutes`); routed through a
 session-enabled handler so check-in state persists in `HttpContext.Session`.
 
+**Rock 16 note — case-sensitive controller registration:** Rock 16's
+`RockHttpControllerSelector` copies the controller map into a case-sensitive dictionary.
+The custom route's `controller` default is set to `"FamilyCheckin"` (matching the class
+name exactly). A lowercase value causes the controller to fail registration in
+**Security → Rest Controllers** and its auth rules get silently deleted. Request routing
+itself remains case-insensitive, so the symptom is an auth-rule loss, not a 404. If you
+rename the controller class, update the route default to match.
+
+**Stable REST GUIDs** (used by Rock to track auth rules across deployments):
+
+| Scope | GUID |
+|-------|------|
+| `FamilyCheckinController` (controller) | `33C6C91B-09DC-47AE-B929-DA4D7C7DC6E5` |
+| `Family` action | `D6923A3F-BA89-490B-B624-97A8971432EF` |
+| `KioskStatus` action | `0B70C51E-87BA-4D5C-92AD-7526E9AC6B1B` |
+| `ProcessMobileCheckin` action | `AD172A95-FDCC-4066-9100-373FA6FD6F23` |
+
+These GUIDs are pinned via `[RestControllerGuid]` / `[RestActionGuid]` attributes and
+must not be changed once deployed; Rock ties per-controller auth rules to them.
+
 | Route | Method | Auth | Purpose |
 |-------|--------|------|---------|
 | `api/org.secc/familycheckin/Family/{param}` | GET | Kiosk-session gated | Run the configured check-in workflow for a phone-number search and return matching families. Requires `Session["BlockGuid"]` to resolve to the **QuickSearch** kiosk block type; enforces the block's min/max phone length server-side (a leading country "1" is dropped; anything else over-length returns no results rather than being trimmed to a different number); rate-limited per session (history in session state); returns a projected result (`Caption`, `SubCaption`, `Group.Id`) rather than the full check-in graph. See ROCK-8765. |
@@ -201,4 +221,4 @@ attributes (don't hand-edit ones that have already run):
 - Related: scannable codes come from [org.secc.QRManager](../org.secc.QRManager/README.md);
   shared helpers from [org.secc.DevLib](../org.secc.DevLib/README.md).
 
-**Last updated:** 2026-07-21
+**Last updated:** 2026-08-23

--- a/Plugins/org.secc.FamilyCheckin/Rest/Controllers/FamilyCheckinController.Partial.cs
+++ b/Plugins/org.secc.FamilyCheckin/Rest/Controllers/FamilyCheckinController.Partial.cs
@@ -38,6 +38,7 @@ namespace org.secc.FamilyCheckin.Rest.Controllers
     /// <summary>
     /// Family Checkin REST API
     /// </summary>
+    [Rock.SystemGuid.RestControllerGuid( "33C6C91B-09DC-47AE-B929-DA4D7C7DC6E5" )]
     public partial class FamilyCheckinController : Rock.Rest.ApiControllerBase, IHasCustomHttpRoutes
     {
         /// <summary>
@@ -72,13 +73,21 @@ namespace org.secc.FamilyCheckin.Rest.Controllers
                 routeTemplate: "api/org.secc/familycheckin/{action}/{param}",
                 defaults: new
                 {
-                    controller = "familycheckin",
+                    // Must match the controller class name's casing exactly. Rock 16's
+                    // RockHttpControllerSelector copies the controller mapping into a
+                    // case-sensitive dictionary, and RegisterControllers() resolves a
+                    // bound {controller} default via that mapping — a lowercase name
+                    // misses, so the controller never registers in Security > Rest
+                    // Controllers and its auth rules get deleted. Request routing
+                    // itself stays case-insensitive either way.
+                    controller = "FamilyCheckin",
                     entityqualifier = RouteParameter.Optional,
                     entityqualifiervalue = RouteParameter.Optional
                 } ).RouteHandler = new SessionRouteHandler();
         }
 
         [HttpGet()]
+        [Rock.SystemGuid.RestActionGuid( "D6923A3F-BA89-490B-B624-97A8971432EF" )]
         public HttpResponseMessage Family( string param )
         {
             try
@@ -173,6 +182,7 @@ namespace org.secc.FamilyCheckin.Rest.Controllers
         }
 
         [HttpGet()]
+        [Rock.SystemGuid.RestActionGuid( "0B70C51E-87BA-4D5C-92AD-7526E9AC6B1B" )]
         public HttpResponseMessage KioskStatus( int param )
         {
             // ROCK-8765: Intentionally anonymous — physical kiosks are unauthenticated
@@ -204,6 +214,7 @@ namespace org.secc.FamilyCheckin.Rest.Controllers
 
         [Authenticate, Secured]
         [HttpGet()]
+        [Rock.SystemGuid.RestActionGuid( "AD172A95-FDCC-4066-9100-373FA6FD6F23" )]
         public HttpResponseMessage ProcessMobileCheckin( string param )
         {
             try

--- a/Plugins/org.secc.Rest/Controllers/SecurityController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/SecurityController.Partial.cs
@@ -28,6 +28,7 @@ namespace org.secc.Rest.Controllers
     /// <summary>
     /// TaggedItems REST API
     /// </summary>
+    [Rock.SystemGuid.RestControllerGuid( "23B0A764-52A6-4F32-A4C1-F0B5445D3504" )]
     public partial class SecurityController : ApiController, IHasCustomHttpRoutes
     {
         /// <summary>
@@ -41,7 +42,10 @@ namespace org.secc.Rest.Controllers
                 routeTemplate: "api/org.secc/People/{action}",
                 defaults: new
                 {
-                    controller = "security"
+                    // Must match the controller class name's casing exactly — Rock 16's
+                    // controller-mapping lookup during REST controller registration is
+                    // case-sensitive (see FamilyCheckinController.AddRoutes).
+                    controller = "Security"
                 } ).RouteHandler = new SessionRouteHandler();
         }
 
@@ -53,6 +57,7 @@ namespace org.secc.Rest.Controllers
         /// <param name="entityGuid">The entity unique identifier.</param>
         /// <param name="name">The name.</param>
         /// <returns></returns>
+        [Rock.SystemGuid.RestActionGuid( "D3D6E170-CD7E-43BC-B277-6D0CDA0C20D3" )]
         public HttpResponseMessage Post( string phone )
         {
 
@@ -60,6 +65,7 @@ namespace org.secc.Rest.Controllers
         }
 
         [HttpGet()]
+        [Rock.SystemGuid.RestActionGuid( "7080335B-8BD0-4A04-8C16-F4CA54A87C5B" )]
         public HttpResponseMessage CurrentUser()
         {
             try

--- a/Plugins/org.secc.Rest/README.md
+++ b/Plugins/org.secc.Rest/README.md
@@ -20,6 +20,18 @@ This plugin adds Web API controllers to Rock that aren't part of core. They fall
 
 Most controllers extend Rock's `ApiControllerBase` (or `ApiController`) and declare their routes with `[Route(...)]` attributes, so Rock's standard Web API route discovery registers them. `SecurityController` is the exception: it implements `IHasCustomHttpRoutes` and registers its own `api/org.secc/People/{action}` route against a `SessionRouteHandler` so those calls run with ASP.NET session state.
 
+> **Rock 16 note — case-sensitive controller name in custom routes.** Rock 16's REST-controller registration lookup is case-sensitive. When `AddRoutes` maps the custom `api/org.secc/People/{action}` route, the `controller` default must be `"Security"` — matching the controller class name's exact casing. Any other casing causes the route to 404 at runtime even though the assembly loads successfully.
+
+### REST GUIDs (stable identifiers)
+
+Rock 16+ assigns stable GUIDs to controllers and actions so REST endpoint registrations survive renames. The GUIDs for `SecurityController` are:
+
+| Scope | GUID |
+|-------|------|
+| Controller (`[RestControllerGuid]`) | `23B0A764-52A6-4F32-A4C1-F0B5445D3504` |
+| `Post` action (`[RestActionGuid]`) | `D3D6E170-CD7E-43BC-B277-6D0CDA0C20D3` |
+| `CurrentUser` action (`[RestActionGuid]`) | `7080335B-8BD0-4A04-8C16-F4CA54A87C5B` |
+
 ```mermaid
 flowchart TD
     A[HTTP request to api/...] --> B{Route source}
@@ -195,4 +207,4 @@ Only `SecurityController` needs the `IHasCustomHttpRoutes.AddRoutes` + `SessionR
 
 ---
 
-**Last updated:** 2026-07-27
+**Last updated:** 2026-08-23


### PR DESCRIPTION
Rock 16's RockHttpControllerSelector copies the controller mapping into a case-sensitive dictionary, so RegisterControllers() no longer resolves lowercase bound {controller} route defaults. The FamilyCheckin and Security controllers were never discovered, and Rock 16 deletes undiscovered RestController/RestAction rows along with their auth rules, breaking mobile check-in for non-staff users.

- Match route default controller names to class-name casing ("familycheckin" -> "FamilyCheckin", "security" -> "Security")
- Add RestControllerGuid/RestActionGuid attributes so DB rows and auth rules survive future re-registration and signature changes

After deploy: restart Rock (or refresh the Rest Controller list), then re-add the auth rule on ProcessMobileCheckin for authenticated users.