### PR TITLE
ROCK-8991 Send publish group confirmations from noreply@secc.org; leader email becomes Reply-To

### DIFF
--- a/Plugins/org.secc.GroupManager/README.md
+++ b/Plugins/org.secc.GroupManager/README.md
@@ -72,7 +72,7 @@ Categories in Rock: **SECC > Groups**, **SECC > Camp**, and **Groups**.
 | Camp Allergies | RockBlock | Campers in a group who have allergies (backed by a stored proc). |
 | Publish Groups Lava | RockBlock | Output PublishGroups via Lava. Settings: `Lava Template`, `Campus Parameter Name` (default `CampusId`), `Category Parameter Name` (default `CategoryId`), `Filter Categories` (defined-value guid list limiting the category filter), `Category Filter Display Mode` (1 = hidden, 2+ = shown). Hides groups whose **Active** member count has reached `GroupCapacity`; group/publish-group attributes load via Rock's bulk `LoadAttributes` (qualifier filtering, inherited attributes, default values). |
 | Publish Group List | RockBlock | List of PublishGroups. |
-| Publish Group Registration | RockBlock | Register a person for a published group. |
+| Publish Group Registration | RockBlock | Register a person for a published group. The confirmation email is sent **From `noreply@secc.org`** with the publish group's `ConfirmationFromName`; the leader-entered `ConfirmationEmail` is used as the **Reply-To**. |
 | Publish Group Request | RockBlock | Display a publish-group request. |
 
 ### Models

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupRegistration.ascx.cs
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupRegistration.ascx.cs
@@ -427,8 +427,13 @@ namespace RockWeb.Plugins.org_secc.GroupManager
             mergeObjects["Group"] = _publishGroup.Group;
 
             var message = new RockEmailMessage();
-            message.FromEmail = _publishGroup.ConfirmationEmail;
+            // ROCK-8991: send from a deliverable SECC address; the leader-entered address becomes the Reply-To.
+            message.FromEmail = "noreply@secc.org";
             message.FromName = _publishGroup.ConfirmationFromName;
+            if ( _publishGroup.ConfirmationEmail.IsNotNullOrWhiteSpace() )
+            {
+                message.ReplyToEmail = _publishGroup.ConfirmationEmail;
+            }
             message.Subject = _publishGroup.ConfirmationSubject;
             message.Message = _publishGroup.ConfirmationBody;
             message.AddRecipient( new RockEmailMessageRecipient( person, mergeObjects ) );

--- a/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupRequest.ascx
+++ b/Plugins/org.secc.GroupManager/org_secc/GroupManager/PublishGroupRequest.ascx
@@ -150,7 +150,8 @@
                             <h3>Confirmation Email</h3>
                             <hr />
                             <Rock:RockTextBox runat="server" ID="tbConfirmationFromName" Label="Confirmation From Name" Required="true" />
-                            <Rock:EmailBox runat="server" ID="tbConfirmationFromEmail" Label="Confirmation From Email" Required="true" />
+                            <Rock:EmailBox runat="server" ID="tbConfirmationFromEmail" Label="Confirmation Reply-To Email" Required="true"
+                                Help="Replies to the confirmation email are sent to this address. The email itself is sent from noreply@secc.org." />
                             <Rock:RockTextBox runat="server" ID="tbConfirmationSubject" Label="Confirmation Email Subject" Required="true" />
                             <Rock:HtmlEditor runat="server" ID="ceConfirmationBody" Label="Confirmation Email Body" Height="400" Required="true" />
                         </asp:Panel>


### PR DESCRIPTION
## Summary
- `PublishGroupRegistration.ascx.cs` `SendConfirmation()`: `FromEmail` is now `noreply@secc.org` (same pattern as `GroupAppGroupMembersController` and the home-group editor); the leader-entered `PublishGroup.ConfirmationEmail` is set as `ReplyToEmail` when non-blank. `FromName` unchanged.
- `PublishGroupRequest.ascx`: `tbConfirmationFromEmail` relabeled "Confirmation Reply-To Email" with help text. Control ID unchanged; code-behind untouched (ROCK-9118 branch owns it).
- `org.secc.GroupManager/README.md`: one-line note on send behavior.

No block settings, migrations, or data changes. Existing stored addresses become the Reply-To as-is.

JIRA: https://seccdev.atlassian.net/browse/ROCK-8991

## Review notes
- Real behavior change is for groups whose leader address is `@secc.org` (safe-sender already rewrote external-domain senders to `OrganizationEmail`).

## Test plan
- [x] Build `org.secc.GroupManager` (built and compiled clean during review)
- [ ] Deploy to DEV; open page 2006 for a Small Group and confirm the relabeled field renders and saves
- [ ] Register a test person via `allgroups/registration/{slug}` for a Small Group with a staff-address leader; confirm headers `From: <Leader Name> <noreply@secc.org>` and `Reply-To: <leader address>`
- [ ] Repeat once for a Home Group (Reply-To should equal `noreply@secc.org`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



