### PR TITLE
Fix duplicate-key crash in PublishGroupLava attribute binding

### DIFF
--- a/Plugins/org.secc.GroupManager/README.md
+++ b/Plugins/org.secc.GroupManager/README.md
@@ -70,7 +70,7 @@ Categories in Rock: **SECC > Groups**, **SECC > Camp**, and **Groups**.
 | Breakout Group Migration | RockBlock | Tool to migrate kids into groups. |
 | Camp Group | RockBlock | Camp leaders view their group. |
 | Camp Allergies | RockBlock | Campers in a group who have allergies (backed by a stored proc). |
-| Publish Groups Lava | RockBlock | Output PublishGroups via Lava. |
+| Publish Groups Lava | RockBlock | Output PublishGroups via Lava. Settings: `Lava Template`, `Campus Parameter Name` (default `CampusId`), `Category Parameter Name` (default `CategoryId`), `Filter Categories` (defined-value guid list limiting the category filter), `Category Filter Display Mode` (1 = hidden, 2+ = shown). Hides groups whose **Active** member count has reached `GroupCapacity`; group/publish-group attributes load via Rock's bulk `LoadAttributes` (qualifier filtering, inherited attributes, default values). |
 | Publish Group List | RockBlock | List of PublishGroups. |
 | Publish Group Registration | RockBlock | Register a person for a published group. |
 | Publish Group Request | RockBlock | Display a publish-group request. |
@@ -143,3 +143,5 @@ Ships Rock plugin migrations under `/Migrations/` that build up the `PublishGrou
   migrations that have already run.
 - The Camp Allergies stored procedure is defined inline in `011_AddCampAllergyReportProc`; change
   it with a new migration rather than editing the proc in the database directly.
+
+**Last updated:** 2026-08-24

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupLava.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupLava.ascx.cs
@@ -36,6 +36,10 @@ namespace RockWeb.Plugins.org_secc.GroupManager
     [Category( "SECC > Groups" )]
     [Description( "Block to output publish groups in lava." )]
     [CodeEditorField( "Lava Template", "Lava to display all published groups", CodeEditorMode.Lava )]
+    [TextField( "Campus Parameter Name", "Page parameter name for the campus id.", false, "CampusId" )]
+    [TextField( "Category Parameter Name", "Page parameter name for the category id.", false, "CategoryId" )]
+    [TextField( "Filter Categories", "Delimited list of category defined value guids to limit the category filter to.", false, "" )]
+    [TextField( "Category Filter Display Mode", "1 = hidden, 2 or greater = shown.", false, "1" )]
 
     public partial class PublishGroupLava : Rock.Web.UI.RockBlock
     {
@@ -63,29 +67,6 @@ namespace RockWeb.Plugins.org_secc.GroupManager
             // Initialize services
             var rockContext = new RockContext();
             var publishGroupService = new PublishGroupService( rockContext );
-            var attributeService = new AttributeService( rockContext );
-            var attributeValueService = new AttributeValueService( rockContext );
-
-            //Get the entity types
-            var publishGroupEntityTypeId = EntityTypeCache.Get( typeof( PublishGroup ) ).Id;
-            var groupEntityTypeId = EntityTypeCache.Get( typeof( Group ) ).Id;
-
-            //Attribute Queryables
-            var publishGroupAttributeQry = attributeService.Queryable()
-                .Where( a => a.EntityTypeId == publishGroupEntityTypeId )
-                .Select( a => a.Id );
-
-            var groupAttributeQry = attributeService.Queryable()
-               .Where( a => a.EntityTypeId == groupEntityTypeId )
-               .Select( a => a.Id );
-
-            //Attribute Value Queryables
-            var publishGroupAttributeValueQry = attributeValueService.Queryable()
-                .Where( av => publishGroupAttributeQry.Contains( av.AttributeId ) );
-
-            var groupAttributeValueQry = attributeValueService.Queryable()
-               .Where( av => groupAttributeQry.Contains( av.AttributeId ) );
-
 
             var qry = publishGroupService
                 .Queryable( "Group" )
@@ -94,7 +75,7 @@ namespace RockWeb.Plugins.org_secc.GroupManager
                 .Where( pg => pg.StartDateTime <= Rock.RockDateTime.Today && pg.EndDateTime >= Rock.RockDateTime.Today ) //Active
                 .Where( pg => pg.Group.GroupType.GroupCapacityRule == GroupCapacityRule.None
                               || pg.Group.GroupCapacity == null || pg.Group.GroupCapacity == 0
-                              || pg.Group.Members.Count() < pg.Group.GroupCapacity ); // Not full
+                              || pg.Group.Members.Count( m => m.GroupMemberStatus == GroupMemberStatus.Active ) < pg.Group.GroupCapacity ); // Not full
 
 
             // Filter by campus
@@ -114,54 +95,14 @@ namespace RockWeb.Plugins.org_secc.GroupManager
                         .Any( dv => categories.Contains( dv.Id ) ) );
             }
 
-            //Group join in attributes
-            var mixedQry = qry
-                .GroupJoin( publishGroupAttributeValueQry,
-                    pg => pg.Id,
-                    av => av.EntityId,
-                    ( pg, av ) => new { pg, av } )
-                .GroupJoin( groupAttributeValueQry,
-                    pg => pg.pg.GroupId,
-                    av => av.EntityId,
-                    ( pg, av ) => new { PublishGroup = pg.pg, PublishGroupAttributes = pg.av, GroupAttributes = av } );
+            var publishGroups = qry.ToList()
+                .Where( pg => pg.Group != null )
+                .ToList();
 
-            //Add in the attributes in the proper format
-            var publishGroups = new List<PublishGroup>();
-
-            foreach ( var item in mixedQry.ToList() )
-            {
-                var publishGroup = item.PublishGroup;
-                // Group by key: a group can have values for two attributes sharing the same key
-                // (e.g. the same attribute defined on two group types after a group type change)
-                var publishGroupAttributes = item.PublishGroupAttributes
-                    .GroupBy( av => av.AttributeKey )
-                    .Select( g => g.First() )
-                    .ToList();
-                publishGroup.AttributeValues = publishGroupAttributes.ToDictionary( av => av.AttributeKey, av => new AttributeValueCache( av ) );
-                publishGroup.Attributes = publishGroupAttributes.ToDictionary( av => av.AttributeKey, av => AttributeCache.Get( av.AttributeId ) );
-                if ( publishGroup.Group == null )
-                {
-                    continue;
-                }
-                var groupTypeIdString = publishGroup.Group.GroupTypeId.ToString();
-                var groupAttributes = item.GroupAttributes
-                    .GroupBy( av => av.AttributeKey )
-                    .Select( g => g
-                        .OrderByDescending( av =>
-                        {
-                            // Prefer the attribute qualified to the group's current group type over
-                            // stale values left behind by a group type change
-                            var attribute = AttributeCache.Get( av.AttributeId );
-                            return attribute != null
-                                && attribute.EntityTypeQualifierColumn == "GroupTypeId"
-                                && attribute.EntityTypeQualifierValue == groupTypeIdString;
-                        } )
-                        .First() )
-                    .ToList();
-                publishGroup.Group.AttributeValues = groupAttributes.ToDictionary( av => av.AttributeKey, av => new AttributeValueCache( av ) );
-                publishGroup.Group.Attributes = groupAttributes.ToDictionary( av => av.AttributeKey, av => AttributeCache.Get( av.AttributeId ) );
-                publishGroups.Add( publishGroup );
-            }
+            // Rock's bulk LoadAttributes handles qualifier filtering, inherited attributes,
+            // default values, and duplicate keys
+            publishGroups.LoadAttributes( rockContext );
+            publishGroups.Select( pg => pg.Group ).Distinct().ToList().LoadAttributes( rockContext );
 
             // Output mergefields.
             var mergeFields = LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
@@ -261,7 +202,7 @@ namespace RockWeb.Plugins.org_secc.GroupManager
 
             var categoryId = PageParameter( GetAttributeValue( "CategoryParameterName" ) ).AsIntegerOrNull();
             var ministrySlug = PageParameter( "ministry" ).ToLower();
-            if ( categoryId.HasValue )
+            if ( definedType != null && categoryId.HasValue )
             {
                 if ( definedType.DefinedValues.Where( v => ( selectedCategoryGuids.Contains( v.Guid ) || selectedCategoryGuids.Count() == 0 ) && v.Id == categoryId.Value ).FirstOrDefault() != null )
                 {
@@ -269,7 +210,7 @@ namespace RockWeb.Plugins.org_secc.GroupManager
                 }
 
             }
-            else if ( !string.IsNullOrEmpty( ministrySlug ) )
+            else if ( definedType != null && !string.IsNullOrEmpty( ministrySlug ) )
             {
                 var definedValues = definedType.DefinedValues.Where( v => ( selectedCategoryGuids.Contains( v.Guid ) || selectedCategoryGuids.Count() == 0 ) ).ToList();
                 DefinedTypeService definedTypeService = new DefinedTypeService( new RockContext() );

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupLava.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupLava.ascx.cs
@@ -131,14 +131,35 @@ namespace RockWeb.Plugins.org_secc.GroupManager
             foreach ( var item in mixedQry.ToList() )
             {
                 var publishGroup = item.PublishGroup;
-                publishGroup.AttributeValues = item.PublishGroupAttributes.ToDictionary( av => av.AttributeKey, av => new AttributeValueCache( av ) );
-                publishGroup.Attributes = item.PublishGroupAttributes.ToDictionary( av => av.AttributeKey, av => AttributeCache.Get( av.AttributeId ) );
+                // Group by key: a group can have values for two attributes sharing the same key
+                // (e.g. the same attribute defined on two group types after a group type change)
+                var publishGroupAttributes = item.PublishGroupAttributes
+                    .GroupBy( av => av.AttributeKey )
+                    .Select( g => g.First() )
+                    .ToList();
+                publishGroup.AttributeValues = publishGroupAttributes.ToDictionary( av => av.AttributeKey, av => new AttributeValueCache( av ) );
+                publishGroup.Attributes = publishGroupAttributes.ToDictionary( av => av.AttributeKey, av => AttributeCache.Get( av.AttributeId ) );
                 if ( publishGroup.Group == null )
                 {
                     continue;
                 }
-                publishGroup.Group.AttributeValues = item.GroupAttributes.ToDictionary( av => av.AttributeKey, av => new AttributeValueCache( av ) );
-                publishGroup.Group.Attributes = item.GroupAttributes.ToDictionary( av => av.AttributeKey, av => AttributeCache.Get( av.AttributeId ) );
+                var groupTypeIdString = publishGroup.Group.GroupTypeId.ToString();
+                var groupAttributes = item.GroupAttributes
+                    .GroupBy( av => av.AttributeKey )
+                    .Select( g => g
+                        .OrderByDescending( av =>
+                        {
+                            // Prefer the attribute qualified to the group's current group type over
+                            // stale values left behind by a group type change
+                            var attribute = AttributeCache.Get( av.AttributeId );
+                            return attribute != null
+                                && attribute.EntityTypeQualifierColumn == "GroupTypeId"
+                                && attribute.EntityTypeQualifierValue == groupTypeIdString;
+                        } )
+                        .First() )
+                    .ToList();
+                publishGroup.Group.AttributeValues = groupAttributes.ToDictionary( av => av.AttributeKey, av => new AttributeValueCache( av ) );
+                publishGroup.Group.Attributes = groupAttributes.ToDictionary( av => av.AttributeKey, av => AttributeCache.Get( av.AttributeId ) );
                 publishGroups.Add( publishGroup );
             }
 

--- a/Plugins/org.secc.PastoralCare/org_secc/PastoralCare/NursingHomeList.ascx.cs
+++ b/Plugins/org.secc.PastoralCare/org_secc/PastoralCare/NursingHomeList.ascx.cs
@@ -555,39 +555,15 @@ namespace RockWeb.Plugins.org_secc.PastoralCare
             Dictionary<Guid, string> volunteerList = new Dictionary<Guid, string>();
             groupId = groupService.GetByGuid( volunteerGroup );
 
-            var groupMemberEntityTypeId = EntityTypeCache.Get( typeof( GroupMember ) ).Id;
-
-            var groupMemberAttributeQry = attributeService.Queryable()
-                .Where( a => a.EntityTypeId == groupMemberEntityTypeId )
-                .Select( a => a.Id );
-
-            var groupMemberAttributeValueQry = attributeValueService.Queryable()
-               .Where( av => groupMemberAttributeQry.Contains( av.AttributeId ) );
-
             if ( groupId != null )
             {
-                var groupMemberList = groupMemberService.Queryable()
+                var groupMembers = groupMemberService.Queryable()
                    .Where( a => a.GroupId == groupId.Id && a.GroupMemberStatus == GroupMemberStatus.Active )
-                   .GroupJoin( groupMemberAttributeValueQry,
-                        gm => gm.Id,
-                        av => av.EntityId,
-                        ( gm, av ) => new { GroupMember = gm, GroupMemberAttributeValues = av } )
-                     .ToList();
+                   .ToList();
 
-                var groupMembers = new List<GroupMember>();
-
-                foreach ( var set in groupMemberList )
-                {
-                    var groupMember = set.GroupMember;
-
-                    groupMember.Attributes = set.GroupMemberAttributeValues
-                        .ToDictionary( av => av.AttributeKey, av => AttributeCache.Get( av.AttributeId ) );
-
-                    groupMember.AttributeValues = set.GroupMemberAttributeValues
-                        .ToDictionary( av => av.AttributeKey, av => new AttributeValueCache( av ) );
-
-                    groupMembers.Add( groupMember );
-                }
+                // Rock's bulk LoadAttributes handles qualifier filtering, inherited attributes,
+                // default values, and duplicate keys
+                groupMembers.LoadAttributes( rockContext );
 
                 foreach ( var nursingHome in facilities )
                 {

--- a/Plugins/org.secc.Rest/Controllers/ChannelItemController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/ChannelItemController.Partial.cs
@@ -73,13 +73,28 @@ namespace org.secc.Rest.Controllers
             //AttributeFiltering
             var ignoreKeys = new List<string> { "contentchannelid", "tag", "take", "page", "hideInactive", "orderby", "reverse" };
 
+            // Same precedence as the response dictionary: when a key exists on both a type- and a
+            // channel-qualified attribute, only the channel-scoped attribute is filterable.
+            var filterableAttributeIdsByKey = attributeQry.ToList()
+                .GroupBy( a => a.Key, System.StringComparer.OrdinalIgnoreCase )
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.Any( a => a.EntityTypeQualifierColumn == "ContentChannelId" )
+                        ? g.Where( a => a.EntityTypeQualifierColumn == "ContentChannelId" ).Select( a => a.Id ).ToList()
+                        : g.Select( a => a.Id ).ToList(),
+                    System.StringComparer.OrdinalIgnoreCase );
+
             var urlKeyValues = ControllerContext.Request.GetQueryNameValuePairs();
             foreach ( var pair in urlKeyValues )
             {
                 if ( !ignoreKeys.Contains( pair.Key.ToLower() ) )
                 {
+                    var attributeIds = filterableAttributeIdsByKey.ContainsKey( pair.Key )
+                        ? filterableAttributeIdsByKey[pair.Key]
+                        : new List<int>();
+
                     var filterQry = new AttributeValueService( rockContext ).Queryable()
-                       .Where( av => attributeQry.Where( a => a.Key == pair.Key ).Select( a => a.Id ).Contains( av.AttributeId ) )
+                       .Where( av => attributeIds.Contains( av.AttributeId ) )
                        .Where( av => av.Value == pair.Value );
 
                     contentItems = contentItems.Where( i => filterQry.Select( av => av.EntityId ).Contains( i.Id ) );

--- a/Plugins/org.secc.Rest/Controllers/ChannelItemController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/ChannelItemController.Partial.cs
@@ -116,7 +116,7 @@ namespace org.secc.Rest.Controllers
                     Content = i.ContentChanelItem.Content,
                     Priority = i.ContentChanelItem.Priority,
                     Order = i.ContentChanelItem.Order,
-                    Attributes = i.AttributeValues.ToDictionary( a => a.AttributeKey, a => a.Value ),
+                    Attributes = BuildAttributeDictionary( i.AttributeValues ),
                     Tags = GetTags( i.ContentChanelItem, rockContext ),
                     Slug = i.ContentChanelItem.PrimarySlug,
                     CreatedBy = i.ContentChanelItem.CreatedByPersonName,
@@ -195,7 +195,7 @@ namespace org.secc.Rest.Controllers
                     Content = i.ContentChanelItem.Content,
                     Priority = i.ContentChanelItem.Priority,
                     Order = i.ContentChanelItem.Order,
-                    Attributes = i.AttributeValues.ToDictionary( a => a.AttributeKey, a => a.Value ),
+                    Attributes = BuildAttributeDictionary( i.AttributeValues ),
                     Tags = GetTags( i.ContentChanelItem, rockContext ),
                     Slug = i.ContentChanelItem.PrimarySlug,
                     CreatedBy = i.ContentChanelItem.CreatedByPersonName,
@@ -204,6 +204,16 @@ namespace org.secc.Rest.Controllers
                 } ).ToList();
 
             return Json( items.FirstOrDefault() );
+        }
+
+        private static Dictionary<string, string> BuildAttributeDictionary( IEnumerable<AttributeValue> attributeValues )
+        {
+            // The same key can exist on both a ContentChannelTypeId-qualified and a
+            // ContentChannelId-qualified attribute; the channel-scoped value wins the collision.
+            return attributeValues
+                .GroupBy( av => av.AttributeKey )
+                .Select( g => g.FirstOrDefault( av => AttributeCache.Get( av.AttributeId )?.EntityTypeQualifierColumn == "ContentChannelId" ) ?? g.First() )
+                .ToDictionary( av => av.AttributeKey, av => av.Value );
         }
 
         private List<string> GetTags( ContentChannelItem contentChannelItem, RockContext rockContext )

--- a/Plugins/org.secc.Rest/README.md
+++ b/Plugins/org.secc.Rest/README.md
@@ -141,6 +141,8 @@ Org policy: communications may not be sent to minors unless another adult is inc
 ### ChannelItems query filtering *(ChannelItemController)*
 Reserved query keys (`contentchannelid`, `tag`, `take`, `page`, `hideInactive`, `orderby`, `reverse`) control paging/sort; **any other query key** is treated as a content-channel-item **attribute key** and filtered on exact attribute value.
 
+**Same-key collision precedence:** the same attribute key can exist on both a `ContentChannelTypeId`-qualified and a `ContentChannelId`-qualified attribute. In both `ChannelItems` and `ChannelItem` responses the **channel-qualified value wins** the collision (previously this crashed with an HTTP 500), and query-string attribute filtering applies the same precedence — when a key exists in both scopes, only the channel-scoped attribute's values are matched, so filtering and the returned `Attributes` dictionary agree.
+
 ### Contribution transactions *(FinancialTransactionsExtensionsController)*
 Returns a nested `DataSet` (transactions + per-account details), filtered to the Contribution transaction type and excluding the **non-cash** currency type (`F64662E7-0E12-4604-BBB0-DB774AC3C830`). Without `personId`, pulls everyone whose `GivingGroupId` equals `groupId`.
 
@@ -207,4 +209,4 @@ Only `SecurityController` needs the `IHasCustomHttpRoutes.AddRoutes` + `SessionR
 
 ---
 
-**Last updated:** 2026-08-23
+**Last updated:** 2026-08-24


### PR DESCRIPTION
## Summary
Started as a fix for the duplicate-attribute-key crash in **Publish Groups Lava** (`ToDictionary` threw `ArgumentException` when a group carried values for two same-key attributes, e.g. after a group type change). An xhigh code review of that fix (ROCK-9080) expanded the scope to the findings below.

### PublishGroupLava.ascx.cs
- **Deepest fix:** replaced the hand-rolled attribute GroupJoin + dedup machinery with Rock's bulk `LoadAttributes( rockContext )`, which handles qualifier filtering, inherited attributes, default values, and duplicate keys. Eliminates the crash class plus the review findings (inherited/unqualified attributes losing ties to stale values, lone stale values rendering, nondeterministic winners, missing DefaultValues, empty-key entries).
- Restored the `Group` eager load (the anonymous-type projection was discarding it — one lazy-load query per publish group).
- **Behavioral change (intentional):** group capacity now counts only **Active** members (was all members including Inactive/Pending), matching Rock's capacity semantics — groups with open Active spots are no longer hidden from the published list.
- Null-guarded `definedType` in `SetFilters` (previously NRE'd on environments missing the Marketing Campaign Audience Type defined type when a category/ministry parameter was present).
- Declared the four block settings `SetFilters` reads (`Campus Parameter Name`, `Category Parameter Name`, `Filter Categories`, `Category Filter Display Mode`) — they previously didn't exist in Block Properties, so those code paths were dead.

### ChannelItemController.Partial.cs (same crash, live in REST)
- The same duplicate-key `ToDictionary` crash existed in `api/ChannelItems` / `api/ChannelItem`: a `ContentChannelTypeId`-qualified and a `ContentChannelId`-qualified attribute can share a key → HTTP 500. Responses now dedupe per key with the **channel-scoped value winning**.
- Query-string attribute filtering applies the same precedence, so filtering and the returned `Attributes` dictionary agree.

### NursingHomeList.ascx.cs (same crash, unscoped query)
- The GroupMember attribute query filtered only on `EntityTypeId`, joining every GroupMember attribute value system-wide, with the same undeduped `ToDictionary` crash. Replaced with bulk `LoadAttributes`.

### Docs
- Updated `org.secc.Rest` and `org.secc.GroupManager` READMEs (collision precedence, new block settings, capacity behavior).

Out-of-diff drive-by from the same review (Statement.cs wrong attribute join) is tracked separately as ROCK-9081 / PR #295.

## Behavior deltas to validate
- Group attributes with no saved value now render their **DefaultValue** in lava (previously empty); stale values from former group types drop out entirely — both match stock Rock behavior.
- Groups with enough Inactive/Pending members to exceed capacity (but open Active spots) now appear in the published list.
- `api/ChannelItems`: filtering by a key that exists in both scopes now matches only the channel-scoped value.

## Test plan
- [ ] Publish Groups Lava page renders with the known stale-data group (no crash, live values shown, defaults present).
- [ ] `GET api/ChannelItem/{id}` for an item with both type- and channel-level values for one key returns 200 with the channel value.
- [ ] `GET api/ChannelItems/{channelId}?SomeKey=value` filtering agrees with returned attributes.
- [ ] Nursing Home List block renders and Excel export lists volunteers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)