### PR TITLE
ROCK-9081 Fix TransactionDetails attribute join on wrong column

### DIFF
--- a/Plugins/org.secc.Finance/Utility/Statement.cs
+++ b/Plugins/org.secc.Finance/Utility/Statement.cs
@@ -160,17 +160,11 @@ namespace org.secc.Finance.Utility
                 mergeFields.Add( "Country", string.Empty );
             }
 
-            var transactionDetails = qry.GroupJoin( new AttributeValueService( rockContext ).Queryable(),
-                ft => ft.Id,
-                av => av.Id,
-                ( obj, av ) => new { Transaction = obj, AttributeValues = av } )
-                .ToList()
-                .Select( obj =>
-                 {
-                     obj.Transaction.Attributes = obj.AttributeValues.Select( av2 => AttributeCache.Get( av2.Attribute ) ).ToDictionary( k => k.Key, v => v );
-                     obj.Transaction.AttributeValues = obj.AttributeValues.Select( av2 => new AttributeValueCache( av2 ) ).ToDictionary( k => k.AttributeKey, v => v );
-                     return obj.Transaction;
-                 } );
+            var transactionDetails = qry.ToList();
+
+            // Rock's bulk LoadAttributes handles qualifier filtering, inherited attributes,
+            // default values, and duplicate keys
+            transactionDetails.LoadAttributes( rockContext );
 
             mergeFields.Add( "TransactionDetails", transactionDetails );
 

--- a/Plugins/org.secc.Finance/Utility/Statement.cs
+++ b/Plugins/org.secc.Finance/Utility/Statement.cs
@@ -55,10 +55,10 @@ namespace org.secc.Finance.Utility
             {
                 qry = qry.Where( t => !excludedCurrencyTypes.Contains( t.Transaction.FinancialPaymentDetail.CurrencyTypeValue.Guid ) );
                 excludedQry = excludedQry.Where( t => excludedCurrencyTypes.Contains( t.Transaction.FinancialPaymentDetail.CurrencyTypeValue.Guid ) );
-                excludedQry = excludedQry.OrderByDescending( t => t.Transaction.TransactionDateTime );
+                excludedQry = excludedQry.OrderByDescending( t => t.Transaction.TransactionDateTime ).ThenByDescending( t => t.Id );
             }
 
-            qry = qry.OrderByDescending( t => t.Transaction.TransactionDateTime );
+            qry = qry.OrderByDescending( t => t.Transaction.TransactionDateTime ).ThenByDescending( t => t.Id );
 
             mergeFields.Add( "StatementStartDate", dateRange.Start?.ToShortDateString() );
             mergeFields.Add( "StatementEndDate", dateRange.End?.ToShortDateString() );
@@ -160,20 +160,39 @@ namespace org.secc.Finance.Utility
                 mergeFields.Add( "Country", string.Empty );
             }
 
-            var transactionDetails = qry.ToList();
+            // Eager-load the navigations the lava and the in-memory AccountSummary grouping walk;
+            // the query is AsNoTracking, so lazy loading of navigations is not reliable.
+            var transactionDetails = qry.Include( t => t.Transaction ).Include( t => t.Account ).ToList();
 
-            // Rock's bulk LoadAttributes handles qualifier filtering, inherited attributes,
-            // default values, and duplicate keys
+            var excludedTransactionDetails = excludedCurrencyTypes.Count > 0
+                ? excludedQry.Include( t => t.Transaction ).Include( t => t.Account ).ToList()
+                : new List<FinancialTransactionDetail>();
+
+            // The old code joined AttributeValue.Id to FinancialTransactionDetail.Id (wrong column), so
+            // attributes never loaded. Bulk-load attributes for the details AND their parent transactions —
+            // the statement lava reads values like CheckNumber off the parent FinancialTransaction.
             transactionDetails.LoadAttributes( rockContext );
+            if ( excludedTransactionDetails.Any() )
+            {
+                excludedTransactionDetails.LoadAttributes( rockContext );
+            }
+
+            var parentTransactions = transactionDetails
+                .Concat( excludedTransactionDetails )
+                .Select( d => d.Transaction )
+                .Where( t => t != null )
+                .DistinctBy( t => t.Id )
+                .ToList();
+            parentTransactions.LoadAttributes( rockContext );
 
             mergeFields.Add( "TransactionDetails", transactionDetails );
 
 
             if ( excludedCurrencyTypes.Count > 0 )
             {
-                mergeFields.Add( "ExcludedTransactionDetails", excludedQry.ToList() );
+                mergeFields.Add( "ExcludedTransactionDetails", excludedTransactionDetails );
             }
-            mergeFields.Add( "AccountSummary", qry.GroupBy( t => new { t.Account.Name, t.Account.PublicName, t.Account.Description } )
+            mergeFields.Add( "AccountSummary", transactionDetails.GroupBy( t => new { t.Account.Name, t.Account.PublicName, t.Account.Description } )
                                                 .Select( s => new AccountSummary
                                                 {
                                                     AccountName = s.Key.Name,
@@ -182,7 +201,8 @@ namespace org.secc.Finance.Utility
                                                     Total = s.Sum( a => a.Amount ),
                                                     Order = s.Max( a => a.Account.Order )
                                                 } )
-                                                .OrderBy( s => s.Order ) );
+                                                .OrderBy( s => s.Order )
+                                                .ToList() );
             // pledge information
             var pledges = new FinancialPledgeService( rockContext ).Queryable().AsNoTracking()
                                 .Where( p => p.PersonAliasId.HasValue && personAliasIds.Contains( p.PersonAliasId.Value )


### PR DESCRIPTION
## Summary
- `Statement.cs` joined `FinancialTransactionDetail.Id` to `AttributeValue.Id` (the AttributeValue **primary key**, not `EntityId`) over a completely unfiltered `AttributeValueService.Queryable()`, so contribution statement `TransactionDetails` "attributes" were populated from whatever arbitrary AttributeValue row shared the detail's Id number.
- Replaced the GroupJoin with Rock's bulk `LoadAttributes( rockContext )` on the materialized detail list, which loads correctly-scoped, deduplicated attribute values (with defaults) for the actual transaction details.
- **Review follow-up (d5559426):**
  - Also bulk-load attributes on the parent `FinancialTransaction`s — the statement lava reads values like `CheckNumber` off `transaction.Transaction`, which the detail-level load never touched.
  - Load attributes for `ExcludedTransactionDetails` so both legs behave the same.
  - Eager-load `Transaction`/`Account` navigations (queries are `AsNoTracking`, so lazy loading is unreliable) and add a `ThenByDescending( Id )` tiebreaker for deterministic row order.
  - Materialize `AccountSummary` from the already-fetched details instead of re-running the query at lava-render time.

Found during the ROCK-9080 / PR #294 code review as an out-of-diff drive-by.

JIRA: [ROCK-9081](https://seccdev.atlassian.net/browse/ROCK-9081)

## Reviewer notes
- **DefaultValue semantics change:** Rock's bulk loader synthesizes attribute values carrying `Attribute.DefaultValue` for attributes with no stored row, and replaces stored blanks with the default. Any `FinancialTransaction`/`FinancialTransactionDetail` attribute later given a non-blank DefaultValue will render on every statement line, including historical transactions. Statements are mailed IRS substantiation documents, so flagging explicitly.
- **Row order:** the old (broken) GroupJoin shape may have suppressed the `ORDER BY` in EF6, meaning rows historically arrived in clustered-index order rather than `TransactionDateTime DESC`. The lava iterates `TransactionDetails reversed`, so a flipped source order flips the rendered statement. See test plan.

## Test plan
- [x] Generate a contribution statement for a person with check gifts in the date range; confirm `CheckNumber` renders next to check transactions (the ROCK-9081 symptom). ✔ Verified 2026-09-02.
- ~~Generate a statement for a person whose transaction details carry attribute values; confirm lava referencing TransactionDetails attributes renders the correct values.~~ N/A — the statement template doesn't display detail-level attributes, so the original wrong-column join was a latent bug that never surfaced; the fix corrects the data anyway.
- [x] Render the same donor/date-range statement on the pre-PR build and this build and compare transaction row order; if they differ, confirm with finance which order matches archived statements. ✔ Verified 2026-09-02: renders date ascending, same-date ties in entry (Id) order, which matches expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROCK-9081]: https://seccdev.atlassian.net/browse/ROCK-9081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
