### PR TITLE
ROCK-9085 Fix oversized chevron on registration progress tracker in SECC2024

### DIFF
--- a/Plugins/org.secc.Themes/README.md
+++ b/Plugins/org.secc.Themes/README.md
@@ -2,6 +2,8 @@
 
 > Southeast's Rock site themes — the master pages, page layouts, and styling that skin Rock's external and check-in sites.
 
+Last updated: 2026-09-02
+
 ## Overview
 
 This "plugin" is not compiled code; it is the collection of Rock **themes** Southeast maintains.
@@ -53,7 +55,7 @@ field types here.
 | `SECC2019Portal` | Site (portal) | 10 | Ships a Compass `config.rb` for SCSS compilation. |
 | `SECC2019_Child_Invert` | Check-in | 11 | Adds `Checkin.aspx` + `Checkin-Site.Master`, `Sections`/`SidebarSections`. |
 | `SECC2019_LandingPage` | Landing pages | 17 | Full*/Simple* card, centered, fifty-fifty, and overlay layouts. |
-| `SECC2024` | Public site | 11 | Newer site theme; adds a `TwoColumn` layout. |
+| `SECC2024` | Public site | 11 | Newer site theme; adds a `TwoColumn` layout and Rock 16 progress-tracker compatibility styling for registration/sign-up screens, including size fixes for inline separator SVGs and a responsive hide below 768px. |
 | `SECC2014` | Public site (legacy) | 9 | Older site theme; LESS styles + vendor scripts. |
 | `Easter` | Seasonal site | 8 | Includes `Assets/Lava/` page-render snippets and `Site.Master.cs`. |
 | `ChristmasTogether` | Seasonal check-in | 1 | `Checkin.aspx` + `Site.Master` only; LESS variable overrides. |

--- a/Plugins/org.secc.Themes/Themes/SECC2024/Styles/rock/_components.scss
+++ b/Plugins/org.secc.Themes/Themes/SECC2024/Styles/rock/_components.scss
@@ -2391,3 +2391,158 @@ iframe.file-browser {
     background-color: $grid-row-odd-bg;
   }
 }
+
+// 41. Progress Tracker
+// -------------------------
+// Rock 16's Obsidian blocks (Registration Entry, Sign-Up Register) render a
+// progress tracker whose step separators are inline <svg> elements with no
+// width/height attributes -- they are sized entirely by CSS. Those rules ship
+// only in Rock's own Styles/theme.css, which Site.Master does not load, so
+// without them the separator SVG falls back to its viewBox aspect ratio
+// (22:80) and stretches to several thousand pixels tall.
+
+.progress-tracker {
+  display: flex;
+  background: #fff;
+  border: 1px solid #efefef;
+  border-radius: 0px;
+
+  // Rock's markup uses the Bootstrap 4 display utilities (`d-none d-md-flex`)
+  // to hide the tracker on small screens. This theme is Bootstrap 3 and does
+  // not ship them, so reproduce that behavior scoped to the tracker.
+  &.d-none {
+    display: none;
+  }
+
+  @media (min-width: $screen-sm-min) {
+    &.d-md-flex {
+      display: flex;
+    }
+  }
+
+  // Same story for `text-truncate` on the step title and subtitle.
+  .text-truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.progress-tracker-container {
+  flex-grow: 1;
+  overflow: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.progress-steps {
+  display: flex;
+  flex-grow: 1;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.progress-step {
+  position: relative;
+  display: flex;
+  flex: 1 1 0;
+  min-width: 140px;
+  overflow: hidden;
+}
+
+.progress-tracker-arrow {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: block;
+  width: 14px;
+  height: 100%;
+  color: #efefef;
+
+  svg {
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.progress-step-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 6px 12px 6px 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25;
+  color: #777;
+}
+
+.progress-tracker-icon {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 1px 0 0;
+  margin-right: 6px;
+  font-size: 12px;
+  color: #fff;
+  background: #7c7c7c;
+  border-radius: 999px;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+
+  &.current {
+    background: #fff;
+    border: 2px solid #7c7c7c;
+  }
+
+  &.upcoming {
+    background: #fff;
+    border: 2px solid #777;
+  }
+}
+
+.progress-tracker-more {
+  flex: 0 1 auto;
+  min-width: 56px;
+
+  .progress-step-link {
+    padding: 4px 14px;
+    font-size: 24px;
+  }
+
+  & + .progress-tracker-more {
+    display: none;
+  }
+}
+
+.progress-tracker-details {
+  min-width: 0;
+  margin-top: 2px;
+}
+
+.current + .progress-tracker-details {
+  .progress-tracker-title,
+  .progress-tracker-subtitle {
+    color: #7c7c7c;
+  }
+}
+
+.progress-tracker-title {
+  color: #333;
+}
+
+.progress-tracker-subtitle {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1rem;
+  color: #777;
+}


### PR DESCRIPTION
https://seccdev.atlassian.net/browse/ROCK-9085

Rock 16's Obsidian Registration Entry renders its progress-tracker chevrons as inline SVG with **no intrinsic size** — CSS is the only thing that can size them:

```html
<svg viewBox="0 0 22 80" preserveAspectRatio="none">
```

The rules that size it live in Rock's `theme.css`, which SECC2024's `Site.Master` never links. With nothing constraining it the browser falls back to `width:100%` and derives height from the 22:80 viewBox ratio — **1200 × 4364px**, a giant diagonal line across the page.

**Why it looked intermittent:** `theme.css` reaches the page only via `AdminCss.ascx.cs` (BlockType 523), gated on `Authorization.ADMINISTRATE`. Admins saw a correct page; every actual registrant saw the broken one. Verified across 12 anonymous fetches on all three web nodes — `theme.css` absent every time.

**Why now:** nothing on our side changed. The gating is from 2017 (`584eaa0f`, deliberate — keep 252 KB of Rock core CSS off public pages) and held for nine years because the port in `rock/_components.scss` covered everything Rock emitted. v16 introduced markup it had never seen. `git log -S "progress-tracker" --all` returns zero commits; the v13-era `theme.css.bak` has no hits either.

## Change

`Themes/SECC2024/Styles/rock/_components.scss`, new section 41. Ports the 18 `progress-tracker` rules from Rock's `theme.css` verbatim, plus shims for three Bootstrap 4 utilities Rock's markup uses that this Bootstrap 3 theme doesn't ship (`.d-none`, `.d-md-flex`, `.text-truncate`), scoped to `.progress-tracker` so no global utility is introduced.

Not done here: linking `theme.css` in `Site.Master`. It also fixes this, and everything like it — but it reverses a considered 2017 decision and drops 252 KB of Rock core CSS under a custom Bootstrap 3 design. Own ticket.

## Verification

Removed `theme.css` from the DOM on the live page and injected the compiled output:

| element | admin baseline | broken | with fix |
|---|---|---|---|
| arrow svg | 14×48 | **1200×4364** | 14×48 |
| tracker | 1200×50 | **1200×8907** | 1200×50 |

Blast radius — recompiled `main.scss` from `master` and this branch, diffed the 1.3 MB outputs: **1 hunk, 131 added, 0 removed, 0 modified**. All 22 selectors namespaced under `progress-tracker*` / `progress-step*`; no unscoped utilities emitted; no SECC-authored markup uses these class names. Admins unaffected — `theme.css` loads after `main.css` with identical values.

## Pages fixed

All confirmed broken anonymously, all covered by this one change: `12bethlehem26` (reported), `27passhsmu18`, `27passhsm18ovr`, `27passyau18`, `27passya18ovr`, `27passhsmldr`, `27passyaldr`.

## Notes

Below 768px the tracker is now hidden, matching Rock's `d-none d-md-flex` intent. Today mobile renders the 4000px chevron — better, but a visible change.

**Deploy:** edit on the share (`\\seccrockprod...\IIS_Rock16\Themes\`, not `F:\` — that copy is shadowed) → compile from page 477 → confirm it landed (`Select-String main.css -Pattern "progress-tracker-arrow"`; a failed compile is silent) → AppDomain restart per node → check in a private window.

