### PR TITLE
Fix stale/missing theme static file references after v16 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ Plugins/*/packages/
 Plugins/*/bin/
 Plugins/*/obj/
 Plugins/*/Themes/**/*.css
+# vendor CSS that is not compiled from .less must be tracked
+!Plugins/*/Themes/**/simplebar.css
 Tools/org.secc.OAuthTestClient/.vs/
 Tools/**/bin/
 Tools/**/obj/

--- a/Plugins/org.secc.FamilyCheckin/Themes/SE Kids/Layouts/Site.Master
+++ b/Plugins/org.secc.FamilyCheckin/Themes/SE Kids/Layouts/Site.Master
@@ -35,7 +35,6 @@
 	<!-- Included CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>"/>
-	<link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
 
     <script src="<%# ResolveRockUrl("~/Scripts/modernizr.js" ) %>" ></script>
 

--- a/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020/Layouts/Site.Master
+++ b/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020/Layouts/Site.Master
@@ -34,7 +34,6 @@
 	<!-- Included CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>"/>
-	<link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
 
     <script src="<%# ResolveRockUrl("~/Scripts/modernizr.js" ) %>" ></script>
 

--- a/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020/Styles/simplebar.css
+++ b/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020/Styles/simplebar.css
@@ -1,0 +1,211 @@
+[data-simplebar] {
+  position: relative;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-content: flex-start;
+  align-items: flex-start;
+}
+
+.simplebar-wrapper {
+  overflow: hidden;
+  width: inherit;
+  height: inherit;
+  max-width: inherit;
+  max-height: inherit;
+}
+
+.simplebar-mask {
+  direction: inherit;
+  position: absolute;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: auto !important;
+  height: auto !important;
+  z-index: 0;
+}
+
+.simplebar-offset {
+  direction: inherit !important;
+  box-sizing: inherit !important;
+  resize: none !important;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  padding: 0;
+  margin: 0;
+  -webkit-overflow-scrolling: touch;
+}
+
+.simplebar-content-wrapper {
+  direction: inherit;
+  box-sizing: border-box !important;
+  position: relative;
+  display: block;
+  height: 100%; /* Required for horizontal native scrollbar to not appear if parent is taller than natural height */
+  width: auto;
+  max-width: 100%; /* Not required for horizontal scroll to trigger */
+  max-height: 100%; /* Needed for vertical scroll to trigger */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.simplebar-content-wrapper::-webkit-scrollbar,
+.simplebar-hide-scrollbar::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+.simplebar-content:before,
+.simplebar-content:after {
+  content: ' ';
+  display: table;
+}
+
+.simplebar-placeholder {
+  max-height: 100%;
+  max-width: 100%;
+  width: 100%;
+  pointer-events: none;
+}
+
+.simplebar-height-auto-observer-wrapper {
+  box-sizing: inherit !important;
+  height: 100%;
+  width: 100%;
+  max-width: 1px;
+  position: relative;
+  float: left;
+  max-height: 1px;
+  overflow: hidden;
+  z-index: -1;
+  padding: 0;
+  margin: 0;
+  pointer-events: none;
+  flex-grow: inherit;
+  flex-shrink: 0;
+  flex-basis: 0;
+}
+
+.simplebar-height-auto-observer {
+  box-sizing: inherit;
+  display: block;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 1000%;
+  width: 1000%;
+  min-height: 1px;
+  min-width: 1px;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.simplebar-track {
+  z-index: 1;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+[data-simplebar].simplebar-dragging .simplebar-content {
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+[data-simplebar].simplebar-dragging .simplebar-track {
+  pointer-events: all;
+}
+
+.simplebar-scrollbar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  min-height: 10px;
+}
+
+.simplebar-scrollbar:before {
+  position: absolute;
+  content: '';
+  background: black;
+  border-radius: 7px;
+  left: 2px;
+  right: 2px;
+  opacity: 0;
+  transition: opacity 0.2s linear;
+}
+
+.simplebar-scrollbar.simplebar-visible:before {
+  /* When hovered, remove all transitions from drag handle */
+  opacity: 0.5;
+  transition: opacity 0s linear;
+}
+
+.simplebar-track.simplebar-vertical {
+  top: 0;
+  width: 11px;
+}
+
+.simplebar-track.simplebar-vertical .simplebar-scrollbar:before {
+  top: 2px;
+  bottom: 2px;
+}
+
+.simplebar-track.simplebar-horizontal {
+  left: 0;
+  height: 11px;
+}
+
+.simplebar-track.simplebar-horizontal .simplebar-scrollbar:before {
+  height: 100%;
+  left: 2px;
+  right: 2px;
+}
+
+.simplebar-track.simplebar-horizontal .simplebar-scrollbar {
+  right: auto;
+  left: 0;
+  top: 2px;
+  height: 7px;
+  min-height: 0;
+  min-width: 10px;
+  width: auto;
+}
+
+/* Rtl support */
+[data-simplebar-direction='rtl'] .simplebar-track.simplebar-vertical {
+  right: auto;
+  left: 0;
+}
+
+.hs-dummy-scrollbar-size {
+  direction: rtl;
+  position: fixed;
+  opacity: 0;
+  visibility: hidden;
+  height: 500px;
+  width: 500px;
+  overflow-y: hidden;
+  overflow-x: scroll;
+}
+
+.simplebar-hide-scrollbar {
+  position: fixed;
+  left: 0;
+  visibility: hidden;
+  overflow-y: scroll;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}

--- a/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020_Shine/Layouts/Site.Master
+++ b/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020_Shine/Layouts/Site.Master
@@ -35,7 +35,6 @@
 	<!-- Included CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>"/>
-	<link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
 
     <script src="<%# ResolveRockUrl("~/Scripts/modernizr.js" ) %>" ></script>
 

--- a/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020_Shine/Styles/simplebar.css
+++ b/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020_Shine/Styles/simplebar.css
@@ -1,0 +1,211 @@
+[data-simplebar] {
+  position: relative;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-content: flex-start;
+  align-items: flex-start;
+}
+
+.simplebar-wrapper {
+  overflow: hidden;
+  width: inherit;
+  height: inherit;
+  max-width: inherit;
+  max-height: inherit;
+}
+
+.simplebar-mask {
+  direction: inherit;
+  position: absolute;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: auto !important;
+  height: auto !important;
+  z-index: 0;
+}
+
+.simplebar-offset {
+  direction: inherit !important;
+  box-sizing: inherit !important;
+  resize: none !important;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  padding: 0;
+  margin: 0;
+  -webkit-overflow-scrolling: touch;
+}
+
+.simplebar-content-wrapper {
+  direction: inherit;
+  box-sizing: border-box !important;
+  position: relative;
+  display: block;
+  height: 100%; /* Required for horizontal native scrollbar to not appear if parent is taller than natural height */
+  width: auto;
+  max-width: 100%; /* Not required for horizontal scroll to trigger */
+  max-height: 100%; /* Needed for vertical scroll to trigger */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.simplebar-content-wrapper::-webkit-scrollbar,
+.simplebar-hide-scrollbar::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+.simplebar-content:before,
+.simplebar-content:after {
+  content: ' ';
+  display: table;
+}
+
+.simplebar-placeholder {
+  max-height: 100%;
+  max-width: 100%;
+  width: 100%;
+  pointer-events: none;
+}
+
+.simplebar-height-auto-observer-wrapper {
+  box-sizing: inherit !important;
+  height: 100%;
+  width: 100%;
+  max-width: 1px;
+  position: relative;
+  float: left;
+  max-height: 1px;
+  overflow: hidden;
+  z-index: -1;
+  padding: 0;
+  margin: 0;
+  pointer-events: none;
+  flex-grow: inherit;
+  flex-shrink: 0;
+  flex-basis: 0;
+}
+
+.simplebar-height-auto-observer {
+  box-sizing: inherit;
+  display: block;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 1000%;
+  width: 1000%;
+  min-height: 1px;
+  min-width: 1px;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.simplebar-track {
+  z-index: 1;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+[data-simplebar].simplebar-dragging .simplebar-content {
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+[data-simplebar].simplebar-dragging .simplebar-track {
+  pointer-events: all;
+}
+
+.simplebar-scrollbar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  min-height: 10px;
+}
+
+.simplebar-scrollbar:before {
+  position: absolute;
+  content: '';
+  background: black;
+  border-radius: 7px;
+  left: 2px;
+  right: 2px;
+  opacity: 0;
+  transition: opacity 0.2s linear;
+}
+
+.simplebar-scrollbar.simplebar-visible:before {
+  /* When hovered, remove all transitions from drag handle */
+  opacity: 0.5;
+  transition: opacity 0s linear;
+}
+
+.simplebar-track.simplebar-vertical {
+  top: 0;
+  width: 11px;
+}
+
+.simplebar-track.simplebar-vertical .simplebar-scrollbar:before {
+  top: 2px;
+  bottom: 2px;
+}
+
+.simplebar-track.simplebar-horizontal {
+  left: 0;
+  height: 11px;
+}
+
+.simplebar-track.simplebar-horizontal .simplebar-scrollbar:before {
+  height: 100%;
+  left: 2px;
+  right: 2px;
+}
+
+.simplebar-track.simplebar-horizontal .simplebar-scrollbar {
+  right: auto;
+  left: 0;
+  top: 2px;
+  height: 7px;
+  min-height: 0;
+  min-width: 10px;
+  width: auto;
+}
+
+/* Rtl support */
+[data-simplebar-direction='rtl'] .simplebar-track.simplebar-vertical {
+  right: auto;
+  left: 0;
+}
+
+.hs-dummy-scrollbar-size {
+  direction: rtl;
+  position: fixed;
+  opacity: 0;
+  visibility: hidden;
+  height: 500px;
+  width: 500px;
+  overflow-y: hidden;
+  overflow-x: scroll;
+}
+
+.simplebar-hide-scrollbar {
+  position: fixed;
+  left: 0;
+  visibility: hidden;
+  overflow-y: scroll;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}

--- a/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020_Students/Layouts/Site.Master
+++ b/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020_Students/Layouts/Site.Master
@@ -35,7 +35,6 @@
 	<!-- Included CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>"/>
-	<link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
 
     <script src="<%# ResolveRockUrl("~/Scripts/modernizr.js" ) %>" ></script>
 

--- a/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020_Students/Styles/simplebar.css
+++ b/Plugins/org.secc.FamilyCheckin/Themes/SEKids2020_Students/Styles/simplebar.css
@@ -1,0 +1,211 @@
+[data-simplebar] {
+  position: relative;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-content: flex-start;
+  align-items: flex-start;
+}
+
+.simplebar-wrapper {
+  overflow: hidden;
+  width: inherit;
+  height: inherit;
+  max-width: inherit;
+  max-height: inherit;
+}
+
+.simplebar-mask {
+  direction: inherit;
+  position: absolute;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: auto !important;
+  height: auto !important;
+  z-index: 0;
+}
+
+.simplebar-offset {
+  direction: inherit !important;
+  box-sizing: inherit !important;
+  resize: none !important;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  padding: 0;
+  margin: 0;
+  -webkit-overflow-scrolling: touch;
+}
+
+.simplebar-content-wrapper {
+  direction: inherit;
+  box-sizing: border-box !important;
+  position: relative;
+  display: block;
+  height: 100%; /* Required for horizontal native scrollbar to not appear if parent is taller than natural height */
+  width: auto;
+  max-width: 100%; /* Not required for horizontal scroll to trigger */
+  max-height: 100%; /* Needed for vertical scroll to trigger */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.simplebar-content-wrapper::-webkit-scrollbar,
+.simplebar-hide-scrollbar::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+.simplebar-content:before,
+.simplebar-content:after {
+  content: ' ';
+  display: table;
+}
+
+.simplebar-placeholder {
+  max-height: 100%;
+  max-width: 100%;
+  width: 100%;
+  pointer-events: none;
+}
+
+.simplebar-height-auto-observer-wrapper {
+  box-sizing: inherit !important;
+  height: 100%;
+  width: 100%;
+  max-width: 1px;
+  position: relative;
+  float: left;
+  max-height: 1px;
+  overflow: hidden;
+  z-index: -1;
+  padding: 0;
+  margin: 0;
+  pointer-events: none;
+  flex-grow: inherit;
+  flex-shrink: 0;
+  flex-basis: 0;
+}
+
+.simplebar-height-auto-observer {
+  box-sizing: inherit;
+  display: block;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 1000%;
+  width: 1000%;
+  min-height: 1px;
+  min-width: 1px;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.simplebar-track {
+  z-index: 1;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+[data-simplebar].simplebar-dragging .simplebar-content {
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+[data-simplebar].simplebar-dragging .simplebar-track {
+  pointer-events: all;
+}
+
+.simplebar-scrollbar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  min-height: 10px;
+}
+
+.simplebar-scrollbar:before {
+  position: absolute;
+  content: '';
+  background: black;
+  border-radius: 7px;
+  left: 2px;
+  right: 2px;
+  opacity: 0;
+  transition: opacity 0.2s linear;
+}
+
+.simplebar-scrollbar.simplebar-visible:before {
+  /* When hovered, remove all transitions from drag handle */
+  opacity: 0.5;
+  transition: opacity 0s linear;
+}
+
+.simplebar-track.simplebar-vertical {
+  top: 0;
+  width: 11px;
+}
+
+.simplebar-track.simplebar-vertical .simplebar-scrollbar:before {
+  top: 2px;
+  bottom: 2px;
+}
+
+.simplebar-track.simplebar-horizontal {
+  left: 0;
+  height: 11px;
+}
+
+.simplebar-track.simplebar-horizontal .simplebar-scrollbar:before {
+  height: 100%;
+  left: 2px;
+  right: 2px;
+}
+
+.simplebar-track.simplebar-horizontal .simplebar-scrollbar {
+  right: auto;
+  left: 0;
+  top: 2px;
+  height: 7px;
+  min-height: 0;
+  min-width: 10px;
+  width: auto;
+}
+
+/* Rtl support */
+[data-simplebar-direction='rtl'] .simplebar-track.simplebar-vertical {
+  right: auto;
+  left: 0;
+}
+
+.hs-dummy-scrollbar-size {
+  direction: rtl;
+  position: fixed;
+  opacity: 0;
+  visibility: hidden;
+  height: 500px;
+  width: 500px;
+  overflow-y: hidden;
+  overflow-x: scroll;
+}
+
+.simplebar-hide-scrollbar {
+  position: fixed;
+  left: 0;
+  visibility: hidden;
+  overflow-y: scroll;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}

--- a/Plugins/org.secc.LessInclude/Themes/StarkLess/Layouts/Blank.aspx
+++ b/Plugins/org.secc.LessInclude/Themes/StarkLess/Layouts/Blank.aspx
@@ -12,7 +12,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.LessInclude/Themes/StarkLess/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.LessInclude/Themes/StarkLess/Layouts/Dialog.aspx
@@ -85,7 +85,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.LessInclude/Themes/StarkLess/Layouts/Site.Master
+++ b/Plugins/org.secc.LessInclude/Themes/StarkLess/Layouts/Site.Master
@@ -36,7 +36,6 @@
     <asp:ContentPlaceHolder runat="server" ID="CSSDefault">
         <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>"/>
-	    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
     </asp:ContentPlaceHolder>
 
     <script src="<%# ResolveRockUrl("~/Scripts/modernizr.js" ) %>" ></script>

--- a/Plugins/org.secc.Security/Themes/my-secc/Layouts/Blank.aspx
+++ b/Plugins/org.secc.Security/Themes/my-secc/Layouts/Blank.aspx
@@ -12,7 +12,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Security/Themes/my-secc/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Security/Themes/my-secc/Layouts/Dialog.aspx
@@ -85,7 +85,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Security/Themes/my-secc/Layouts/Site.Master
+++ b/Plugins/org.secc.Security/Themes/my-secc/Layouts/Site.Master
@@ -21,7 +21,6 @@
 	<!-- Included CSS Files -->
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/home.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>"/>
-	<link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>"/>
 

--- a/Plugins/org.secc.SportsAndFitness/Themes/SportsAndFitness/Layouts/Blank.aspx
+++ b/Plugins/org.secc.SportsAndFitness/Themes/SportsAndFitness/Layouts/Blank.aspx
@@ -12,7 +12,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.SportsAndFitness/Themes/SportsAndFitness/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.SportsAndFitness/Themes/SportsAndFitness/Layouts/Dialog.aspx
@@ -85,7 +85,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.SportsAndFitness/Themes/SportsAndFitness/Layouts/Splash.aspx
+++ b/Plugins/org.secc.SportsAndFitness/Themes/SportsAndFitness/Layouts/Splash.aspx
@@ -33,7 +33,6 @@
     <!-- Included CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~/Themes/Rock/Styles/bootstrap.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~/Themes/Rock/Styles/theme.css", true) %>"/>
-	<link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
 
     <script src="<%# ResolveRockUrl("~/Scripts/bootstrap.min.js", true) %>" ></script>
 

--- a/Plugins/org.secc.Themes/Themes/Easter/Layouts/Blank.aspx
+++ b/Plugins/org.secc.Themes/Themes/Easter/Layouts/Blank.aspx
@@ -13,7 +13,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/Easter/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Themes/Themes/Easter/Layouts/Dialog.aspx
@@ -86,7 +86,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/Easter/Layouts/Site.Master
+++ b/Plugins/org.secc.Themes/Themes/Easter/Layouts/Site.Master
@@ -23,7 +23,6 @@
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/easter.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/home.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>"/>
-	<link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>"/>
 

--- a/Plugins/org.secc.Themes/Themes/LWYA/Layouts/Blank.aspx
+++ b/Plugins/org.secc.Themes/Themes/LWYA/Layouts/Blank.aspx
@@ -13,7 +13,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/LWYA/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Themes/Themes/LWYA/Layouts/Dialog.aspx
@@ -86,7 +86,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/Rogers/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Themes/Themes/Rogers/Layouts/Dialog.aspx
@@ -86,7 +86,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2014/Layouts/Blank.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2014/Layouts/Blank.aspx
@@ -13,7 +13,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2014/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2014/Layouts/Dialog.aspx
@@ -86,7 +86,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2014/Layouts/Site.Master
+++ b/Plugins/org.secc.Themes/Themes/SECC2014/Layouts/Site.Master
@@ -33,7 +33,6 @@
     <!-- Included CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/main.css", true) %>"/>
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>"/>
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
     <asp:ContentPlaceHolder ID="css" runat="server" />
 
     <script src="<%# ResolveRockUrl("~~/Scripts/modernizr-custom.js" ) %>" ></script>

--- a/Plugins/org.secc.Themes/Themes/SECC2019/Layouts/Blank.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2019/Layouts/Blank.aspx
@@ -13,7 +13,6 @@
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/main.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2019/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2019/Layouts/Dialog.aspx
@@ -86,7 +86,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2019/Layouts/Site.Master
+++ b/Plugins/org.secc.Themes/Themes/SECC2019/Layouts/Site.Master
@@ -103,7 +103,6 @@
     <!-- Included CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>"/>
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/main.css", true) %>"/>
-    <link rel="stylesheet" href="<%# ResolveRockUrl("/Styles/developer.css", true) %>"/>
 
     <!-- GDPR -->
     <link rel="stylesheet" href="/Themes/SECC2019/Scripts/GDPR/gdpr.css" />

--- a/Plugins/org.secc.Themes/Themes/SECC2019Portal/Layouts/Blank.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2019Portal/Layouts/Blank.aspx
@@ -14,7 +14,6 @@
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/main.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2019Portal/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2019Portal/Layouts/Dialog.aspx
@@ -86,7 +86,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2019Portal/Layouts/Site.Master
+++ b/Plugins/org.secc.Themes/Themes/SECC2019Portal/Layouts/Site.Master
@@ -92,7 +92,6 @@
 
     <!-- SECC2019Portal Theme CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/seportal.css", true) %>"/>
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
     <asp:ContentPlaceHolder ID="css" runat="server" />
 
     <!-- Included JS Files -->

--- a/Plugins/org.secc.Themes/Themes/SECC2019_Child_Invert/Layouts/Blank.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2019_Child_Invert/Layouts/Blank.aspx
@@ -14,7 +14,6 @@
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/main.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2019_Child_Invert/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2019_Child_Invert/Layouts/Dialog.aspx
@@ -86,7 +86,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2019_Child_Invert/Layouts/Site.Master
+++ b/Plugins/org.secc.Themes/Themes/SECC2019_Child_Invert/Layouts/Site.Master
@@ -85,7 +85,6 @@
     <!-- Included CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>"/>
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/main.css", true) %>"/>
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
     <asp:ContentPlaceHolder ID="css" runat="server" />
 
     <!-- Included JS Files -->

--- a/Plugins/org.secc.Themes/Themes/SECC2019_LandingPage/Layouts/Blank.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2019_LandingPage/Layouts/Blank.aspx
@@ -11,7 +11,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2019_LandingPage/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2019_LandingPage/Layouts/Dialog.aspx
@@ -84,7 +84,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2024/Layouts/Blank.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Layouts/Blank.aspx
@@ -14,7 +14,6 @@
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/main.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2024/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Layouts/Dialog.aspx
@@ -86,7 +86,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/SECC2024/Layouts/Site.Master
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Layouts/Site.Master
@@ -103,7 +103,6 @@
     <!-- Included CSS Files -->
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>"/>
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/main.css", true) %>"/>
-    <link rel="stylesheet" href="<%# ResolveRockUrl("/Styles/developer.css", true) %>"/>
 
     <!-- GDPR -->
     <link rel="stylesheet" href="/Themes/SECC2024/Scripts/GDPR/gdpr.css" />

--- a/Plugins/org.secc.Themes/Themes/my-secc/Layouts/Blank.aspx
+++ b/Plugins/org.secc.Themes/Themes/my-secc/Layouts/Blank.aspx
@@ -12,7 +12,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/my-secc/Layouts/Dialog.aspx
+++ b/Plugins/org.secc.Themes/Themes/my-secc/Layouts/Dialog.aspx
@@ -85,7 +85,6 @@
 
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>" />
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>" />
-    <link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>" />
 
     <style>
         html, body {

--- a/Plugins/org.secc.Themes/Themes/my-secc/Layouts/Site.Master
+++ b/Plugins/org.secc.Themes/Themes/my-secc/Layouts/Site.Master
@@ -21,7 +21,6 @@
 	<!-- Included CSS Files -->
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/home.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/layout.css", true) %>"/>
-	<link rel="stylesheet" href="<%# ResolveRockUrl("~/Styles/developer.css", true) %>"/>
     <link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/bootstrap.css", true) %>"/>
 	<link rel="stylesheet" href="<%# ResolveRockUrl("~~/Styles/theme.css", true) %>"/>
 


### PR DESCRIPTION
## Summary
Two related cleanups for theme static-file references that surfaced as `Fingerprint.Tag` ExceptionLog spam after the Rock v13 → v16 upgrade.

### 1. Remove stale developer.css links (39 files)
Core Rock deleted `RockWeb/Styles/developer.css` in v10 (April 2019, SparkDevNetwork/Rock commits `bd36781fa1` / `5e16125f26`), but our custom themes — cloned from pre-2019 Stark/Rock templates — still linked it. Through Rock v13 the file happened to ship with our install so the link silently worked. After the v16 upgrade the file is gone, and every page render on an affected theme hit `Fingerprint.Tag`, which logs an exception on every request (failures are never cached). Pure removal of the stale `<link>` lines.

### 2. Add missing simplebar.css to SEKids2020 check-in themes (3 files + .gitignore)
`Checkin-Site.Master` in SEKids2020 / SEKids2020_Shine / SEKids2020_Students links `~~/Styles/simplebar.css`, but the `.gitignore` rule for compiled theme CSS (`Plugins/*/Themes/**/*.css`) kept this vendor file from ever being tracked. It was hand-placed on the production servers for SEKids2020 and Shine; the Students theme (whose layout was copied from SEKids2020) never got the file, so it has logged a fingerprint exception per check-in page render. Adds SimpleBar 5.2.1 CSS (matching the committed `simplebar.js` version) to all three themes and a gitignore exception so the file is tracked instead of living only on the servers.

Production theme files were already fixed in place; this commits the same fixes so future deploys don't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)