### PR TITLE
Fix staff calendar event times shifted +4 hours on OnePoint

### DIFF
--- a/Plugins/org.secc.Themes/Themes/SECC2019Portal/Assets/Lava/CalendarEventItemListAccordion.lava
+++ b/Plugins/org.secc.Themes/Themes/SECC2019Portal/Assets/Lava/CalendarEventItemListAccordion.lava
@@ -40,8 +40,8 @@
 									              <tr>
 										              <td valign="middle" class="calendar-icon"><img src="/Themes/SECC2019/Assets/img/events/Events.svg" aria-role="presentation" width="90" height="60" /></td>
 										              <td valign="middle" class="g-padding-r-20--sm">
-									                  <span class="g-display-block--xs g-font-size-20--xs g-font-family--primary g-font-weight--400 g-line-height--sm">{{ eventItemOccurrence.DateTime | Date: 'dddd'  }}</span>
-									                  <span class="g-display-block--xs g-font-size-44--xs g-font-family--primary g-font-weight--400 g-line-height--sm" style="white-space: nowrap">{{ eventItemOccurrence.DateTime | Date: 'MMM dd'  }}</span>
+									                  <span class="g-display-block--xs g-font-size-20--xs g-font-family--primary g-font-weight--400 g-line-height--sm">{{ eventItemOccurrence.Date | Date: 'dddd'  }}</span>
+									                  <span class="g-display-block--xs g-font-size-44--xs g-font-family--primary g-font-weight--400 g-line-height--sm" style="white-space: nowrap">{{ eventItemOccurrence.Date | Date: 'MMM dd'  }}</span>
 										              </td>
 									              </tr>
 								              </table>
@@ -54,7 +54,7 @@
 								              <div class="row">
 									              <div class="col-md-8 col-md-offset-2">
 										              <h3 class="g-font-weight--700">Event Details</h3>
-										              <p><strong>Time:</strong> {{ eventItemOccurrence.DateTime | Date: 'hh:mm tt'  }}</p>
+										              <p><strong>Time:</strong> {{ eventItemOccurrence.Time }}</p>
 										              <p><strong>Location:</strong> {{ eventItemOccurrence.Location }}</p>
                                   <p> {{ eventLocationDesc }}</p>
 										              <div class="g-margin-t-30--sm g-margin-t-20--xs">


### PR DESCRIPTION
## Problem

Staff reported the Ministry Leader Meeting and All Staff Meeting showing **1:30 PM** on `onepoint.secc.org/staff-calendar` when both are 9:30 AM. Freshservice 15203.

+4h is the EDT offset. It appeared right after the v16 cutover.

## Root cause

Not the data, and not the fleet.

- `Schedule.iCalendarContent` is correct at rest — floating `DTSTART:...T093000`, no `TZID`, untouched since Oct 2025.
- All three prod nodes are byte-identical: same RockWeb path, same `CalendarLava.ascx.cs` hash, same `Rock.dll` (1.16.12.1), same OS time zone and `OrgTimeZone`. The shift also survived an app-pool recycle, ruling out stale compiled state and the per-AppDomain occurrence cache.

The shift is deterministic, in the Lava date pipeline:

1. Core `CalendarLava` hands Lava a `DateTime` of `09:30`, `Kind=Unspecified`.
2. It is wrapped via `ConvertToRockOffset` → `09:30 −04:00`. Still correct.
3. `LavaDateTimeValue.ToStringValue()` is `_value.ToString("u")`, which **normalizes to UTC** and appends `Z` → `"2026-09-08 13:30:00Z"`.
4. `RockFilters.Date` now receives a *string*, so it takes the else branch → `LavaDateTime.ParseToOffset` honors the `Z` → `DateTimeOffset` at `13:30 +00:00`.
5. `LavaDateTime.ToString` formats that **as-is, with no conversion back to org time** → `01:30 PM`.

Confirmed on prod via the Lava tester:

```
{{ '2026-09-08 13:30:00Z' | Date:'hh:mm tt' }}   →   01:30 PM
```

## Fix

Use the string properties core `CalendarLava` already computes server-side, so no `DateTime` enters the Lava date pipeline. Three merge-field swaps in the `SECC2019Portal` theme template — no core patch, no data change, no build.

| Line | Was | Now |
|---|---|---|
| 57 | `DateTime \| Date: 'hh:mm tt'` | `Time` |
| 43 | `DateTime \| Date: 'dddd'` | `Date \| Date: 'dddd'` |
| 44 | `DateTime \| Date: 'MMM dd'` | `Date \| Date: 'MMM dd'` |

`Time` and `Date` are populated at `CalendarLava.ascx.cs:460-461` and both appear in the block's `LiquidType` allowlist (line 736) — verified against `hotfix-1.16.12`, the build whose hash matches what is deployed. Correct under either Lava engine.

Routing the headers through `Date` also removes a latent day-roll: an evening event shifted to UTC lands on the next calendar day and would have printed the wrong weekday.

## Verified

- `.Date | Date:'dddd'` round-trip is DST-safe. `ToShortDateString()` carries no time, so `ParseToOffset` appends the org offset to midnight; traced its DST re-parse branch for both an EDT date (September) and an EST date (January). Midnight shifted by the offset cannot cross a day boundary.
- Month pager (lines 5–15) unaffected. `StartDate` is always midnight, so a +4h shift keeps the same calendar day for `yyyyMM`, `MMMM yyyy` and `MM/01/yyyy`. `'Now' | Date:` uses the filter's explicit-offset branch, which was never broken.

## Known residual, deliberately not fixed here

Line 32 still reads the raw `DateTime`:

```
{%- assign eventStartDiff = 'Now' | DateDiff: eventItemOccurrence.DateTime, 'm' -%}
```

`{% if eventStartDiff > 0 %}` gates whether an event renders, so a 9:30 meeting counts as upcoming until 1:30 PM and lingers for four hours after it starts. Times will read correctly; stale entries won't drop on time.

Fixing it means picking new behavior — switching to `.Date` would drop events at midnight instead of at start time, leaving a morning meeting listed all day. Left for a deliberate decision rather than folded into a display fix.

## Deploy notes

- Theme asset, so a file drop — no build, no `Rock.dll`.
- The theme tree appeared at `F:\Rock16\wwwroot\Themes\SECC2019Portal\Assets\Lava\` on both nodes checked, with identical hashes. If those are per-node copies rather than a share mount, the file must reach **all three** nodes or the display will split by node.
- Clear the Lava template cache or recycle each pool afterward. Rock caches includes in memory, and this fleet has a history of theme files going stale per node.

## Not covered

`SECC2019` and `SECC2024` carry their own copies of this accordion template, and any other block piping a `DateTime` through `| Date:` has the same exposure. Not swept here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

