### PR TITLE
ROCK-8786 Guard RemoveGroupMember against cross-group groupMemberId

### DIFF
--- a/Plugins/org.secc.Rest/Controllers/GroupAppGroupMembersController.Partial.cs
+++ b/Plugins/org.secc.Rest/Controllers/GroupAppGroupMembersController.Partial.cs
@@ -500,7 +500,10 @@ namespace org.secc.Rest.Controllers
                 var _rockContext = new RockContext();
                 var groupMemberService = new GroupMemberService( _rockContext );
                 var groupMember = groupMemberService.Get( groupMemberId );
-                if ( groupMember == null )
+
+                // The target must belong to the group the caller is authorized on;
+                // otherwise a caller could hard-delete members of other groups.
+                if ( groupMember == null || groupMember.GroupId != groupId )
                 {
                     return NotFound();
                 }

--- a/Plugins/org.secc.Rest/README.md
+++ b/Plugins/org.secc.Rest/README.md
@@ -79,7 +79,7 @@ All require a logged-in user (`GetCurrentUser`, else `401`) and apply per-group 
 | `api/GroupApp/GetGroupMembers/{groupId}` | GET | member or VIEW | Members; leaders also see address/email/phone/parent contact and an `IsMinor` flag (leader-gated). Table-based groups filter by `TableNumber`. |
 | `api/GroupApp/GroupMembers/{groupId}/Communicate` | POST | EDIT **and** MANAGE_MEMBERS | Send an email to all/one member (optionally parents). Individual sends to a minor auto-CC the minor's parents/guardians, or return `400` if no parent email is on record (see minor-communication policy below). The target `GroupMemberId` must belong to `{groupId}` (else `404`). |
 | `api/GroupApp/GroupMembers/{groupId}/Add` | POST | EDIT **and** MANAGE_MEMBERS | Match-or-create a person and add as a member; copies leader's `TableNumber`. |
-| `api/GroupApp/GroupMembers/{groupId}/Remove/{groupMemberId}` | DELETE | EDIT **and** MANAGE_MEMBERS | Hard-delete a group member. |
+| `api/GroupApp/GroupMembers/{groupId}/Remove/{groupMemberId}` | DELETE | EDIT **and** MANAGE_MEMBERS | Hard-delete a group member. The `groupMemberId` must belong to `{groupId}` (else `404`). |
 | `api/GroupApp/Attendance/{groupId}/{occurrenceDate}` | GET | VIEW or leader | Attendance for an occurrence. |
 | `api/GroupApp/Attendance/` | POST | leader | Mark a member (of this group) present. Reconciles with the member's existing attendance for the group+date: with `locationId`, matches within that room (+`scheduleId`); without it, matches by group+person+date, preferring a kiosk-origin row, so a kiosk check-in is flipped rather than duplicated. Creates a row if none exists. |
 | `api/GroupApp/Attendances/{attendanceId}` | DELETE | leader | Delete an attendance record. |


### PR DESCRIPTION
## Summary
- `DELETE api/GroupApp/GroupMembers/{groupId}/Remove/{groupMemberId}` authorized the caller on `{groupId}` (EDIT + MANAGE_MEMBERS) but then deleted `{groupMemberId}` without verifying it belonged to that group. A leader on one group could hard-delete a group member record from any other group by passing a foreign id.
- Add the same belongs-to-group guard PR #259 added to `Communicate`: return `404` when `groupMember.GroupId != groupId`.
- Document the rule on the Remove endpoint row in `Plugins/org.secc.Rest/README.md`.

Investigation plan and adjacency sweep (five sibling gaps, not addressed here) on [ROCK-8786](https://seccdev.atlassian.net/browse/ROCK-8786).

## Test plan
No test project references org.secc.Rest. Manual check on DEV:
- [ ] As a leader of group A, `DELETE .../GroupMembers/{A}/Remove/{memberOfB}` returns `404`; member of B still present.
- [ ] As a leader of group A, `DELETE .../GroupMembers/{A}/Remove/{memberOfA}` still returns `200` and removes the member.
- [ ] Non-leader on A still gets `403`; unknown `groupMemberId` still gets `404`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROCK-8786]: https://seccdev.atlassian.net/browse/ROCK-8786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ